### PR TITLE
Update deps

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/f1f6c7c9002a678508c270f317df0caee600bec7.zip",
-            "hash": "1220ac6621386003a842836737ed55dd866bd21b725ae3142f72ea466db10778a926"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/87b562eb397325f02552942f13caf42b7f6b146f.zip",
+            "hash": "1220d3c15eee66edf1236ed460d88375f07c6593ad3af796dd69463453d73bf40399"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/cff275c90e9031f6f2d17a65665968c9c0f29ae7.zip",
-            "hash": "12206662e711adb99135adb915fab1fa7c75fad034bc221339dc60003c7752485f39"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5e22b5792c5e891f25ba64dc33355bd04ec7ddd9.zip",
+            "hash": "12208a0c1a6ecacc199eea515d026a7897983ace2a8cabf33032a179b3a1bc57db90"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/f1f6c7c9002a678508c270f317df0caee600bec7.zip",
-            "hash": "1220ac6621386003a842836737ed55dd866bd21b725ae3142f72ea466db10778a926"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/87b562eb397325f02552942f13caf42b7f6b146f.zip",
+            "hash": "1220d3c15eee66edf1236ed460d88375f07c6593ad3af796dd69463453d73bf40399"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/cff275c90e9031f6f2d17a65665968c9c0f29ae7.zip",
-            "hash": "12206662e711adb99135adb915fab1fa7c75fad034bc221339dc60003c7752485f39"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5e22b5792c5e891f25ba64dc33355bd04ec7ddd9.zip",
+            "hash": "12208a0c1a6ecacc199eea515d026a7897983ace2a8cabf33032a179b3a1bc57db90"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",


### PR DESCRIPTION
This includes the latest acton-yang and orchestron dependencies:
- new TTX classes which are developed in parallel with TTT: https://github.com/orchestron-orchestrator/orchestron/pull/40
- fix for module imports when prefix contains hyphen: https://github.com/orchestron-orchestrator/acton-yang/pull/83