### PR TITLE
Update deps (union fixes)

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/87b562eb397325f02552942f13caf42b7f6b146f.zip",
-            "hash": "1220d3c15eee66edf1236ed460d88375f07c6593ad3af796dd69463453d73bf40399"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/ded728c199b64b5e417d715aaa6a14543f7ca48a.zip",
+            "hash": "122080c940b7b49fddac92da47211b390093207741aabb85be3c85375c47f886cd68"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5e22b5792c5e891f25ba64dc33355bd04ec7ddd9.zip",
-            "hash": "12208a0c1a6ecacc199eea515d026a7897983ace2a8cabf33032a179b3a1bc57db90"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/d313b7217059beb7ac6608f0d90a587a0bd2eb69.zip",
+            "hash": "1220683a8d172a29cbfbfe0709a3348cdad37d75185f53ea4ccec37e557aa780e710"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/87b562eb397325f02552942f13caf42b7f6b146f.zip",
-            "hash": "1220d3c15eee66edf1236ed460d88375f07c6593ad3af796dd69463453d73bf40399"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/ded728c199b64b5e417d715aaa6a14543f7ca48a.zip",
+            "hash": "122080c940b7b49fddac92da47211b390093207741aabb85be3c85375c47f886cd68"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5e22b5792c5e891f25ba64dc33355bd04ec7ddd9.zip",
-            "hash": "12208a0c1a6ecacc199eea515d026a7897983ace2a8cabf33032a179b3a1bc57db90"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/d313b7217059beb7ac6608f0d90a587a0bd2eb69.zip",
+            "hash": "1220683a8d172a29cbfbfe0709a3348cdad37d75185f53ea4ccec37e557aa780e710"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/src/respnet_gen.act
+++ b/gen/src/respnet_gen.act
@@ -3764,7 +3764,7 @@ actor main(env):
         orchestron.build.SchemaTransformChain(".*yang.orig", [orchestron.build.SchemaTransformNoComments()])
     ])
     orchestron.build.apply_schema_transforms_to_dir(fc, "yang/JuniperCRPD_23_4R1_9", [
-        orchestron.build.SchemaTransformChain(".*yang.orig", [orchestron.build.SchemaTransformUnions()])
+        orchestron.build.SchemaTransformChain(".*yang.orig", [orchestron.build.SchemaTransformNoComments()])
     ])
 
     spec = orchestron.build.SysSpec("respnet", [

--- a/gen/yang/JuniperCRPD_23_4R1_9/junos-conf-protocols@2023-01-01.yang
+++ b/gen/yang/JuniperCRPD_23_4R1_9/junos-conf-protocols@2023-01-01.yang
@@ -1,5 +1,4 @@
 module junos-conf-protocols {
-  yang-version "1";
   namespace "http://yang.juniper.net/junos/conf/protocols";
   prefix "jc-protocols";
   import junos-common-types {
@@ -47,27 +46,27 @@ module junos-conf-protocols {
     choice include-any-choice {
       case case_1 {
         leaf-list include-any {
-          type string;
-          description "Groups, one or more of which must be present";
           ordered-by user;
+          description "Groups, one or more of which must be present";
+          type string;
         }
       }
     }
     choice include-all-choice {
       case case_1 {
         leaf-list include-all {
-          type string;
-          description "Groups, all of which must be present";
           ordered-by user;
+          description "Groups, all of which must be present";
+          type string;
         }
       }
     }
     choice exclude-choice {
       case case_1 {
         leaf-list exclude {
-          type string;
-          description "Groups, all of which must be absent";
           ordered-by user;
+          description "Groups, all of which must be absent";
+          type string;
         }
       }
     }
@@ -75,27 +74,27 @@ module junos-conf-protocols {
   grouping apply-advanced {
     description "Apply advanced configuration logic";
     leaf-list apply-groups {
-      type string;
-      description "Groups from which to inherit configuration data";
       ordered-by user;
+      description "Groups from which to inherit configuration data";
+      type string;
     }
     leaf-list apply-groups-except {
-      type string;
-      description "Don't inherit configuration data from these groups";
       ordered-by user;
+      description "Don't inherit configuration data from these groups";
+      type string;
     }
     list apply-macro {
-      description "Macro and parameters for commit script expansion";
       key name;
       ordered-by user;
+      description "Macro and parameters for commit script expansion";
       uses apply-macro-type;
     }
   }
   grouping apply-macro-type {
     description "Macro data for commit-script expansion";
     leaf name {
-      type string;
       description "Name of the macro to be expanded";
+      type string;
     }
     list data {
       key name;
@@ -104,75 +103,80 @@ module junos-conf-protocols {
   }
   grouping bandwidth-type {
     leaf per-traffic-class-bandwidth {
-      type string;
       description "Bandwidth to reserve";
       units bps;
+      type string;
     }
     leaf ct0 {
-      type string;
       description "Bandwidth from traffic class 0";
       units bps;
+      type string;
     }
     leaf ct1 {
-      type string;
       description "Bandwidth from traffic class 1";
       units bps;
+      type string;
     }
     leaf ct2 {
-      type string;
       description "Bandwidth from traffic class 2";
       units bps;
+      type string;
     }
     leaf ct3 {
-      type string;
       description "Bandwidth from traffic class 3";
       units bps;
+      type string;
     }
   }
   grouping cfm-traceoptions {
     description "Trace options for connectivity fault management";
     leaf no-remote-trace {
-      type empty;
       description "Disable remote tracing";
+      type empty;
     }
     container file {
       description "Trace file information";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "3";
         description "Maximum number of trace files";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
       leaf match {
-        type "jt:regular-expression";
         description "Regular expression for lines to be logged";
+        type "jt:regular-expression";
       }
     }
     list flag {
-      description "Tracing parameters";
       key name;
       ordered-by user;
+      description "Tracing parameters";
       leaf name {
         type enumeration {
           enum configuration {
@@ -202,79 +206,94 @@ module junos-conf-protocols {
   }
   grouping civic-address-elements {
     leaf what {
-      type uint16 {
-        range "0 .. 2";
-      }
-      default "1";
       description "Type of address";
+      default "1";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "0 .. 2";
+        }
+      }
     }
     leaf country-code {
+      description "Two-letter country code";
       type string {
         length "2";
       }
-      description "Two-letter country code";
     }
     list ca-type {
       key name;
       ordered-by user;
       leaf name {
-        type uint16 {
-          range "0 .. 255";
-        }
         description "Address element type";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "0 .. 255";
+          }
+        }
       }
       leaf ca-value {
+        description "Address element value";
         type string {
           length "1 .. 248";
         }
-        description "Address element value";
       }
     }
   }
   grouping clksync-traceoptions {
     description "Trace options for syncE and PTP";
     leaf no-remote-trace {
-      type empty;
       description "Disable remote tracing";
+      type empty;
     }
     container file {
       description "Trace file information";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "3";
         description "Maximum number of trace files";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
       leaf match {
-        type "jt:regular-expression";
         description "Regular expression for lines to be logged";
+        type "jt:regular-expression";
       }
     }
     list flag {
-      description "Tracing parameters";
       key name;
       ordered-by user;
+      description "Tracing parameters";
       leaf name {
         type enumeration {
           enum init {
@@ -323,74 +342,89 @@ module junos-conf-protocols {
   grouping co-ordinate-elements {
     description "Geographical co-ordinates";
     leaf longitude {
-      type uint16 {
-        range "0 .. 360";
-      }
       description "Longitude value";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "0 .. 360";
+        }
+      }
     }
     leaf lattitude {
-      type uint16 {
-        range "0 .. 360";
-      }
       description "Lattitude value";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "0 .. 360";
+        }
+      }
     }
   }
   grouping juniper-default-ri-protocols-igmp-snooping {
     description "IGMP snooping options";
     list vlan {
-      description "VLAN options";
       key name;
       ordered-by user;
+      description "VLAN options";
       leaf name {
-        type string;
         description "VLAN name";
+        type string;
       }
       container traceoptions {
         description "Trace options for IGMP Snooping";
         container file {
           description "Trace file options";
           leaf filename {
+            description "Name of file in which to write trace information";
             type string {
               length "1 .. 1024";
             }
-            description "Name of file in which to write trace information";
           }
           leaf replace {
-            type empty;
             description "Replace trace file rather than appending to it";
             status deprecated;
+            type empty;
           }
           leaf size {
-            type string;
             description "Maximum trace file size";
+            type string;
           }
           leaf files {
-            type uint32 {
-              range "2 .. 1000";
-            }
-            default "10";
             description "Maximum number of trace files";
+            default "10";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 1000";
+              }
+            }
           }
           leaf no-stamp {
-            type empty;
             description "Do not timestamp trace file";
             status deprecated;
+            type empty;
           }
           choice world-readable-choice {
             leaf world-readable {
-              type empty;
               description "Allow any user to read the log file";
+              type empty;
             }
             leaf no-world-readable {
-              type empty;
               description "Don't allow any user to read the log file";
+              type empty;
             }
           }
         }
         list flag {
-          description "Tracing parameters";
           key name;
           ordered-by user;
+          description "Tracing parameters";
           leaf name {
             type enumeration {
               enum packets {
@@ -435,72 +469,82 @@ module junos-conf-protocols {
             }
           }
           leaf send {
-            type empty;
             description "Trace transmitted packets";
+            type empty;
           }
           leaf receive {
-            type empty;
             description "Trace received packets";
+            type empty;
           }
           leaf detail {
-            type empty;
             description "Trace detailed information";
+            type empty;
           }
           leaf disable {
-            type empty;
             description "Disable this trace flag";
+            type empty;
           }
         }
       }
       leaf query-interval {
-        type uint32 {
-          range "1 .. 1024";
-        }
-        default "125";
         description "When to send host query messages";
+        default "125";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 1024";
+          }
+        }
       }
       container l2-querier {
         description "Enable L2 querier mode";
         leaf source-address {
-          type "jt:ipv4addr";
           description "Source IP address to use for L2 querier";
+          type "jt:ipv4addr";
         }
       }
       leaf query-response-interval {
-        type string;
-        default "10";
         description "How long to wait for a host query response";
+        default "10";
         units seconds;
+        type string;
       }
       leaf query-last-member-interval {
-        type string;
-        default "1";
         description "When to send group query messages";
+        default "1";
         units seconds;
+        type string;
       }
       leaf robust-count {
-        type uint32 {
-          range "2 .. 10";
-        }
-        default "2";
         description "Expected packet loss on a subnet";
+        default "2";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 10";
+          }
+        }
       }
       leaf immediate-leave {
-        type empty;
         description "Enable immediate group leave on interfaces";
+        type empty;
       }
       container proxy {
-        description "Enable proxy mode";
         presence "enable proxy";
+        description "Enable proxy mode";
         leaf source-address {
-          type "jt:ipv4addr";
           description "Source IP address to use for proxy";
+          type "jt:ipv4addr";
         }
       }
       leaf evpn-ssm-reports-only {
-        type empty;
         description "Accept and process only <s,g> reports of SSM groups";
+        type empty;
       }
       container data-forwarding {
         description "MVR Data forwarding options";
@@ -509,8 +553,8 @@ module junos-conf-protocols {
             container source {
               description "MVR source vlan";
               leaf groups {
-                type "jt:ipv4prefix";
                 description "Group range";
+                type "jt:ipv4prefix";
               }
             }
           }
@@ -520,25 +564,27 @@ module junos-conf-protocols {
               choice enab_disab_translate {
                 case case_1 {
                   leaf translate {
-                    type empty;
                     description "Translate vid of outgoing pkt to receiver vlan's tag";
+                    type empty;
                   }
                 }
               }
               list source-list {
-                description "Source VLANs for this receiver vlan";
                 key name;
                 ordered-by user;
+                description "Source VLANs for this receiver vlan";
                 leaf name {
-                  type string;
                   description "VLAN name";
+                  type string;
                 }
               }
               leaf install {
-                type empty;
                 description "Install forwarded bridging entires";
+                type empty;
               }
               leaf mode {
+                description "MVR Mode";
+                default "transparent";
                 type enumeration {
                   enum transparent {
                     description "MVR Transparent Mode";
@@ -547,156 +593,189 @@ module junos-conf-protocols {
                     description "MVR Proxy Mode";
                   }
                 }
-                default "transparent";
-                description "MVR Mode";
               }
             }
           }
         }
       }
       list interface {
-        description "Interface options for IGMP";
         key name;
         ordered-by user;
+        description "Interface options for IGMP";
         leaf name {
-          type "jt:interface-name";
           description "Interface name";
+          type union {
+            type "jt:interface-name";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         leaf multicast-router-interface {
-          type empty;
           description "Enabling multicast-router-interface on the interface";
+          type empty;
         }
         leaf immediate-leave {
-          type empty;
           description "Enable immediate group leave on interface";
+          type empty;
         }
         leaf host-only-interface {
-          type empty;
           description "Enable interface to be treated as host-side interface";
+          type empty;
         }
         leaf group-limit {
-          type uint16;
           description "Maximum number of groups an interface can join";
+          type union {
+            type uint16;
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         container static {
           description "Static group or source membership";
           list group {
-            description "IP multicast group address";
             key name;
             ordered-by user;
+            description "IP multicast group address";
             leaf name {
-              type "jt:ipv4addr";
               description "IP multicast group address";
+              type "jt:ipv4addr";
             }
             list source {
-              description "IP multicast source address";
               key name;
               ordered-by user;
+              description "IP multicast source address";
               leaf name {
-                type "jt:ipv4addr";
                 description "Source address of IP multicast data";
+                type "jt:ipv4addr";
               }
             }
           }
         }
       }
       list qualified-vlan {
-        description "VLAN options for qualified-learning";
         key name;
         ordered-by user;
+        description "VLAN options for qualified-learning";
         leaf name {
-          type uint32 {
-            range "0 .. 1023";
-          }
           description "VLAN ID of the learning-domain";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 1023";
+            }
+          }
         }
         leaf query-interval {
-          type uint32 {
-            range "1 .. 1024";
-          }
           description "When to send host query messages";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 1024";
+            }
+          }
         }
         container l2-querier {
           description "Enable L2 querier mode";
           leaf source-address {
-            type "jt:ipv4addr";
             description "Source IP address to use for L2 querier";
+            type "jt:ipv4addr";
           }
         }
         leaf query-response-interval {
-          type string;
           description "How long to wait for a host query response";
           units seconds;
+          type string;
         }
         leaf query-last-member-interval {
-          type string;
           description "When to send group query messages";
           units seconds;
+          type string;
         }
         leaf robust-count {
-          type uint32 {
-            range "2 .. 10";
-          }
           description "Expected packet loss on a subnet";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 10";
+            }
+          }
         }
         leaf immediate-leave {
-          type empty;
           description "Enable immediate group leave on interfaces";
+          type empty;
         }
         container proxy {
-          description "Enable proxy mode";
           presence "enable proxy";
+          description "Enable proxy mode";
           leaf source-address {
-            type "jt:ipv4addr";
             description "Source IP address to use for proxy";
+            type "jt:ipv4addr";
           }
         }
         leaf evpn-ssm-reports-only {
-          type empty;
           description "Accept and process only <s,g> reports of SSM groups";
+          type empty;
         }
         list interface {
-          description "Interface options for IGMP";
           key name;
           ordered-by user;
+          description "Interface options for IGMP";
           leaf name {
-            type "jt:interface-name";
             description "Interface name";
+            type union {
+              type "jt:interface-name";
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
           leaf multicast-router-interface {
-            type empty;
             description "Enabling multicast-router-interface on the interface";
+            type empty;
           }
           leaf immediate-leave {
-            type empty;
             description "Enable immediate group leave on interface";
+            type empty;
           }
           leaf host-only-interface {
-            type empty;
             description "Enable interface to be treated as host-side interface";
+            type empty;
           }
           leaf group-limit {
-            type uint16;
             description "Maximum number of groups an interface can join";
+            type union {
+              type uint16;
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
           container static {
             description "Static group or source membership";
             list group {
-              description "IP multicast group address";
               key name;
               ordered-by user;
+              description "IP multicast group address";
               leaf name {
-                type "jt:ipv4addr";
                 description "IP multicast group address";
+                type "jt:ipv4addr";
               }
               list source {
-                description "IP multicast source address";
                 key name;
                 ordered-by user;
+                description "IP multicast source address";
                 leaf name {
-                  type "jt:ipv4addr";
                   description "Source address of IP multicast data";
+                  type "jt:ipv4addr";
                 }
               }
             }
@@ -704,10 +783,15 @@ module junos-conf-protocols {
         }
       }
       leaf version {
-        type uint8 {
-          range "2 .. 3";
-        }
         description "Set IGMP version number on interface_help_string";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint8 {
+            range "2 .. 3";
+          }
+        }
       }
     }
     container traceoptions {
@@ -715,47 +799,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum packets {
@@ -806,119 +895,144 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf query-interval {
-      type uint32 {
-        range "1 .. 1024";
-      }
-      default "125";
       description "When to send host query messages";
+      default "125";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 1024";
+        }
+      }
     }
     leaf query-response-interval {
-      type string;
-      default "10";
       description "How long to wait for a host query response";
+      default "10";
       units seconds;
+      type string;
     }
     leaf query-last-member-interval {
-      type string;
-      default "1";
       description "When to send group query messages";
+      default "1";
       units seconds;
+      type string;
     }
     leaf robust-count {
-      type uint32 {
-        range "2 .. 10";
-      }
-      default "2";
       description "Expected packet loss on a subnet";
+      default "2";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "2 .. 10";
+        }
+      }
     }
     leaf immediate-leave {
-      type empty;
       description "Enable immediate group leave on interfaces";
+      type empty;
     }
     leaf evpn-ssm-reports-only {
-      type empty;
       description "Accept and process only <s,g> reports of SSM groups";
+      type empty;
     }
     leaf version {
-      type uint8 {
-        range "2 .. 3";
-      }
       description "Set IGMP snooping version number";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint8 {
+          range "2 .. 3";
+        }
+      }
     }
     container proxy {
-      description "Enable proxy mode";
       presence "enable proxy";
+      description "Enable proxy mode";
       leaf source-address {
-        type "jt:ipv4addr";
         description "Source IP address to use for proxy";
+        type "jt:ipv4addr";
       }
       leaf irb {
-        type empty;
         description "Proxy IGMP reports to IRB";
+        type empty;
       }
     }
     list interface {
-      description "Interface options for IGMP";
       key name;
       ordered-by user;
+      description "Interface options for IGMP";
       leaf name {
-        type "jt:interface-name";
         description "Interface name";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf multicast-router-interface {
-        type empty;
         description "Enabling multicast-router-interface on the interface";
+        type empty;
       }
       leaf immediate-leave {
-        type empty;
         description "Enable immediate group leave on interfaces";
+        type empty;
       }
       leaf host-only-interface {
-        type empty;
         description "Enable interfaces to be treated as host-side interfaces";
+        type empty;
       }
       leaf group-limit {
-        type uint16 {
-          range "1 .. 65535";
-        }
         description "Maximum number of (source,group) per interface";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "1 .. 65535";
+          }
+        }
       }
       container static {
         description "Static group or source membership";
         list group {
-          description "IP multicast group address";
           key name;
           ordered-by user;
+          description "IP multicast group address";
           leaf name {
-            type "jt:ipv4addr";
             description "IP multicast group address";
+            type "jt:ipv4addr";
           }
           list source {
-            description "IP multicast source address";
             key name;
             ordered-by user;
+            description "IP multicast source address";
             leaf name {
-              type "jt:ipv4addr";
               description "Source address of IP multicast data";
+              type "jt:ipv4addr";
             }
           }
         }
@@ -928,59 +1042,64 @@ module junos-conf-protocols {
   grouping juniper-default-ri-protocols-mld-snooping {
     description "MLD snooping options";
     list vlan {
-      description "VLAN options";
       key name;
       ordered-by user;
+      description "VLAN options";
       leaf name {
-        type string;
         description "VLAN name";
+        type string;
       }
       container traceoptions {
         description "Trace options for MLD Snooping";
         container file {
           description "Trace file options";
           leaf filename {
+            description "Name of file in which to write trace information";
             type string {
               length "1 .. 1024";
             }
-            description "Name of file in which to write trace information";
           }
           leaf replace {
-            type empty;
             description "Replace trace file rather than appending to it";
             status deprecated;
+            type empty;
           }
           leaf size {
-            type string;
             description "Maximum trace file size";
+            type string;
           }
           leaf files {
-            type uint32 {
-              range "2 .. 1000";
-            }
-            default "10";
             description "Maximum number of trace files";
+            default "10";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 1000";
+              }
+            }
           }
           leaf no-stamp {
-            type empty;
             description "Do not timestamp trace file";
             status deprecated;
+            type empty;
           }
           choice world-readable-choice {
             leaf world-readable {
-              type empty;
               description "Allow any user to read the log file";
+              type empty;
             }
             leaf no-world-readable {
-              type empty;
               description "Don't allow any user to read the log file";
+              type empty;
             }
           }
         }
         list flag {
-          description "Tracing parameters";
           key name;
           ordered-by user;
+          description "Tracing parameters";
           leaf name {
             type enumeration {
               enum packets {
@@ -1031,219 +1150,269 @@ module junos-conf-protocols {
             }
           }
           leaf send {
-            type empty;
             description "Trace transmitted packets";
+            type empty;
           }
           leaf receive {
-            type empty;
             description "Trace received packets";
+            type empty;
           }
           leaf detail {
-            type empty;
             description "Trace detailed information";
+            type empty;
           }
           leaf disable {
-            type empty;
             description "Disable this trace flag";
+            type empty;
           }
         }
       }
       leaf query-interval {
-        type uint32 {
-          range "1 .. 1024";
-        }
-        default "125";
         description "When to send host query messages";
+        default "125";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 1024";
+          }
+        }
       }
       container l2-querier {
         description "Enable L2 querier mode";
         leaf source-address {
-          type "jt:ipv6addr";
           description "Source IP address to use for L2 querier";
+          type "jt:ipv6addr";
         }
       }
       leaf query-response-interval {
-        type string;
-        default "10";
         description "How long to wait for a host query response";
+        default "10";
         units seconds;
+        type string;
       }
       leaf query-last-member-interval {
-        type string;
-        default "1";
         description "When to send group query messages";
+        default "1";
         units seconds;
+        type string;
       }
       leaf robust-count {
-        type uint32 {
-          range "2 .. 10";
-        }
-        default "2";
         description "Expected packet loss on a subnet";
+        default "2";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 10";
+          }
+        }
       }
       leaf immediate-leave {
-        type empty;
         description "Enable immediate group leave on interfaces";
+        type empty;
       }
       container proxy {
         description "Enable proxy mode";
         leaf source-address {
-          type "jt:ipv6addr";
           description "Source IP address to use for proxy";
+          type "jt:ipv6addr";
         }
       }
       leaf evpn-ssm-reports-only {
-        type empty;
         description "Accept and process only <s,g> reports of SSM groups";
+        type empty;
       }
       leaf version {
-        type uint8 {
-          range "1 .. 2";
-        }
         description "Set MLD snooping version number";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint8 {
+            range "1 .. 2";
+          }
+        }
       }
       list interface {
-        description "Interface options for MLD";
         key name;
         ordered-by user;
+        description "Interface options for MLD";
         leaf name {
-          type "jt:interface-name";
           description "Interface name";
+          type union {
+            type "jt:interface-name";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         leaf multicast-router-interface {
-          type empty;
           description "Enabling multicast-router-interface on the interface";
+          type empty;
         }
         leaf immediate-leave {
-          type empty;
           description "Enable immediate group leave on interfaces";
+          type empty;
         }
         leaf host-only-interface {
-          type empty;
           description "Enable interfaces to be treated as host-side interfaces";
+          type empty;
         }
         leaf group-limit {
-          type uint16;
           description "Maximum number of groups an interface can join";
+          type union {
+            type uint16;
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         container static {
           description "Static group or source membership";
           list group {
-            description "IP multicast group address";
             key name;
             ordered-by user;
+            description "IP multicast group address";
             leaf name {
-              type "jt:ipv6addr";
               description "IP multicast group address";
+              type "jt:ipv6addr";
             }
             list source {
-              description "IP multicast source address";
               key name;
               ordered-by user;
+              description "IP multicast source address";
               leaf name {
-                type "jt:ipv6addr";
                 description "Source address of IP multicast data";
+                type "jt:ipv6addr";
               }
             }
           }
         }
       }
       list qualified-vlan {
-        description "VLAN options for qualified-learning";
         key name;
         ordered-by user;
+        description "VLAN options for qualified-learning";
         leaf name {
-          type uint32 {
-            range "0 .. 1023";
-          }
           description "VLAN ID of the learning-domain";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 1023";
+            }
+          }
         }
         leaf query-interval {
-          type uint32 {
-            range "1 .. 1024";
-          }
           description "When to send host query messages";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 1024";
+            }
+          }
         }
         container l2-querier {
           leaf source-address {
-            type "jt:ipv6addr";
             description "Source IP address to use for L2 querier";
+            type "jt:ipv6addr";
           }
         }
         leaf query-response-interval {
-          type string;
           description "How long to wait for a host query response";
           units seconds;
+          type string;
         }
         leaf query-last-member-interval {
-          type string;
           description "When to send group query messages";
           units seconds;
+          type string;
         }
         leaf robust-count {
-          type uint32 {
-            range "2 .. 10";
-          }
           description "Expected packet loss on a subnet";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 10";
+            }
+          }
         }
         leaf immediate-leave {
-          type empty;
           description "Enable immediate group leave on interfaces";
+          type empty;
         }
         container proxy {
           description "Enable proxy mode";
           leaf source-address {
-            type "jt:ipv6addr";
             description "Source IP address to use for proxy";
+            type "jt:ipv6addr";
           }
         }
         leaf evpn-ssm-reports-only {
-          type empty;
           description "Accept and process only <s,g> reports of SSM groups";
+          type empty;
         }
         list interface {
-          description "Interface options for MLD";
           key name;
           ordered-by user;
+          description "Interface options for MLD";
           leaf name {
-            type "jt:interface-name";
             description "Interface name";
+            type union {
+              type "jt:interface-name";
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
           leaf multicast-router-interface {
-            type empty;
             description "Enabling multicast-router-interface on the interface";
+            type empty;
           }
           leaf immediate-leave {
-            type empty;
             description "Enable immediate group leave on interfaces";
+            type empty;
           }
           leaf host-only-interface {
-            type empty;
             description "Enable interfaces to be treated as host-side interfaces";
+            type empty;
           }
           leaf group-limit {
-            type uint16;
             description "Maximum number of groups an interface can join";
+            type union {
+              type uint16;
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
           container static {
             description "Static group or source membership";
             list group {
-              description "IP multicast group address";
               key name;
               ordered-by user;
+              description "IP multicast group address";
               leaf name {
-                type "jt:ipv6addr";
                 description "IP multicast group address";
+                type "jt:ipv6addr";
               }
               list source {
-                description "IP multicast source address";
                 key name;
                 ordered-by user;
+                description "IP multicast source address";
                 leaf name {
-                  type "jt:ipv6addr";
                   description "Source address of IP multicast data";
+                  type "jt:ipv6addr";
                 }
               }
             }
@@ -1256,47 +1425,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum packets {
@@ -1347,118 +1521,143 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf query-interval {
-      type uint32 {
-        range "1 .. 1024";
-      }
-      default "125";
       description "When to send host query messages";
+      default "125";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 1024";
+        }
+      }
     }
     leaf query-response-interval {
-      type string;
-      default "10";
       description "How long to wait for a host query response";
+      default "10";
       units seconds;
+      type string;
     }
     leaf query-last-member-interval {
-      type string;
-      default "1";
       description "When to send group query messages";
+      default "1";
       units seconds;
+      type string;
     }
     leaf robust-count {
-      type uint32 {
-        range "2 .. 10";
-      }
-      default "2";
       description "Expected packet loss on a subnet";
+      default "2";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "2 .. 10";
+        }
+      }
     }
     leaf immediate-leave {
-      type empty;
       description "Enable immediate group leave on interfaces";
+      type empty;
     }
     leaf evpn-ssm-reports-only {
-      type empty;
       description "Accept and process only <s,g> reports of SSM groups";
+      type empty;
     }
     leaf version {
-      type uint8 {
-        range "1 .. 2";
-      }
       description "Set MLD snooping version number";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint8 {
+          range "1 .. 2";
+        }
+      }
     }
     container proxy {
       description "Enable proxy mode";
       leaf source-address {
-        type "jt:ipv6addr";
         description "Source IP address to use for proxy";
+        type "jt:ipv6addr";
       }
       leaf irb {
-        type empty;
         description "Proxy IGMP reports to IRB";
+        type empty;
       }
     }
     list interface {
-      description "Interface options for MLD";
       key name;
       ordered-by user;
+      description "Interface options for MLD";
       leaf name {
-        type "jt:interface-name";
         description "Interface name";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf multicast-router-interface {
-        type empty;
         description "Enabling multicast-router-interface on the interface";
+        type empty;
       }
       leaf immediate-leave {
-        type empty;
         description "Enable immediate group leave on interfaces";
+        type empty;
       }
       leaf host-only-interface {
-        type empty;
         description "Enable interfaces to be treated as host-side interfaces";
+        type empty;
       }
       leaf group-limit {
-        type uint16 {
-          range "1 .. 65535";
-        }
         description "Maximum number of (source,group) per interface";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "1 .. 65535";
+          }
+        }
       }
       container static {
         description "Static group or source membership";
         list group {
-          description "IP multicast group address";
           key name;
           ordered-by user;
+          description "IP multicast group address";
           leaf name {
-            type "jt:ipv6addr";
             description "IP multicast group address";
+            type "jt:ipv6addr";
           }
           list source {
-            description "IP multicast source address";
             key name;
             ordered-by user;
+            description "IP multicast source address";
             leaf name {
-              type "jt:ipv6addr";
               description "Source address of IP multicast data";
+              type "jt:ipv6addr";
             }
           }
         }
@@ -1471,47 +1670,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum packets {
@@ -1550,20 +1754,20 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
@@ -1575,87 +1779,114 @@ module junos-conf-protocols {
   }
   grouping juniper-protocols-amt-relay {
     container family {
-      description "Protocol family";
       presence "enable family";
+      description "Protocol family";
       container inet {
         presence "enable inet";
         leaf anycast-prefix {
-          type "jt:ipv4prefix";
           description "IPv4 anycast prefix";
+          type "jt:ipv4prefix";
         }
         leaf local-address {
-          type "jt:ipv4addr";
           description "IPv4 local address";
+          type "jt:ipv4addr";
         }
       }
     }
     leaf secret-key-timeout {
-      type uint32 {
-        range "5 .. 1440";
-      }
       description "Time interval for the secret key to expire";
       units minutes;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "5 .. 1440";
+        }
+      }
     }
     leaf tunnel-limit {
-      type uint32;
       description "Number of AMT tunnels";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf unicast-stream-limit {
-      type uint32;
       description "Maximum number of AMT unicast streams(s,g,intf)";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf accounting {
-      type empty;
       description "Enable AMT accounting";
+      type empty;
     }
     leaf-list tunnel-devices {
-      type "jt:interface-device";
-      description "Tunnel devices to be used for creating ud interfaces";
       ordered-by user;
+      description "Tunnel devices to be used for creating ud interfaces";
+      type union {
+        type "jt:interface-device";
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
   }
   grouping juniper-protocols-ancp {
     container traceoptions {
       description "Trace options for ANCP";
       leaf no-remote-trace {
-        type empty;
         description "Disable remote tracing";
+        type empty;
       }
       container file {
         description "Trace file information";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "3";
           description "Maximum number of trace files";
+          default "3";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
         leaf match {
-          type "jt:regular-expression";
           description "Regular expression for lines to be logged";
+          type "jt:regular-expression";
         }
       }
       leaf level {
+        description "Level of debugging output";
+        default "error";
         type enumeration {
           enum error {
             description "Match error conditions";
@@ -1676,13 +1907,11 @@ module junos-conf-protocols {
             description "Match all levels";
           }
         }
-        default "error";
-        description "Level of debugging output";
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum config {
@@ -1727,237 +1956,352 @@ module junos-conf-protocols {
           }
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     container qos-adjust {
-      description "Enable QoS adjust for interfaces and interface-sets";
       presence "enable qos-adjust";
+      description "Enable QoS adjust for interfaces and interface-sets";
       leaf sdsl-bytes {
-        type int32 {
-          range "-100 .. 100";
-        }
-        default "0";
         description "Set SDSL byte adjust value";
         status deprecated;
+        default "0";
         units bytes;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "-100 .. 100";
+          }
+        }
       }
       leaf sdsl-overhead-adjust {
-        type uint32 {
-          range "80 .. 100";
-        }
-        default "100";
         description "Set SDSL overhead adjusted";
         status deprecated;
+        default "100";
         units percent;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "80 .. 100";
+          }
+        }
       }
       leaf vdsl-bytes {
-        type int32 {
-          range "-100 .. 100";
-        }
-        default "0";
         description "Set VDSL byte adjust value";
         status deprecated;
+        default "0";
         units bytes;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "-100 .. 100";
+          }
+        }
       }
       leaf vdsl-overhead-adjust {
-        type uint32 {
-          range "80 .. 100";
-        }
-        default "100";
         description "Set VDSL overhead adjusted";
         status deprecated;
+        default "100";
         units percent;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "80 .. 100";
+          }
+        }
       }
       leaf vdsl2-bytes {
-        type int32 {
-          range "-100 .. 100";
-        }
-        default "0";
         description "Set VDSL2 byte adjust value";
         status deprecated;
+        default "0";
         units bytes;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "-100 .. 100";
+          }
+        }
       }
       leaf vdsl2-overhead-adjust {
-        type uint32 {
-          range "80 .. 100";
-        }
-        default "100";
         description "Set VDSL2 overhead adjusted";
         status deprecated;
+        default "100";
         units percent;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "80 .. 100";
+          }
+        }
       }
       leaf adsl-bytes {
-        type int32 {
-          range "-100 .. 100";
-        }
-        default "0";
         description "Set ADSL byte adjust value";
         status deprecated;
+        default "0";
         units bytes;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "-100 .. 100";
+          }
+        }
       }
       leaf adsl2-bytes {
-        type int32 {
-          range "-100 .. 100";
-        }
-        default "0";
         description "Set ADSL2 byte adjust value";
         status deprecated;
+        default "0";
         units bytes;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "-100 .. 100";
+          }
+        }
       }
       leaf adsl2-plus-bytes {
-        type int32 {
-          range "-100 .. 100";
-        }
-        default "0";
         description "Set ADSL-PLUS byte adjust value";
         status deprecated;
+        default "0";
         units bytes;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "-100 .. 100";
+          }
+        }
       }
       leaf other-bytes {
-        type int32 {
-          range "-100 .. 100";
-        }
-        default "0";
         description "Set OTHER byte adjust value";
         status deprecated;
+        default "0";
         units bytes;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "-100 .. 100";
+          }
+        }
       }
       leaf other-overhead-adjust {
-        type uint32 {
-          range "80 .. 100";
-        }
-        default "100";
         description "Set OTHER overhead adjusted";
         status deprecated;
+        default "100";
         units percent;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "80 .. 100";
+          }
+        }
       }
     }
     leaf pre-ietf-mode {
-      type empty;
       description "Enable backward compatibility mode";
+      type empty;
     }
     leaf maximum-discovery-table-entries {
-      type uint32 {
-        range "1 .. 100000";
-      }
       description "Maximum number of discovery table entries per neighbor";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 100000";
+        }
+      }
     }
     leaf adjacency-timer {
-      type uint32 {
-        range "1 .. 25";
-      }
       description "Set adjacency timer in seconds";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 25";
+        }
+      }
     }
     leaf maximum-helper-restart-time {
-      type uint32 {
-        range "45 .. 600";
-      }
       description "Set maximum helper restart timer";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "45 .. 600";
+        }
+      }
     }
     leaf qos-adjust-adsl {
-      type uint32 {
-        range "0 .. 100";
-      }
-      default "100";
       description "Set ADSL QoS adjustment factor";
       status deprecated;
+      default "100";
       units percent;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 100";
+        }
+      }
     }
     leaf qos-adjust-adsl2 {
-      type uint32 {
-        range "0 .. 100";
-      }
-      default "100";
       description "Set ADSL2 QoS adjustment factor";
       status deprecated;
+      default "100";
       units percent;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 100";
+        }
+      }
     }
     leaf qos-adjust-adsl2-plus {
-      type uint32 {
-        range "0 .. 100";
-      }
-      default "100";
       description "Set ADSL2+ QoS adjustment factor";
       status deprecated;
+      default "100";
       units percent;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 100";
+        }
+      }
     }
     leaf qos-adjust-vdsl {
-      type uint32 {
-        range "0 .. 100";
-      }
-      default "100";
       description "Set VDSL QoS adjustment factor";
       status deprecated;
+      default "100";
       units percent;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 100";
+        }
+      }
     }
     leaf qos-adjust-vdsl2 {
-      type uint32 {
-        range "0 .. 100";
-      }
-      default "100";
       description "Set VDSL2 QoS adjustment factor";
       status deprecated;
+      default "100";
       units percent;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 100";
+        }
+      }
     }
     leaf qos-adjust-sdsl {
-      type uint32 {
-        range "0 .. 100";
-      }
-      default "100";
       description "Set SDSL QoS adjustment factor";
       status deprecated;
+      default "100";
       units percent;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 100";
+        }
+      }
     }
     leaf qos-adjust-other {
-      type uint32 {
-        range "0 .. 100";
-      }
-      default "100";
       description "Set OTHER QoS adjustment factor";
       status deprecated;
+      default "100";
       units percent;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 100";
+        }
+      }
     }
     leaf gsmp-syn-wait {
-      type empty;
       description "Enable partition ID learning";
+      type empty;
     }
     leaf gsmp-syn-timeout {
-      type uint32 {
-        range "1 .. 60";
-      }
-      default "30";
       description "Set partition ID learning timeout";
+      default "30";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 60";
+        }
+      }
     }
     leaf adjacency-loss-hold-time {
-      type uint32 {
-        range "0 .. 1800";
-      }
-      default "0";
       description "Audit duration upon adjacency loss";
+      default "0";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 1800";
+        }
+      }
     }
     container interfaces {
       description "ANCP interface config options";
       list interface-set {
-        description "ANCP interface-set specific options";
         key name;
+        description "ANCP interface-set specific options";
         leaf name {
-          type string;
           description "Name of the interface set";
+          type string;
         }
         leaf access-identifier {
-          type string;
           description "Subscriber specific access identifier information";
+          type string;
         }
         leaf neighbor {
-          type "jt:ipaddr";
           description "Neighbor IP address";
           status deprecated;
+          type "jt:ipaddr";
         }
       }
       list interface {
@@ -1966,130 +2310,166 @@ module junos-conf-protocols {
       }
     }
     list neighbor {
-      description "ANCP neighbor config options";
       key name;
+      description "ANCP neighbor config options";
       leaf name {
-        type "jt:ipaddr";
         description "IP address of neighbor";
+        type "jt:ipaddr";
       }
       leaf discovery-mode {
-        type empty;
         description "Enable topology discovery";
         status deprecated;
+        type empty;
       }
       choice ietf-mode-option {
         case case_1 {
           leaf pre-ietf-mode {
-            type empty;
             description "Enable backward compatibility mode";
+            type empty;
           }
         }
         case case_2 {
           leaf ietf-mode {
-            type empty;
             description "Enable IETF mode";
+            type empty;
           }
         }
       }
       leaf adjacency-timer {
-        type uint32 {
-          range "1 .. 25";
-        }
         description "Set adjacency timer in seconds";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 25";
+          }
+        }
       }
       leaf maximum-discovery-table-entries {
-        type uint32 {
-          range "1 .. 100000";
-        }
         description "Maximum number of discovery table entries";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100000";
+          }
+        }
       }
       container auto-configure-trigger {
-        description "Auto-configure trigger support";
         presence "enable auto-configure-trigger";
+        description "Auto-configure trigger support";
         leaf interface {
-          type "jt:interface-device";
+          type union {
+            type "jt:interface-device";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
       }
       leaf adjacency-loss-hold-time {
-        type uint32 {
-          range "0 .. 1800";
-        }
         description "Audit duration upon adjacency loss";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 1800";
+          }
+        }
       }
     }
   }
   grouping ancp_interfaces_type {
     description "Physical interface";
     leaf name {
-      type "jt:interface-name";
+      type union {
+        type "jt:interface-name";
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf access-identifier {
-      type string;
       description "Subscriber specific access identifier information";
+      type string;
     }
     leaf neighbor {
-      type "jt:ipaddr";
       description "Neighbor IP address";
       status deprecated;
+      type "jt:ipaddr";
     }
     leaf overhead-accounting {
-      type empty;
       description "Enable overhead accounting on per ACI basis";
       status deprecated;
+      type empty;
     }
   }
   grouping juniper-protocols-bgp {
     container path-selection {
       description "Configure path selection strategy";
       leaf l2vpn-use-bgp-rules {
-        type empty;
         description "Use standard BGP rules during L2VPN path selection";
+        type empty;
       }
       leaf cisco-non-deterministic {
-        type empty;
         description "Use Cisco IOS nondeterministic path selection algorithm";
+        type empty;
       }
       leaf always-compare-med {
-        type empty;
         description "Always compare MED values, regardless of neighbor AS";
+        type empty;
       }
       container med-plus-igp {
-        description "Add IGP cost to next-hop to MED before comparing MED values";
         presence "enable med-plus-igp";
+        description "Add IGP cost to next-hop to MED before comparing MED values";
         leaf med-multiplier {
-          type uint16 {
-            range "1 .. 1000";
-          }
-          default "1";
           description "Multiplier for MED";
+          default "1";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "1 .. 1000";
+            }
+          }
         }
         leaf igp-multiplier {
-          type uint16 {
-            range "1 .. 1000";
-          }
-          default "1";
           description "Multiplier for IGP cost to next-hop";
+          default "1";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "1 .. 1000";
+            }
+          }
         }
       }
       leaf external-router-id {
-        type empty;
         description "Compare router ID on BGP externals";
+        type empty;
       }
       leaf as-path-ignore {
-        type empty;
         description "Ignore AS path comparison during path selection";
+        type empty;
       }
     }
     list group {
-      description "Define a peer group";
       key name;
       ordered-by user;
+      description "Define a peer group";
       leaf name {
-        type string;
         description "Group name";
+        type string;
       }
       leaf type {
+        description "Type of peer group";
         type enumeration {
           enum internal {
             description "IBGP group";
@@ -2098,23 +2478,27 @@ module junos-conf-protocols {
             description "EBGP group";
           }
         }
-        description "Type of peer group";
       }
       leaf description {
+        description "Text description";
         type string {
           length "1 .. 255";
         }
-        description "Text description";
       }
       leaf local-address {
-        type "jt:ipaddr";
         description "Address of local end of BGP session";
+        type "jt:ipaddr";
       }
       leaf hold-time {
-        type uint32 {
-          range "0 .. 65535";
-        }
         description "Hold time used when negotiating with a peer";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 65535";
+          }
+        }
       }
       container family {
         description "Protocol family for NLRIs in updates";
@@ -2142,17 +2526,18 @@ module junos-conf-protocols {
           }
         }
         container route-target {
-          description "Route target NLRI used for VPN route filtering";
           presence "enable route-target";
+          description "Route target NLRI used for VPN route filtering";
         }
       }
       leaf authentication-key {
+        description "MD5 authentication key";
         type string {
           length "1 .. 126";
         }
-        description "MD5 authentication key";
       }
       leaf authentication-algorithm {
+        description "Authentication algorithm name";
         type enumeration {
           enum md5 {
             description "Message Digest 5";
@@ -2167,55 +2552,59 @@ module junos-conf-protocols {
             description "TCP Authentication Option";
           }
         }
-        description "Authentication algorithm name";
       }
       leaf tcpao-auth-mismatch {
+        description "Continue without TCP-AO if any one TCP endpoint does not have TCP-AO configured";
         type enumeration {
           enum allow-without-tcpao {
             description "Allow the connection establishment without TCP-AO";
           }
         }
-        description "Continue without TCP-AO if any one TCP endpoint does not have TCP-AO configured";
       }
       leaf authentication-key-chain {
+        description "Key chain name";
         type string {
           length "1 .. 128";
         }
-        description "Key chain name";
       }
       leaf-list export {
-        type "jt:policy-algebra";
-        description "Export policy";
         ordered-by user;
+        description "Export policy";
+        type "jt:policy-algebra";
       }
       leaf tcp-mss {
-        type uint32 {
-          range "1 .. 4096";
-        }
         description "Maximum TCP segment size";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 4096";
+          }
+        }
       }
       list neighbor {
-        description "Configure a neighbor";
         key name;
         ordered-by user;
+        description "Configure a neighbor";
         leaf name {
           type "jt:ipaddr-scoped";
         }
         leaf description {
+          description "Text description";
           type string {
             length "1 .. 255";
           }
-          description "Text description";
         }
         leaf passive {
-          type empty;
           description "Do not send open messages to a peer";
+          type empty;
         }
       }
     }
     leaf log-updown {
-      type empty;
       description "Log a message for peer state transitions";
+      type empty;
     }
   }
   grouping bgp-af-gr {
@@ -2226,14 +2615,14 @@ module junos-conf-protocols {
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable restarter functionality";
+              type empty;
             }
           }
         }
         leaf stale-time {
-          type string;
           description "Stale time in seconds or dhms notation (1..16777215)";
+          type string;
         }
       }
       container extended-route-retention {
@@ -2241,23 +2630,24 @@ module junos-conf-protocols {
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable extended-route-retention (LLGR-helper) functionality";
+              type empty;
             }
           }
         }
         leaf retention-time {
-          type string;
           description "Retention time in seconds or dhms notation (1..16777215)";
+          type string;
         }
         leaf-list retention-policy {
-          type "jt:policy-algebra";
-          description "Retention policy for Extended Route Retention";
           ordered-by user;
+          description "Retention policy for Extended Route Retention";
+          type "jt:policy-algebra";
         }
       }
     }
     leaf forwarding-state-bit {
+      description "Control forwarding-state flag negotiation";
       type enumeration {
         enum set {
           description "Always set";
@@ -2266,7 +2656,6 @@ module junos-conf-protocols {
           description "Use state of associated FIB(s)";
         }
       }
-      description "Control forwarding-state flag negotiation";
     }
   }
   grouping bgp-afi-default {
@@ -2292,74 +2681,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -2367,24 +2781,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -2399,60 +2813,70 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
   }
   grouping apath-options {
     description "Number of paths to advertise";
     leaf receive {
-      type empty;
       description "Receive multiple paths from peer";
+      type empty;
     }
     container send {
-      description "Send multiple paths to peer";
       presence "enable send";
+      description "Send multiple paths to peer";
       container path-selection-mode {
         description "Configure how to select add-path routes";
         choice mode {
           case case_1 {
             leaf all-paths {
-              type empty;
               description "Advertise all paths allowed by path count";
+              type empty;
             }
           }
           case case_2 {
             leaf equal-cost-paths {
-              type empty;
               description "Advertise equal cost paths";
+              type empty;
             }
           }
         }
       }
       leaf-list prefix-policy {
-        type "jt:policy-algebra";
-        description "Perform add-path only for prefixes that match policy";
         ordered-by user;
+        description "Perform add-path only for prefixes that match policy";
+        type "jt:policy-algebra";
       }
       leaf path-count {
-        type int32 {
-          range "2 .. 64";
-        }
         description "Number of paths to advertise";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "2 .. 64";
+          }
+        }
       }
       leaf include-backup-path {
-        type int32 {
-          range "1 .. 2";
-        }
         description "Number of backup paths to advertise";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "1 .. 2";
+          }
+        }
       }
       leaf multipath {
-        type empty;
         description "Include only multipath contributor routes";
+        type empty;
       }
     }
   }
@@ -2479,74 +2903,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -2554,24 +3003,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -2586,26 +3035,26 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     leaf-list no-validate {
-      type "jt:policy-algebra";
-      description "Bypass validation procedure for routes that match policy";
       ordered-by user;
+      description "Bypass validation procedure for routes that match policy";
+      type "jt:policy-algebra";
     }
     leaf strip-nexthop {
-      type empty;
       description "Strip the next-hop from the outgoing flow update";
+      type empty;
     }
     leaf allow-policy-add-nexthop {
-      type empty;
       description "Allow policy to add nexthop to a route without nexthop";
       status deprecated;
+      type empty;
     }
   }
   grouping bgp-afi-flow-with-redirect-ip-action {
@@ -2631,74 +3080,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -2706,24 +3180,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -2738,37 +3212,37 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     leaf-list no-validate {
-      type "jt:policy-algebra";
-      description "Bypass validation procedure for routes that match policy";
       ordered-by user;
+      description "Bypass validation procedure for routes that match policy";
+      type "jt:policy-algebra";
     }
     leaf strip-nexthop {
-      type empty;
       description "Strip the next-hop from the outgoing flow update";
+      type empty;
     }
     container legacy-redirect-ip-action {
-      description "Configure legacy redirect to IP support";
       presence "enable legacy-redirect-ip-action";
+      description "Configure legacy redirect to IP support";
       leaf receive {
-        type empty;
         description "Accept legacy encoded redirect-to-ip action attribute";
+        type empty;
       }
       leaf send {
-        type empty;
         description "Advertise Redirect action as legacy redirect attribute";
+        type empty;
       }
     }
     leaf secondary-independent-resolution {
-      type empty;
       description "Resolve FLOW routes in VRF table independent of VPN FLOW route";
+      type empty;
     }
   }
   grouping bgp-afi-inet-transport {
@@ -2794,74 +3268,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -2869,24 +3368,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -2901,28 +3400,28 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container aggregate-label {
-      description "Aggregate labels of incoming routes with the same FEC";
       presence "enable aggregate-label";
+      description "Aggregate labels of incoming routes with the same FEC";
       leaf community {
-        type string;
         description "Community to identify the FEC of incoming routes";
+        type string;
       }
     }
     leaf per-prefix-label {
-      type empty;
       description "Allocate a unique label to each advertised prefix";
+      type empty;
     }
     leaf per-group-label {
-      type empty;
       description "Advertise prefixes with unique labels per group";
+      type empty;
     }
     container traffic-statistics {
       description "Collect statistics for BGP label-switched paths";
@@ -2930,8 +3429,8 @@ module junos-conf-protocols {
       uses bgpaf-traffic-statistics;
     }
     container protection {
-      description "Compute backup path for active nexthop failure";
       presence "enable protection";
+      description "Compute backup path for active nexthop failure";
     }
   }
   grouping bgp-afi-inet6-labeled {
@@ -2957,74 +3456,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -3032,24 +3556,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -3064,24 +3588,24 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container aggregate-label {
-      description "Aggregate labels of incoming routes with the same FEC";
       presence "enable aggregate-label";
+      description "Aggregate labels of incoming routes with the same FEC";
       leaf community {
-        type string;
         description "Community to identify the FEC of incoming routes";
+        type string;
       }
     }
     leaf per-group-label {
-      type empty;
       description "Advertise prefixes with unique labels per group";
+      type empty;
     }
     container traffic-statistics {
       description "Collect statistics for BGP label-switched paths";
@@ -3091,33 +3615,33 @@ module junos-conf-protocols {
     container rib {
       description "Select table used by labeled unicast routes";
       leaf "inet6.3" {
-        type empty;
         description "Use inet6.3 to exchange labeled unicast routes";
+        type empty;
       }
     }
     container explicit-null {
-      description "Advertise explicit null";
       presence "enable explicit-null";
+      description "Advertise explicit null";
       leaf connected-only {
-        type empty;
         description "Advertise explicit null only for connected routes";
+        type empty;
       }
     }
     container protection {
-      description "Compute backup path for active nexthop failure";
       presence "enable protection";
+      description "Compute backup path for active nexthop failure";
     }
     list topology {
-      description "Multi topology routing tables";
       key name;
       ordered-by user;
+      description "Multi topology routing tables";
       leaf name {
-        type string;
         description "Topology name";
+        type string;
       }
       leaf community {
-        type string;
         description "Community to identify multi topology routes";
+        type string;
       }
     }
   }
@@ -3144,74 +3668,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -3219,24 +3768,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -3251,28 +3800,28 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container aggregate-label {
-      description "Aggregate labels of incoming routes with the same FEC";
       presence "enable aggregate-label";
+      description "Aggregate labels of incoming routes with the same FEC";
       leaf community {
-        type string;
         description "Community to identify the FEC of incoming routes";
+        type string;
       }
     }
     leaf per-prefix-label {
-      type empty;
       description "Allocate a unique label to each advertised prefix";
+      type empty;
     }
     leaf per-group-label {
-      type empty;
       description "Advertise prefixes with unique labels per group";
+      type empty;
     }
     container traffic-statistics {
       description "Collect statistics for BGP label-switched paths";
@@ -3280,12 +3829,12 @@ module junos-conf-protocols {
       uses bgpaf-traffic-statistics;
     }
     container lu-export {
-      description "Install Classful Transport routes in inet6.3";
       presence "enable lu-export";
+      description "Install Classful Transport routes in inet6.3";
     }
     container protection {
-      description "Compute backup path for active nexthop failure";
       presence "enable protection";
+      description "Compute backup path for active nexthop failure";
     }
   }
   grouping bgp-afi-l2vpn {
@@ -3311,74 +3860,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -3386,24 +3960,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -3418,27 +3992,27 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container egress-protection {
-      description "Egress router protection";
       presence "enable egress-protection";
+      description "Egress router protection";
       container context-identifier {
         description "Context identifier";
         leaf context-id {
-          type "jt:ipv4addr";
           description "IP address";
+          type "jt:ipv4addr";
         }
       }
       leaf-list keep-import {
-        type "jt:policy-algebra";
-        description "Import policy";
         ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
       }
     }
   }
@@ -3465,74 +4039,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -3540,24 +4139,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -3572,44 +4171,44 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container aggregate-label {
-      description "Aggregate labels of incoming routes with the same FEC";
       presence "enable aggregate-label";
+      description "Aggregate labels of incoming routes with the same FEC";
       leaf community {
-        type string;
         description "Community to identify the FEC of incoming routes";
+        type string;
       }
     }
     container egress-protection {
-      description "Egress router protection";
       presence "enable egress-protection";
+      description "Egress router protection";
       container context-identifier {
         description "Context identifier";
         leaf context-id {
-          type "jt:ipv4addr";
           description "IP address";
+          type "jt:ipv4addr";
         }
       }
       leaf-list keep-import {
-        type "jt:policy-algebra";
-        description "Import policy";
         ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
       }
     }
     leaf accept-local-nexthop {
-      type empty;
       description "Enable processing of routes with own nexthop";
+      type empty;
     }
     leaf accept-own {
-      type empty;
       description "Enable processing of routes with own originator-id or nexthop";
+      type empty;
     }
   }
   grouping bgp-afi-labeled {
@@ -3635,74 +4234,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -3710,24 +4334,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -3742,28 +4366,28 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container aggregate-label {
-      description "Aggregate labels of incoming routes with the same FEC";
       presence "enable aggregate-label";
+      description "Aggregate labels of incoming routes with the same FEC";
       leaf community {
-        type string;
         description "Community to identify the FEC of incoming routes";
+        type string;
       }
     }
     leaf per-prefix-label {
-      type empty;
       description "Allocate a unique label to each advertised prefix";
+      type empty;
     }
     leaf per-group-label {
-      type empty;
       description "Advertise prefixes with unique labels per group";
+      type empty;
     }
     container traffic-statistics {
       description "Collect statistics for BGP label-switched paths";
@@ -3771,16 +4395,16 @@ module junos-conf-protocols {
       uses bgpaf-traffic-statistics;
     }
     list topology {
-      description "Multi topology routing tables";
       key name;
       ordered-by user;
+      description "Multi topology routing tables";
       leaf name {
-        type string;
         description "Topology name";
+        type string;
       }
       leaf community {
-        type string;
         description "Community to identify multi topology routes";
+        type string;
       }
     }
     container rib {
@@ -3788,52 +4412,52 @@ module junos-conf-protocols {
       uses rib-inet3;
     }
     container explicit-null {
-      description "Advertise explicit null";
       presence "enable explicit-null";
+      description "Advertise explicit null";
       leaf connected-only {
-        type empty;
         description "Advertise explicit null only for connected routes";
+        type empty;
       }
     }
     container protection {
-      description "Compute backup path for active nexthop failure";
       presence "enable protection";
+      description "Compute backup path for active nexthop failure";
     }
     container egress-protection {
-      description "Egress router protection";
       presence "enable egress-protection";
+      description "Egress router protection";
       container context-identifier {
         description "Context identifier";
         leaf context-id {
-          type "jt:ipv4addr";
           description "IP address";
+          type "jt:ipv4addr";
         }
       }
       leaf-list keep-import {
-        type "jt:policy-algebra";
-        description "Import policy";
         ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
       }
     }
     leaf resolve-vpn {
-      type empty;
       description "Install received NLRI in inet.3 also";
+      type empty;
     }
     container entropy-label {
-      description "Use entropy label for entropy label capable BGP LSPs";
       presence "enable entropy-label";
+      description "Use entropy label for entropy label capable BGP LSPs";
       leaf-list import {
-        type "jt:policy-algebra";
-        description "Policy to select BGP LSPs to use entropy label";
         ordered-by user;
+        description "Policy to select BGP LSPs to use entropy label";
+        type "jt:policy-algebra";
       }
       leaf no-next-hop-validation {
-        type empty;
         description "Don't validate next hop field against route next hop";
+        type empty;
       }
       leaf elc-v2-compatible {
-        type empty;
         description "Send and accept ELCv2 in addition to ELCv3";
+        type empty;
       }
     }
   }
@@ -3847,8 +4471,8 @@ module junos-conf-protocols {
       uses bgpaf-accepted-prefix-limit;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     container loops {
       description "Allow local AS in received AS paths";
@@ -3859,8 +4483,8 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -3898,74 +4522,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -3973,24 +4622,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -4005,28 +4654,28 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container protection {
-      description "Compute backup path for active nexthop failure";
       presence "enable protection";
+      description "Compute backup path for active nexthop failure";
     }
     list topology {
-      description "Multi topology routing tables";
       key name;
       ordered-by user;
+      description "Multi topology routing tables";
       leaf name {
-        type string;
         description "Topology name";
+        type string;
       }
       leaf community {
-        type string;
         description "Community to identify multi topology routes";
+        type string;
       }
     }
   }
@@ -4053,74 +4702,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -4128,24 +4802,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -4160,19 +4834,19 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container aggregate-label {
-      description "Aggregate labels of incoming routes with the same FEC";
       presence "enable aggregate-label";
+      description "Aggregate labels of incoming routes with the same FEC";
       leaf community {
-        type string;
         description "Community to identify the FEC of incoming routes";
+        type string;
       }
     }
   }
@@ -4199,74 +4873,99 @@ module junos-conf-protocols {
       uses bgpaf-aigp-options;
     }
     leaf damping {
-      type empty;
       description "Enable route flap damping";
+      type empty;
     }
     leaf local-ipv4-address {
-      type "jt:ipv4addr";
       description "Local IPv4 address";
+      type "jt:ipv4addr";
     }
     container loops {
       description "Allow local AS in received AS paths";
       uses bgpaf-loops;
     }
     container delay-route-advertisements {
-      description "Delay route updates for this family until FIB-sync";
       presence "enable delay-route-advertisements";
+      description "Delay route updates for this family until FIB-sync";
       leaf always-wait-for-krt-drain {
-        type empty;
         description "Wait for KRT-queue drain for more-specific prefixes";
+        type empty;
       }
       container minimum-delay {
         description "Minimum-delay to ensure KRT sees the route flash";
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf inbound-convergence {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Min delay(sec) advertisement after source-peer sent all routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
       container maximum-delay {
         description "Maximum delay deferring routes";
         leaf route-age {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement route age";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
         leaf routing-uptime {
-          type uint32 {
-            range "1 .. 36000";
-          }
           description "Max delay(sec) advertisement after RPD start";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 36000";
+            }
+          }
         }
       }
     }
     container nexthop-resolution {
       description "Configure nexthop resolution properties";
       leaf no-resolution {
-        type empty;
         description "Consider nexthop good without resolution attempt";
+        type empty;
       }
       leaf preserve-nexthop-hierarchy {
-        type empty;
         description "Attempt preserving resolved nexthop chain in forwarding";
+        type empty;
       }
     }
     container defer-initial-multipath-build {
-      description "Defer initial multipath build until EOR is received";
       presence "enable defer-initial-multipath-build";
+      description "Defer initial multipath build until EOR is received";
       leaf maximum-delay {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Max delay(sec) multipath build after peer is up";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -4274,24 +4973,24 @@ module junos-conf-protocols {
       uses bgp-af-gr;
     }
     leaf extended-nexthop {
-      type empty;
       description "Extended nexthop encoding";
+      type empty;
     }
     leaf extended-nexthop-color {
-      type empty;
       description "Resolve using extended color nexthop";
+      type empty;
     }
     leaf extended-nexthop-tunnel {
-      type empty;
       description "Use BGP tunnel attribute";
+      type empty;
     }
     leaf no-install {
-      type empty;
       description "Dont install received routes in forwarding";
+      type empty;
     }
     leaf route-age-bgp-view {
-      type empty;
       description "Maintain BGP route's age based on Update messages only";
+      type empty;
     }
     container output-queue-priority {
       description "Default output-queue to assign updates to";
@@ -4306,35 +5005,35 @@ module junos-conf-protocols {
       uses bgp-output-queue-priority-class;
     }
     leaf advertise-srv6-service {
-      type empty;
       description "Advertise SRv6 service";
+      type empty;
     }
     leaf accept-srv6-service {
-      type empty;
       description "Accept SRv6 service";
+      type empty;
     }
     container aggregate-label {
-      description "Aggregate labels of incoming routes with the same FEC";
       presence "enable aggregate-label";
+      description "Aggregate labels of incoming routes with the same FEC";
       leaf community {
-        type string;
         description "Community to identify the FEC of incoming routes";
+        type string;
       }
     }
     container egress-protection {
-      description "Egress router protection";
       presence "enable egress-protection";
+      description "Egress router protection";
       container context-identifier {
         description "Context identifier";
         leaf context-id {
-          type "jt:ipv4addr";
           description "IP address";
+          type "jt:ipv4addr";
         }
       }
       leaf-list keep-import {
-        type "jt:policy-algebra";
-        description "Import policy";
         ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
       }
     }
   }
@@ -4342,16 +5041,21 @@ module junos-conf-protocols {
     choice class {
       case case_1 {
         leaf priority {
-          type uint32 {
-            range "1 .. 16";
-          }
           description "Output queue priority; higher is better";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 16";
+            }
+          }
         }
       }
       case case_2 {
         leaf expedited {
-          type empty;
           description "Expedited queue; highest priority";
+          type empty;
         }
       }
     }
@@ -4359,199 +5063,264 @@ module junos-conf-protocols {
   grouping bgp_filter_obj {
     description "Filter to apply to tracing";
     leaf match-on {
+      description "Argument on which to match";
       type enumeration {
         enum prefix {
           description "Filter based on prefix";
         }
       }
-      description "Argument on which to match";
     }
     leaf-list policy {
-      type "jt:policy-algebra";
-      description "Filter policy";
       ordered-by user;
+      description "Filter policy";
+      type "jt:policy-algebra";
     }
   }
   grouping bgpaf-accepted-prefix-limit {
     leaf maximum {
-      type uint32 {
-        range "1 .. 4294967295";
-      }
       description "Maximum number of prefixes accepted from a peer";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 4294967295";
+        }
+      }
     }
     container teardown {
-      description "Clear peer connection on reaching limit";
       presence "enable teardown";
+      description "Clear peer connection on reaching limit";
       leaf limit-threshold {
-        type uint32 {
-          range "1 .. 100";
-        }
         description "Percentage of prefix-limit to start warnings";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100";
+          }
+        }
       }
       container idle-timeout {
-        description "Timeout before attempting to restart peer";
         presence "enable idle-timeout";
+        description "Timeout before attempting to restart peer";
         choice idle-parm {
           case case_1 {
             leaf forever {
-              type empty;
               description "Idle the peer until the user intervenes";
+              type empty;
             }
           }
           case case_2 {
             leaf timeout {
-              type uint32 {
-                range "1 .. 2400";
-              }
               description "Timeout value, in minutes, for restarting peer";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 2400";
+                }
+              }
             }
           }
         }
       }
     }
     container drop-excess {
-      description "Drop routes from peer on reaching limit";
       presence "enable drop-excess";
+      description "Drop routes from peer on reaching limit";
       leaf limit-threshold {
-        type uint32 {
-          range "1 .. 100";
-        }
         description "Percentage of prefix-limit to start warnings";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100";
+          }
+        }
       }
     }
     container hide-excess {
-      description "Hide routes from peer on reaching limit";
       presence "enable hide-excess";
+      description "Hide routes from peer on reaching limit";
       leaf limit-threshold {
-        type uint32 {
-          range "1 .. 100";
-        }
         description "Percentage of prefix-limit to start warnings";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100";
+          }
+        }
       }
     }
   }
   grouping bgpaf-aigp-options {
     leaf disable {
-      type empty;
       description "Disable sending and receiving of AIGP attribute";
+      type empty;
     }
   }
   grouping bgpaf-loops {
     leaf loops {
-      type int32 {
-        range "1 .. 10";
-      }
       description "AS-Path loop count";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type int32 {
+          range "1 .. 10";
+        }
+      }
     }
   }
   grouping bgpaf-prefix-limit {
     leaf maximum {
-      type uint32 {
-        range "1 .. 4294967295";
-      }
       description "Maximum number of prefixes from a peer";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 4294967295";
+        }
+      }
     }
     container teardown {
-      description "Clear peer connection on reaching limit";
       presence "enable teardown";
+      description "Clear peer connection on reaching limit";
       leaf limit-threshold {
-        type uint32 {
-          range "1 .. 100";
-        }
         description "Percentage of prefix-limit to start warnings";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100";
+          }
+        }
       }
       container idle-timeout {
-        description "Timeout before attempting to restart peer";
         presence "enable idle-timeout";
+        description "Timeout before attempting to restart peer";
         choice idle-parm {
           case case_1 {
             leaf forever {
-              type empty;
               description "Idle the peer until the user intervenes";
+              type empty;
             }
           }
           case case_2 {
             leaf timeout {
-              type uint32 {
-                range "1 .. 2400";
-              }
               description "Timeout value, in minutes, for restarting peer";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 2400";
+                }
+              }
             }
           }
         }
       }
     }
     container drop-excess {
-      description "Drop routes from peer on reaching limit";
       presence "enable drop-excess";
+      description "Drop routes from peer on reaching limit";
       leaf limit-threshold {
-        type uint32 {
-          range "1 .. 100";
-        }
         description "Percentage of prefix-limit to start warnings";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100";
+          }
+        }
       }
     }
     container hide-excess {
-      description "Hide routes from peer on reaching limit";
       presence "enable hide-excess";
+      description "Hide routes from peer on reaching limit";
       leaf limit-threshold {
-        type uint32 {
-          range "1 .. 100";
-        }
         description "Percentage of prefix-limit to start warnings";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100";
+          }
+        }
       }
     }
   }
   grouping bgpaf-traffic-statistics {
     leaf labeled-path {
-      type empty;
       description "Ingress labeled path statistics";
+      type empty;
     }
     container file {
       description "Statistics file options";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf replace {
-        type empty;
         description "Replace trace file rather than appending to it";
         status deprecated;
+        type empty;
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "10";
         description "Maximum number of trace files";
+        default "10";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       leaf no-stamp {
-        type empty;
         description "Do not timestamp trace file";
         status deprecated;
+        type empty;
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
     }
     leaf interval {
-      type int32 {
-        range "60 .. 65535";
-      }
       description "Time to collect statistics (seconds)";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type int32 {
+          range "60 .. 65535";
+        }
+      }
     }
   }
   grouping juniper-protocols-bgpmcast {
@@ -4561,47 +5330,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum route {
@@ -4631,20 +5405,20 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
@@ -4653,44 +5427,51 @@ module junos-conf-protocols {
     container traceoptions {
       description "Trace options for Layer 2 address service";
       leaf no-remote-trace {
-        type empty;
         description "Disable remote tracing";
+        type empty;
       }
       container file {
         description "Trace file information";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "3";
           description "Maximum number of trace files";
+          default "3";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
         leaf match {
-          type "jt:regular-expression";
           description "Regular expression for lines to be logged";
+          type "jt:regular-expression";
         }
       }
       leaf level {
+        description "Level of debugging output";
+        default "error";
         type enumeration {
           enum error {
             description "Match error conditions";
@@ -4711,13 +5492,11 @@ module junos-conf-protocols {
             description "Match all levels";
           }
         }
-        default "error";
-        description "Level of debugging output";
       }
       list flag {
-        description "Type of operation or event to include in trace";
         key name;
         ordered-by user;
+        description "Type of operation or event to include in trace";
         leaf name {
           type enumeration {
             enum configuration {
@@ -4814,168 +5593,243 @@ module junos-conf-protocols {
         }
       }
       container kernel {
-        description "Trace options for kernel";
         presence "enable kernel";
+        description "Trace options for kernel";
         container irb {
-          description "Trace options for irb";
           presence "enable irb";
+          description "Trace options for irb";
         }
       }
       container in-memory-debug {
-        description "Enable trace parameters in the memory";
         presence "enable in-memory-debug";
+        description "Enable trace parameters in the memory";
       }
     }
     container global-mac-move {
-      description "Enable mac move related options at global level";
       presence "enable global-mac-move";
+      description "Enable mac move related options at global level";
       leaf notification-time {
-        type uint32;
         description "Periodical time interval in secs during which MAC move notification occurs";
         units seconds;
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf threshold-time {
-        type uint32;
         description "Time during which if certain number of MAC moves happen warrant recording";
         units seconds;
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf reopen-time {
-        type uint32;
         description "Time after which a blocked interface is reopened";
         units seconds;
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf threshold-count {
-        type uint32;
         description "Count of MAC moves which warrant recording when happen in certain time";
         units seconds;
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       container traceoptions {
         description "Enable logging for the MAC moves";
         leaf no-remote-trace {
-          type empty;
           description "Disable remote tracing";
+          type empty;
         }
         container file {
           description "Trace file information";
           leaf filename {
+            description "Name of file in which to write trace information";
             type string {
               length "1 .. 1024";
             }
-            description "Name of file in which to write trace information";
           }
           leaf size {
-            type string;
             description "Maximum trace file size";
+            type string;
           }
           leaf files {
-            type uint32 {
-              range "2 .. 1000";
-            }
-            default "3";
             description "Maximum number of trace files";
+            default "3";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 1000";
+              }
+            }
           }
           choice world-readable-choice {
             leaf world-readable {
-              type empty;
               description "Allow any user to read the log file";
+              type empty;
             }
             leaf no-world-readable {
-              type empty;
               description "Don't allow any user to read the log file";
+              type empty;
             }
           }
           leaf match {
-            type "jt:regular-expression";
             description "Regular expression for lines to be logged";
+            type "jt:regular-expression";
           }
         }
       }
       leaf log {
-        type empty;
         description "Syslog all the MAC moves as stored in the mac-move-buffer";
+        type empty;
       }
       leaf disable-action {
-        type empty;
         description "Disable mac move action globally";
+        type empty;
       }
       leaf cooloff-time {
-        type uint32;
         description "Time interval in secs during which no further actions are taken";
         units seconds;
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf statistical-approach-wait-time {
-        type uint32;
         description "Time during which MAC moves are monitored to collect statistics";
         units seconds;
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf interface-recovery-time {
-        type uint32;
         description "Time interval after which interface is made operationally up";
         units seconds;
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       list exclusive-mac {
-        description "MAC addresses to be excluded in mac-move-limit or in VPLS loop prevention algorithm";
         key name;
         ordered-by user;
+        description "MAC addresses to be excluded in mac-move-limit or in VPLS loop prevention algorithm";
         leaf name {
-          type "jt:mac-addr-prefix";
           description "Source MAC address";
+          type "jt:mac-addr-prefix";
         }
       }
     }
     leaf global-mac-table-aging-time {
-      type uint32;
       description "System level MAC table aging time";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32;
+      }
     }
     leaf global-mac-ip-table-aging-time {
-      type uint32 {
-        range "60 .. 1000000";
-      }
       description "System level MAC+IP table aging time";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "60 .. 1000000";
+        }
+      }
     }
     leaf global-le-aging-time {
-      type uint32 {
-        range "120 .. 1000000";
-      }
       description "Set LE aging time";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "120 .. 1000000";
+        }
+      }
     }
     leaf global-le-bridge-domain-aging-time {
-      type uint32 {
-        range "120 .. 1000000";
-      }
       description "Set LE bridge-domain aging time";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "120 .. 1000000";
+        }
+      }
     }
     leaf mclag-arpreq-sync {
-      type empty;
       description "Enable syncing ARP REQ packets to peer MCLAG PE";
+      type empty;
     }
     leaf global-mac-pinning-discard-notification-interval {
-      type uint32 {
-        range "2 .. 86400";
-      }
       description "Set interval for MAC Pinning discard notification";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "2 .. 86400";
+        }
+      }
     }
     container global-ctx-limit {
-      description "Debug context history limit";
       presence "enable global-ctx-limit";
+      description "Debug context history limit";
       leaf ctx-limit {
-        type uint32 {
-          range "0 .. 5000000";
-        }
         description "Debug context history limit";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 5000000";
+          }
+        }
       }
     }
     container global-mac-limit {
-      description "System level MAC limit options";
       presence "enable global-mac-limit";
+      description "System level MAC limit options";
       leaf mac-limit {
-        type uint64;
         description "System level MAC limit";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint64;
+        }
       }
       leaf packet-action {
         type enumeration {
@@ -4986,68 +5840,78 @@ module junos-conf-protocols {
       }
     }
     container global-mac-ip-limit {
-      description "System level MAC+IP limit options";
       presence "enable global-mac-ip-limit";
+      description "System level MAC+IP limit options";
       leaf mac-ip-limit {
-        type uint64 {
-          range "20 .. 1048575";
-        }
         description "System level MAC+IP limit";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint64 {
+            range "20 .. 1048575";
+          }
+        }
       }
     }
     leaf global-mac-statistics {
-      type empty;
       description "Enable MAC address statistics at system level";
+      type empty;
     }
     leaf global-static-mac-move-drop-log {
-      type empty;
       description "Set global static mac move drop and log notification.";
+      type empty;
     }
     leaf source-udp-port {
-      type uint16 {
-        range "49152 .. 65535";
-      }
       description "VXLAN source UDP port";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "49152 .. 65535";
+        }
+      }
     }
     container telemetry {
-      description "Streaming Telemetry Data";
       presence "enable telemetry";
+      description "Streaming Telemetry Data";
       leaf enable-remote-entries {
-        type empty;
         description "Enable Remote mac and mac-ip entries";
+        type empty;
       }
     }
     leaf global-no-mac-learning {
-      type empty;
       description "Disable dynamic MAC address learning at system level";
+      type empty;
     }
     leaf global-no-hw-mac-learning {
-      type empty;
       description "Disable hardware MAC-address learning at system level";
+      type empty;
     }
     leaf global-no-control-mac-aging {
-      type empty;
       description "Disable control MAC-address aging from software";
+      type empty;
     }
     leaf mclag-arp-nd-sync {
-      type empty;
       description "Arp and ND entry sync from peer device.";
+      type empty;
     }
     leaf no-mclag-ifa-sync {
-      type empty;
       description "IFA entry disable sync from/to peer device.";
+      type empty;
     }
     container platform-parameters {
-      description "Platform Parameters Setting";
       presence "enable platform-parameters";
+      description "Platform Parameters Setting";
       container no-mac-flush-on-aa-ae-down {
-        description "Do not flush MAC & MAC-IP entries when active-active AE interface goes down";
         presence "enable no-mac-flush-on-aa-ae-down";
+        description "Do not flush MAC & MAC-IP entries when active-active AE interface goes down";
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable no-mac-flush-on-aa-ae-down";
+              type empty;
             }
           }
         }
@@ -5060,30 +5924,30 @@ module junos-conf-protocols {
         container inet {
           description "Inet version 4 family";
           leaf mac-address {
-            type "jt:mac-unicast";
             description "Proxy MAC address";
+            type "jt:mac-unicast";
           }
         }
         container inet6 {
           description "Inet version 6 family";
           leaf mac-address {
-            type "jt:mac-unicast";
             description "Proxy MAC address";
+            type "jt:mac-unicast";
           }
         }
       }
     }
     leaf arp-nd-probe-disable {
-      type empty;
       description "Disable probing for ip address";
+      type empty;
     }
     leaf arp-nd-probe-failed-log {
-      type empty;
       description "Enable syslog when probing for ip address fails";
+      type empty;
     }
     leaf garp-na-enable {
-      type empty;
       description "Send GARP or unsolicited NA to all connected access devices";
+      type empty;
     }
   }
   grouping juniper-protocols-dot1x {
@@ -5092,47 +5956,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum dot1x-debug {
@@ -5183,106 +6052,123 @@ module junos-conf-protocols {
           }
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf ssl-certificate-path {
-      type string;
-      default "/var/tmp/";
       description "Load SSL certificates for authentication";
+      default "/var/tmp/";
+      type string;
     }
     container authenticator {
-      description "802.1X authenticator options";
       presence "enable authenticator";
+      description "802.1X authenticator options";
       leaf authentication-profile-name {
+        description "Access profile name to use for authentication";
         type string {
           length "1 .. 63";
         }
-        description "Access profile name to use for authentication";
       }
       leaf no-mac-table-binding {
-        type empty;
         description "Disable association between mac table and dot1x";
+        type empty;
       }
       leaf ip-mac-session-binding {
-        type empty;
         description "DHCP or DHCPv6 or SLAAC snooping checking for mac ageout";
+        type empty;
       }
       leaf dynamic-vlan-cleanup-interval {
-        type uint32 {
-          range "60 .. 86400";
-        }
         description "Dynamic vlan cleanup interval";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "60 .. 86400";
+          }
+        }
       }
       container radius-reachability {
-        description "Enable radius-rechability feature";
         presence "enable radius-reachability";
+        description "Enable radius-rechability feature";
         leaf query-period {
-          type uint32 {
-            range "20 .. 65535";
-          }
-          default "120";
           description "Query period interval";
+          default "120";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "20 .. 65535";
+            }
+          }
         }
       }
       container radius-options {
-        description "Info sent to radius server";
         presence "enable radius-options";
+        description "Info sent to radius server";
         leaf add-interface-text-description {
-          type empty;
           description "Appends interface text description to NAS-Port-Id";
+          type empty;
         }
         choice vlan {
           case case_1 {
             leaf use-vlan-name {
-              type empty;
               description "Vlan name";
+              type empty;
             }
           }
           case case_2 {
             leaf use-vlan-id {
-              type empty;
               description "Vlan id";
+              type empty;
             }
           }
         }
       }
       list static {
-        description "Static MAC configuration needed to bypass 802.1X";
         key name;
         ordered-by user;
+        description "Static MAC configuration needed to bypass 802.1X";
         leaf name {
-          type "jt:mac-addr-prefix";
           description "MAC addresses to bypass authentication";
+          type "jt:mac-addr-prefix";
         }
         leaf vlan-assignment {
-          type string;
           description "VLAN name or 802.1q tag for the MAC address";
+          type string;
         }
         leaf bridge-domain-assignment {
-          type string;
           description "Bridge-domain name or 802.1q tag for the MAC address";
+          type string;
         }
         leaf interface {
-          type "jt:interface-name";
           description "Interface on which authentication is bypassed";
+          type union {
+            type "jt:interface-name";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
       }
       list interface {
-        description "802.1X  interface specific options";
         key name;
+        description "802.1X  interface specific options";
         leaf name {
           type string;
         }
         leaf ignore-port-bounce {
-          type empty;
           description "To ignore the port-bounce request received from RADIUS server";
+          type empty;
         }
         leaf-list authentication-order {
+          ordered-by user;
+          description "Flexible authentication order";
           type enumeration {
             enum dot1x {
               description "Dot1x mode";
@@ -5294,14 +6180,14 @@ module junos-conf-protocols {
               description "Captive portal mode";
             }
           }
-          description "Flexible authentication order";
-          ordered-by user;
         }
         leaf disable {
-          type empty;
           description "Disable 802.1X on this interface";
+          type empty;
         }
         leaf supplicant {
+          description "Set supplicant mode for this interface";
+          default "single";
           type enumeration {
             enum single {
               description "Allow multiple clients; authenticate first client only";
@@ -5313,33 +6199,48 @@ module junos-conf-protocols {
               description "Allow multiple clients; authenticate each individually";
             }
           }
-          default "single";
-          description "Set supplicant mode for this interface";
         }
         leaf retries {
-          type uint32 {
-            range "0 .. 10";
-          }
           description "Number of retries after which port is placed into wait state";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 10";
+            }
+          }
         }
         leaf quiet-period {
-          type uint32 {
-            range "0 .. 65535";
-          }
           description "Time to wait after an authentication failure";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 65535";
+            }
+          }
         }
         leaf transmit-period {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Interval before retransmitting initial EAPOL PDUs";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         container multi-domain {
-          description "Enable multi domain authentication";
           presence "enable multi-domain";
+          description "Enable multi domain authentication";
           leaf packet-action {
+            description "Set packet action for this interface";
+            default "drop-and-log";
             type enumeration {
               enum drop-and-log {
                 description " Drop the client and generate the log message";
@@ -5348,56 +6249,64 @@ module junos-conf-protocols {
                 description "Disable port for excessive client authentication";
               }
             }
-            default "drop-and-log";
-            description "Set packet action for this interface";
           }
           leaf max-data-session {
-            type uint32 {
-              range "1 .. 1000";
-            }
             description "Data session limit in multi domain authentication";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 1000";
+              }
+            }
           }
           leaf recovery-timeout {
-            type uint32 {
-              range "60 .. 3600";
-            }
             description "Multi domain recovery timeout";
             units seconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "60 .. 3600";
+              }
+            }
           }
         }
         container mac-radius {
-          description "Enable MAC-RADIUS";
           presence "enable mac-radius";
+          description "Enable MAC-RADIUS";
           leaf restrict {
-            type empty;
             description "Bypass dot1x authentication, use MAC RADIUS only";
+            type empty;
           }
           leaf flap-on-disconnect {
-            type empty;
             description "Reset an interface on receiving a disconnect request";
+            type empty;
           }
           container authentication-protocol {
             description "Set mac-radius authentication method";
             choice protocols {
               case case_1 {
                 leaf eap-md5 {
-                  type empty;
                   description "Authentication protocol EAP-MD5";
+                  type empty;
                 }
               }
               case case_2 {
                 leaf pap {
-                  type empty;
                   description "Authentication protocol PAP";
+                  type empty;
                 }
               }
               case case_3 {
                 container eap-peap {
-                  description "Authentication protocol EAP-PEAP";
                   presence "enable eap-peap";
+                  description "Authentication protocol EAP-PEAP";
                   leaf resume {
-                    type empty;
                     description "Enable resume functionality for faster authentication";
+                    type empty;
                   }
                 }
               }
@@ -5407,165 +6316,220 @@ module junos-conf-protocols {
         choice reauthentication-mode {
           case case_1 {
             leaf no-reauthentication {
-              type empty;
               description "Disable reauthentication";
+              type empty;
             }
           }
           case case_2 {
             leaf reauthentication {
-              type uint32 {
-                range "1 .. 65535";
-              }
               description "Reauthentication interval";
               units seconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 65535";
+                }
+              }
             }
           }
         }
         leaf supplicant-timeout {
-          type uint32 {
-            range "1 .. 60";
-          }
           description "Time to wait for a client response";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 60";
+            }
+          }
         }
         leaf server-timeout {
-          type uint32 {
-            range "1 .. 60";
-          }
           description "Authentication server timeout interval";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 60";
+            }
+          }
         }
         leaf maximum-requests {
-          type uint32 {
-            range "1 .. 10";
-          }
           description "Number of EAPOL RequestIDs to send before timing out";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 10";
+            }
+          }
         }
         leaf request-retry-count {
-          type uint32 {
-            range "1 .. 10";
-          }
           description "Number of requests to send before timing out";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 10";
+            }
+          }
         }
         leaf guest-vlan {
-          type string;
           description "VLAN name or 802.1q tag for unauthenticated or non-responsive hosts";
+          type string;
         }
         leaf guest-gbp-tag {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "GBP tag for unauthenticated or non-responsive hosts";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf guest-bridge-domain {
-          type string;
           description "Bridge-domain name or 802.1q tag for unauthenticated or non-responsive hosts";
+          type string;
         }
         container server-reject-vlan {
           description "VLAN name or 802.1q tag for authentication rejected clients";
           leaf vlan-name {
-            type string;
             description "VLAN name or VLAN Tag (1..4095)";
+            type string;
           }
           leaf block-interval {
-            type uint32 {
-              range "120 .. 65535";
-            }
             description "Interval for authenticator to ignore the EAP-Start packets.";
             units seconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "120 .. 65535";
+              }
+            }
           }
           leaf eapol-block {
-            type empty;
             description "Force the authenticator to ignore EAPOL-Start packets.";
+            type empty;
           }
           leaf gbp-tag {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "GBP tag for authentication rejected clients";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
         }
         container server-reject-bridge-domain {
           description "VLAN name or 802.1q tag for authentication rejected clients";
           leaf bridge-domain {
-            type string;
             description "Bridge-domain name or VLAN Tag (1..4095)";
+            type string;
           }
           leaf block-interval {
-            type uint32 {
-              range "120 .. 65535";
-            }
             description "Interval for authenticator to ignore the EAP-Start packets.";
             units seconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "120 .. 65535";
+              }
+            }
           }
           leaf eapol-block {
-            type empty;
             description "Force the authenticator to ignore EAPOL-Start packets.";
+            type empty;
           }
         }
         container eapol-block {
           description "Force the authenticator to ignore EAPOL-Start packets";
           container server-fail {
-            description "Block EAPOL-Start during RADIUS Timeout";
             presence "enable server-fail";
+            description "Block EAPOL-Start during RADIUS Timeout";
             leaf block-interval {
-              type uint32 {
-                range "120 .. 65535";
-              }
               description "Interval for authenticator to ignore the EAP-Start packets.";
               units seconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "120 .. 65535";
+                }
+              }
             }
           }
           container mac-radius {
-            description "Block EAPOL-Start when client is authenticated in mac-radius mode";
             presence "enable mac-radius";
+            description "Block EAPOL-Start when client is authenticated in mac-radius mode";
           }
           container captive-portal {
-            description "Block EAPOL-Start when client is authenticated in captive-portal mode";
             presence "enable captive-portal";
+            description "Block EAPOL-Start when client is authenticated in captive-portal mode";
           }
         }
         leaf lldp-med-bypass {
-          type empty;
           description "Bypass dot1x authentication, use lldp-med based authentication";
+          type empty;
         }
         container server-fail {
           description "Action to be taken when server is inaccessible";
           leaf gbp-tag {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "GBP tag to be assigned when server is inaccessible";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           choice server-fail-options {
             case case_1 {
               leaf deny {
-                type empty;
                 description "Force client authentication to fail";
+                type empty;
               }
             }
             case case_2 {
               leaf permit {
-                type empty;
                 description "Force client authentication to succeed";
+                type empty;
               }
             }
             case case_3 {
               leaf vlan-name {
-                type string;
                 description "VLAN name or 802.1q tag for unreachable servers";
+                type string;
               }
             }
             case case_4 {
               leaf bridge-domain {
-                type string;
                 description "Bridge-domain name or 802.1q tag for unreachable servers";
+                type string;
               }
             }
             case case_5 {
               leaf use-cache {
-                type empty;
                 description "Use the previous state of the client";
+                type empty;
               }
             }
           }
@@ -5575,88 +6539,88 @@ module junos-conf-protocols {
           choice server-fail-options {
             case case_1 {
               leaf deny {
-                type empty;
                 description "Force VoIP client authentication to fail";
+                type empty;
               }
             }
             case case_2 {
               leaf permit {
-                type empty;
                 description "Force VoIP client authentication to succeed";
+                type empty;
               }
             }
             case case_3 {
               leaf vlan-name {
-                type string;
                 description "Configured VoIP VLAN name or 802.1q tag for unreachable servers";
+                type string;
               }
             }
             case case_4 {
               leaf use-cache {
-                type empty;
                 description "Use the previous state of the VoIP client";
+                type empty;
               }
             }
           }
         }
         leaf redirect-url {
+          description "CWA redirect URL to be used for unauthenticated users";
           type string {
             length "10 .. 247";
           }
-          description "CWA redirect URL to be used for unauthenticated users";
         }
         leaf no-tagged-mac-authentication {
-          type empty;
           description "Don't allow tagged mac for radius authentication";
+          type empty;
         }
         leaf retain-mac-aged-session {
-          type empty;
           description "Retain mac aged out session";
+          type empty;
         }
       }
       container mac-radius {
-        description "User-defined options for mac-radius mode";
         presence "enable mac-radius";
+        description "User-defined options for mac-radius mode";
         leaf password {
+          description "Specify the user-defined password to be used for mac authentication";
           type string {
             length "1 .. 128";
           }
-          description "Specify the user-defined password to be used for mac authentication";
         }
       }
     }
     container supplicant {
       description "802.1X supplicant options";
       list interface {
-        description "802.1X supplicant interface specific options";
         key name;
+        description "802.1X supplicant interface specific options";
         leaf name {
           type string;
         }
         leaf authentication-method {
+          description "802.1X supplicant authentication protocol for this interface";
+          default "eap-tls";
           type enumeration {
             enum eap-tls {
               description "Supplicant authentication protocol EAP-TLS";
             }
           }
-          default "eap-tls";
-          description "802.1X supplicant authentication protocol for this interface";
         }
         leaf local-certificate {
-          type string;
           description "Local certificate identifier to be presented for authentication";
+          type string;
         }
         leaf user-id {
+          description "User id, to be presented for authentication";
           type string {
             length "1 .. 63";
           }
-          description "User id, to be presented for authentication";
         }
         leaf password {
+          description "Password, to be presented for authentication";
           type string {
             length "1 .. 63";
           }
-          description "Password, to be presented for authentication";
         }
       }
     }
@@ -5665,8 +6629,8 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable ES-IS";
+          type empty;
         }
       }
     }
@@ -5675,47 +6639,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum error {
@@ -5757,71 +6726,96 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf preference {
-      type uint32;
       description "Preference of routes";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     container graceful-restart {
       description "ES-IS graceful restart options";
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable graceful restart";
+            type empty;
           }
         }
       }
       leaf restart-duration {
-        type uint32 {
-          range "30 .. 300";
-        }
         description "Maximum time for graceful restart to finish";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "30 .. 300";
+          }
+        }
       }
     }
     list interface {
-      description "Interface configuration";
       key name;
+      description "Interface configuration";
       leaf name {
-        type "jt:interface-name";
         description "Interface name";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf hold-time {
-        type uint32 {
-          range "1 .. 65535";
-        }
         description "Time after which neighbors think the interface is down";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 65535";
+          }
+        }
       }
       leaf end-system-configuration-timer {
-        type uint32 {
-          range "1 .. 65535";
-        }
         description "Suggested end system configuration timer";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 65535";
+          }
+        }
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable ES-IS on this interface";
+            type empty;
           }
         }
       }
@@ -5830,72 +6824,77 @@ module junos-conf-protocols {
   grouping juniper-protocols-evpn-interconnect {
     description "Interconnect configuration for the routing instance";
     leaf-list vrf-import {
-      type "jt:policy-algebra";
-      description "Import policy for Interconnect";
       ordered-by user;
+      description "Import policy for Interconnect";
+      type "jt:policy-algebra";
     }
     leaf-list vrf-export {
-      type "jt:policy-algebra";
-      description "Export policy for Interconnect";
       ordered-by user;
+      description "Export policy for Interconnect";
+      type "jt:policy-algebra";
     }
     container vrf-target {
       description "Interconnect target community configuration";
       leaf community {
-        type string;
         description "Target community to use in import and export";
+        type string;
       }
       leaf import {
-        type string;
         description "Target community to use when filtering on import";
+        type string;
       }
       leaf export {
-        type string;
         description "Target community to use when marking routes on export";
+        type string;
       }
     }
     container route-distinguisher {
       description "Route distinguisher for this interconnect";
       leaf rd-type {
-        type string;
         description "Number in (16 bit:32 bit) or (32 bit 'L':16 bit) or (IP address:16 bit) format";
+        type string;
       }
     }
     list domain-path-id {
-      description "DCI VRF domain path id configuration";
       key name;
-      max-elements 1;
       ordered-by user;
+      description "DCI VRF domain path id configuration";
+      max-elements 1;
       uses domain-id-type;
     }
     container esi {
       description "ESI configuration of interconnect";
       leaf identifier {
-        type "jt:esi";
         description "ESI value for interconnect";
+        type "jt:esi";
       }
       choice mode {
         case case_1 {
           leaf all-active {
-            type empty;
             description "All-active mode";
+            type empty;
           }
         }
       }
       container df-election-type {
-        description "DF Election Type";
         presence "enable df-election-type";
+        description "DF Election Type";
         choice pref_choice {
           case case_1 {
             container preference {
-              description "Preference based DF election";
               presence "enable preference";
+              description "Preference based DF election";
               leaf value {
-                type uint32 {
-                  range "0 .. 65535";
-                }
-                default "32767";
                 description "Preference value for EVPN Multihoming DF election";
+                default "32767";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 65535";
+                  }
+                }
               }
             }
           }
@@ -5903,29 +6902,34 @@ module junos-conf-protocols {
         choice mod_choice {
           case case_1 {
             container mod {
-              description "MOD based DF election";
               presence "enable mod";
+              description "MOD based DF election";
             }
           }
         }
       }
     }
     leaf-list interconnected-vni-list {
-      type string;
       description "List of translated VNIs (1..16777214) or all, that are to be EVPN interconnected";
+      type string;
     }
     leaf-list interconnected-vlan-list {
-      type string;
-      description "List of VLAN identifiers that are to be EVPN interconnected";
       ordered-by user;
+      description "List of VLAN identifiers that are to be EVPN interconnected";
+      type string;
     }
     container irb-symmetric-routing {
       description "Enable EVPN T-2 symmetric DCI routing";
       leaf vni {
-        type uint32 {
-          range "1 .. 16777214";
-        }
         description "VXLAN network identifier used for T-2 symmetric routing IP prefixes";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 16777214";
+          }
+        }
       }
     }
     leaf encapsulation {
@@ -5941,17 +6945,22 @@ module junos-conf-protocols {
   }
   grouping domain-id-type {
     leaf name {
-      type string;
       description "Domain id for type 5 evpn DCI";
+      type string;
     }
   }
   grouping juniper-protocols-isis {
     list interface {
-      description "Interface configuration";
       key name;
+      description "Interface configuration";
       leaf name {
-        type "jt:interface-name";
         description "Interface name";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       container ldp-synchronization {
         description "Advertise maximum metric until LDP is operational";
@@ -5959,58 +6968,73 @@ module junos-conf-protocols {
         uses ldp-sync-obj;
       }
       list level {
-        description "Configure levels on this interface";
         key name;
         ordered-by user;
+        description "Configure levels on this interface";
         leaf name {
-          type uint32 {
-            range "1 .. 2";
-          }
           description "IS-IS level number";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 2";
+            }
+          }
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable IS-IS for this level";
+              type empty;
             }
           }
         }
         leaf metric {
-          type uint32 {
-            range "0 .. 16777215";
-          }
           description "Metric for this level";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 16777215";
+            }
+          }
         }
       }
       leaf lsp-interval {
-        type uint32 {
-          range "1 .. 1000";
-        }
-        default "100";
         description "Interval between LSP transmissions";
+        default "100";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 1000";
+          }
+        }
       }
       leaf point-to-point {
-        type empty;
         description "Treat interface as point to point";
+        type empty;
       }
       container passive {
-        description "Do not run IS-IS, but advertise it";
         presence "enable passive";
+        description "Do not run IS-IS, but advertise it";
         leaf remote-node-iso {
-          type "jt:sysid";
           description "ISO System-ID of the remote node";
+          type "jt:sysid";
         }
         leaf remote-node-id {
-          type "jt:ipv4addr";
           description "Remote address of the link";
+          type "jt:ipv4addr";
         }
       }
       list family {
-        description "Address family specific interface attributes";
         key name;
         ordered-by user;
+        description "Address family specific interface attributes";
         leaf name {
           type enumeration {
             enum inet {
@@ -6024,6 +7048,8 @@ module junos-conf-protocols {
         container bfd-liveness-detection {
           description "Bidirectional Forwarding Detection options";
           leaf version {
+            description "BFD protocol version number";
+            default "automatic";
             type enumeration {
               enum 0 {
                 description "BFD version 0 (deprecated)";
@@ -6035,87 +7061,126 @@ module junos-conf-protocols {
                 description "Choose BFD version automatically";
               }
             }
-            default "automatic";
-            description "BFD protocol version number";
           }
           leaf minimum-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit and receive interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf minimum-transmit-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit interval";
             status deprecated;
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf minimum-receive-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum receive interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf multiplier {
-            type uint32 {
-              range "1 .. 255";
-            }
-            default "3";
             description "Detection time multiplier";
+            default "3";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf inline-disable {
-            type empty;
             description "Disable inline mode for this BFD session";
+            type empty;
           }
           leaf pdu-size {
-            type uint32 {
-              range "24 .. 9000";
-            }
-            default "24";
             description "BFD transport protocol payload size";
+            default "24";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "24 .. 9000";
+              }
+            }
           }
           choice adaptation-choice {
             case case_1 {
               leaf no-adaptation {
-                type empty;
                 description "Disable adaptation";
+                type empty;
               }
             }
           }
           container transmit-interval {
             description "Transmit-interval options";
             leaf minimum-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf threshold {
-              type uint32;
               description "High transmit interval triggering a trap";
               units milliseconds;
+              type union {
+                type uint32;
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
           }
           container detection-time {
             description "Detection-time options";
             leaf threshold {
-              type uint32;
               description "High detection-time triggering a trap";
               units milliseconds;
+              type union {
+                type uint32;
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
           }
           container authentication {
             description "Authentication options";
             leaf key-chain {
-              type string;
               description "Key chain name";
+              type string;
             }
             leaf algorithm {
+              description "Algorithm name";
               type enumeration {
                 enum simple-password {
                   description "Simple password";
@@ -6133,151 +7198,200 @@ module junos-conf-protocols {
                   description "Meticulous keyed secure hash algorithm (SHA1) ";
                 }
               }
-              description "Algorithm name";
             }
             leaf loose-check {
-              type empty;
               description "Verify authentication only if authentication is negotiated";
+              type empty;
             }
           }
           container echo {
             description "Echo mode parameters";
             leaf minimum-interval {
-              type uint32 {
-                range "100 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "100 .. 255000";
+                }
+              }
             }
           }
           container echo-lite {
             description "Echo-lite more parameters";
             leaf minimum-interval {
-              type uint32 {
-                range "100 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "100 .. 255000";
+                }
+              }
             }
           }
           leaf holddown-interval {
-            type uint32 {
-              range "0 .. 255000";
-            }
             description "Time to hold the session-UP notification to the client";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 255000";
+              }
+            }
           }
         }
       }
     }
     container source-packet-routing {
-      description "Enable Source Packet Routing (SPRING)";
       presence "enable source-packet-routing";
+      description "Enable Source Packet Routing (SPRING)";
       container adjacency-segment {
         description "Configure attributes for Adjacency Segments in SPRING";
         leaf hold-time {
-          type uint32 {
-            range "180000 .. 900000";
-          }
           description "Duration(ms) for which adjacency segments will be retained after isolating from an interface";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "180000 .. 900000";
+            }
+          }
         }
       }
       container udp-tunneling {
         description "Enable SR over UDP feature";
         leaf encapsulation {
-          type empty;
           description "Enable UDP Tunnel Encapsulation";
+          type empty;
         }
         leaf decapsulation {
-          type empty;
           description "Enable UDP Tunnel decapsulation";
+          type empty;
         }
       }
       container srgb {
         description "Set the SRGB global block in SPRING";
         leaf start-label {
-          type uint32;
           description "Start range for SRGB label block";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32;
+          }
         }
         leaf index-range {
-          type uint32;
           description "Index to the SRGB start label block";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32;
+          }
         }
       }
       container node-segment {
         description "Enable support for Node segments in SPRING";
         leaf ipv4-index {
-          type uint32 {
-            range "0 .. 199999";
-          }
           description "Set IPv4 Node Segment index";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 199999";
+            }
+          }
         }
         leaf ipv6-index {
-          type uint32 {
-            range "0 .. 199999";
-          }
           description "Set IPv6 Node Segment index";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 199999";
+            }
+          }
         }
         leaf index-range {
-          type uint32 {
-            range "32 .. 16385";
-          }
           description "Set Range of Node Segment indices allowed";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "32 .. 16385";
+            }
+          }
         }
       }
       leaf-list flex-algorithm {
-        type uint32 {
-          range "128 .. 255";
-        }
         description "Flex-algorithms we would like to participate in";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "128 .. 255";
+          }
+        }
         max-elements 16;
       }
       leaf use-flex-algorithm-metric-always {
-        type empty;
         description "Use flex-algo prefix metric whenever available";
+        type empty;
       }
       leaf strict-asla-based-flex-algorithm {
-        type empty;
         description "Flex-Algorithm to ignore links not having ASLA sub-TLVs";
+        type empty;
       }
       leaf new-capability-subtlv {
-        type empty;
         description "Advertise all ranges in single spring capability subtlv";
+        type empty;
       }
       leaf explicit-null {
-        type empty;
         description "Set E and P bits in all Prefix SID advertisements";
+        type empty;
       }
       leaf mapping-server {
-        type string;
         description "Mapping server name";
+        type string;
       }
       leaf no-strict-spf {
-        type empty;
         description " Disable strict spf algo 1 advertisement";
+        type empty;
       }
       leaf no-binding-sid-leaking {
-        type empty;
         description " Disable SRMS binding sid leaking";
+        type empty;
       }
       leaf ldp-stitching {
-        type empty;
         description "Enable SR to LDP stitching";
+        type empty;
       }
       container srv6 {
-        description "Enable IPv6 Segment Routing (SRv6)";
         presence "enable srv6";
+        description "Enable IPv6 Segment Routing (SRv6)";
         list locator {
-          description "SRv6 Locator";
           key name;
           ordered-by user;
+          description "SRv6 Locator";
           leaf name {
-            type string;
             description "Locator name";
+            type string;
           }
           leaf anycast {
-            type empty;
             description "Set A flag in the Prefix-Attribute sub-TLV";
+            type empty;
           }
           list end-sid {
             key name;
@@ -6286,45 +7400,45 @@ module junos-conf-protocols {
               type "jt:ipv6addr";
             }
             container flavor {
-              description "Configure end-SID flavor";
               presence "enable flavor";
+              description "Configure end-SID flavor";
               leaf psp {
-                type empty;
                 description "Penultimate segment pop of the SRH";
+                type empty;
               }
               leaf usp {
-                type empty;
                 description "Ultimate segment pop of the SRH";
+                type empty;
               }
               leaf usd {
-                type empty;
                 description "Ultimate segment decapsulation";
+                type empty;
               }
             }
           }
           container dynamic-end-sid {
-            description "Allocate end SID dynamically";
             presence "enable dynamic-end-sid";
+            description "Allocate end SID dynamically";
             container flavor {
-              description "Configure end-SID flavor";
               presence "enable flavor";
+              description "Configure end-SID flavor";
               leaf psp {
-                type empty;
                 description "Penultimate segment pop of the SRH";
+                type empty;
               }
               leaf usp {
-                type empty;
                 description "Ultimate segment pop of the SRH";
+                type empty;
               }
               leaf usd {
-                type empty;
                 description "Ultimate segment decapsulation";
+                type empty;
               }
             }
           }
           leaf micro-node-sid {
-            type empty;
             description "Program and advertise micro-node-SID";
+            type empty;
           }
         }
       }
@@ -6333,33 +7447,38 @@ module junos-conf-protocols {
         container per-interface-per-member-link {
           description "Configure sensor based stats per nexthop";
           leaf ingress {
-            type empty;
             description "Enable sensor based stats on ingress interface";
+            type empty;
           }
           leaf egress {
-            type empty;
             description "Enable sensor based stats on egress interface";
+            type empty;
           }
         }
         container per-sid {
           description "Configure sensor based stats per spring route";
           leaf ingress {
-            type empty;
             description "Enable sensor based stats for per-sid ingress accounting";
+            type empty;
           }
           leaf egress {
-            type empty;
             description "Enable sensor based stats for IP-MPLS egress accounting";
+            type empty;
           }
         }
         container subscribe {
-          description "Enable on-box sensor-based statistics collection";
           presence "enable subscribe";
+          description "Enable on-box sensor-based statistics collection";
           leaf interval {
-            type uint32 {
-              range "30 .. 86400";
-            }
             description "Statistics collection interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "30 .. 86400";
+              }
+            }
           }
         }
       }
@@ -6368,43 +7487,49 @@ module junos-conf-protocols {
         container statistics-granularity {
           description "Granularity for traffic statistics in SPRING";
           leaf per-interface {
-            type empty;
             description "Interface Based traffic statistics in SPRING";
+            type empty;
           }
         }
         leaf congestion-protection {
-          type empty;
           description "Enable tactical traffic engineering";
+          type empty;
         }
         leaf auto-bandwidth {
-          type string;
           description "Auto bandwidth name";
+          type string;
         }
       }
     }
     list level {
-      description "Configure global level attributes";
       key name;
       ordered-by user;
+      description "Configure global level attributes";
       leaf name {
-        type uint32 {
-          range "1 .. 2";
-        }
         description "IS-IS level number";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 2";
+          }
+        }
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable IS-IS on this level";
+            type empty;
           }
         }
       }
       leaf authentication-key {
-        type "jt:unreadable";
         description "Authentication key (password)";
+        type "jt:unreadable";
       }
       leaf authentication-type {
+        description "Authentication type";
         type enumeration {
           enum md5 {
             description "MD5 authentication";
@@ -6413,31 +7538,35 @@ module junos-conf-protocols {
             description "Simple password authentication";
           }
         }
-        description "Authentication type";
       }
       leaf no-hello-authentication {
-        type empty;
         description "Disable authentication for hello packets";
+        type empty;
       }
       leaf no-csnp-authentication {
-        type empty;
         description "Disable authentication for CSN packets";
+        type empty;
       }
       leaf no-psnp-authentication {
-        type empty;
         description "Disable authentication for PSN packets";
+        type empty;
       }
       leaf wide-metrics-only {
-        type empty;
         description "Generate wide metrics only";
+        type empty;
       }
     }
     leaf lsp-lifetime {
-      type uint32 {
-        range "350 .. 65535";
-      }
       description "Lifetime of LSPs";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "350 .. 65535";
+        }
+      }
     }
   }
   grouping juniper-protocols-l2control {
@@ -6446,47 +7575,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum parse {
@@ -6522,37 +7656,37 @@ module junos-conf-protocols {
           }
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf nonstop-bridging {
-      type empty;
       description "Enable nonstop operation";
+      type empty;
     }
     container options {
       description "Layer2 control options";
       container nsb-extended-timers {
-        description "Extend expiration of timers during switchover";
         presence "enable nsb-extended-timers";
+        description "Extend expiration of timers during switchover";
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable timer extension during switchover";
+              type empty;
             }
           }
         }
       }
       container nsb-optimized-config-read {
-        description "Optimize config re-prasing during switchover";
         presence "enable nsb-optimized-config-read";
+        description "Optimize config re-prasing during switchover";
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable optimized re-parsing of config during switchover";
+              type empty;
             }
           }
         }
@@ -6560,39 +7694,44 @@ module junos-conf-protocols {
     }
     choice ephemeral-db-support-choice {
       leaf ephemeral-db-support {
-        type empty;
         description "Enable ephemeral DB supoort for STP";
+        type empty;
       }
       leaf no-ephemeral-db-support {
-        type empty;
         description "Don't enable ephemeral DB supoort for STP";
+        type empty;
       }
     }
     container bpdu-block {
-      description "Block BPDU on interface (BPDU Protect)";
       presence "enable bpdu-block";
+      description "Block BPDU on interface (BPDU Protect)";
       list interface {
-        description "Interface name to block BPDU on";
         key name;
         ordered-by user;
+        description "Interface name to block BPDU on";
         leaf name {
           type string;
         }
         leaf disable {
-          type empty;
           description "Disable bpdu-block on a port";
+          type empty;
         }
         leaf drop {
-          type empty;
           description "Drop xSTP BPDUs";
+          type empty;
         }
       }
       leaf disable-timeout {
-        type int32 {
-          range "10 .. 3600";
-        }
         description "Disable timeout for BPDU Protect";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "10 .. 3600";
+          }
+        }
       }
     }
     container l2pt {
@@ -6601,80 +7740,85 @@ module junos-conf-protocols {
         key name;
         ordered-by user;
         leaf name {
-          type "jt:interface-device";
+          type union {
+            type "jt:interface-device";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         leaf enable-all-ifl {
-          type empty;
           description "Enable tunneling for all the IFLs under the interface";
+          type empty;
         }
         container protocol {
           description "Protocols for which L2 protocol tunneling need to be enabled";
           container stp {
-            description "Enable L2 protocol tunneling for STP";
             presence "enable stp";
+            description "Enable L2 protocol tunneling for STP";
           }
           container vtp {
-            description "Enable L2 protocol tunneling for VTP";
             presence "enable vtp";
+            description "Enable L2 protocol tunneling for VTP";
           }
           container cdp {
-            description "Enable L2 protocol tunneling for CDP";
             presence "enable cdp";
+            description "Enable L2 protocol tunneling for CDP";
           }
           container ieee8021x {
-            description "Enable L2 protocol tunneling for 8021X";
             presence "enable ieee8021x";
+            description "Enable L2 protocol tunneling for 8021X";
           }
           container ieee8023ah {
-            description "Enable L2 protocol tunneling for 8023AH";
             presence "enable ieee8023ah";
+            description "Enable L2 protocol tunneling for 8023AH";
           }
           container elmi {
-            description "Enable L2 protocol tunneling for ELMI";
             presence "enable elmi";
+            description "Enable L2 protocol tunneling for ELMI";
           }
           container lacp {
-            description "Enable L2 protocol tunneling for LACP";
             presence "enable lacp";
+            description "Enable L2 protocol tunneling for LACP";
           }
           container lldp {
-            description "Enable L2 protocol tunneling for LLDP";
             presence "enable lldp";
+            description "Enable L2 protocol tunneling for LLDP";
           }
           container mmrp {
-            description "Enable L2 protocol tunneling for MMRP";
             presence "enable mmrp";
+            description "Enable L2 protocol tunneling for MMRP";
           }
           container mvrp {
-            description "Enable L2 protocol tunneling for MVRP";
             presence "enable mvrp";
+            description "Enable L2 protocol tunneling for MVRP";
           }
           container pvstp {
-            description "Enable L2 protocol tunneling for PVSTP+";
             presence "enable pvstp";
+            description "Enable L2 protocol tunneling for PVSTP+";
           }
           container gvrp {
-            description "Enable L2 protocol tunneling for GVRP";
             presence "enable gvrp";
+            description "Enable L2 protocol tunneling for GVRP";
           }
           container vstp {
-            description "Enable L2 protocol tunneling for VSTP";
             presence "enable vstp";
+            description "Enable L2 protocol tunneling for VSTP";
           }
           container udld {
-            description "Enable L2 protocol tunneling for UDLD";
             presence "enable udld";
+            description "Enable L2 protocol tunneling for UDLD";
           }
           container all {
-            description "Enable L2 protocol tunneling for all protocols";
             presence "enable all";
+            description "Enable L2 protocol tunneling for all protocols";
           }
         }
         container destination {
           description "Destination tunnel for which L2 protocol tunneling need to be enabled";
           leaf vxlan-tunnel {
-            type empty;
             description "Enable L2 protocol tunneling in vxlan-tunnel";
+            type empty;
           }
         }
       }
@@ -6685,82 +7829,87 @@ module junos-conf-protocols {
         key name;
         ordered-by user;
         leaf name {
-          type "jt:interface-device";
+          type union {
+            type "jt:interface-device";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         leaf enable-all-ifl {
-          type empty;
           description "Enable tunneling for all the IFLs under the interface";
+          type empty;
         }
         container protocol {
           description "Protocols for which L2 protocol tunneling need to be enabled";
           container stp {
-            description "Enable L2 protocol tunneling for STP";
             presence "enable stp";
+            description "Enable L2 protocol tunneling for STP";
           }
           container vtp {
-            description "Enable L2 protocol tunneling for VTP";
             presence "enable vtp";
+            description "Enable L2 protocol tunneling for VTP";
           }
           container cdp {
-            description "Enable L2 protocol tunneling for CDP";
             presence "enable cdp";
+            description "Enable L2 protocol tunneling for CDP";
           }
           container ieee8021x {
-            description "Enable L2 protocol tunneling for 8021X";
             presence "enable ieee8021x";
+            description "Enable L2 protocol tunneling for 8021X";
           }
           container ieee8023ah {
-            description "Enable L2 protocol tunneling for 8023AH";
             presence "enable ieee8023ah";
+            description "Enable L2 protocol tunneling for 8023AH";
           }
           container elmi {
-            description "Enable L2 protocol tunneling for ELMI";
             presence "enable elmi";
+            description "Enable L2 protocol tunneling for ELMI";
           }
           container lacp {
-            description "Enable L2 protocol tunneling for LACP";
             presence "enable lacp";
+            description "Enable L2 protocol tunneling for LACP";
           }
           container lldp {
-            description "Enable L2 protocol tunneling for LLDP";
             presence "enable lldp";
+            description "Enable L2 protocol tunneling for LLDP";
           }
           container mmrp {
-            description "Enable L2 protocol tunneling for MMRP";
             presence "enable mmrp";
+            description "Enable L2 protocol tunneling for MMRP";
           }
           container mvrp {
-            description "Enable L2 protocol tunneling for MVRP";
             presence "enable mvrp";
+            description "Enable L2 protocol tunneling for MVRP";
           }
           container pvstp {
-            description "Enable L2 protocol tunneling for PVSTP+";
             presence "enable pvstp";
+            description "Enable L2 protocol tunneling for PVSTP+";
           }
           container gvrp {
-            description "Enable L2 protocol tunneling for GVRP";
             presence "enable gvrp";
+            description "Enable L2 protocol tunneling for GVRP";
           }
           container vstp {
-            description "Enable L2 protocol tunneling for VSTP";
             presence "enable vstp";
+            description "Enable L2 protocol tunneling for VSTP";
           }
           container udld {
-            description "Enable L2 protocol tunneling for UDLD";
             presence "enable udld";
+            description "Enable L2 protocol tunneling for UDLD";
           }
           container all {
-            description "Enable L2 protocol tunneling for all protocols";
             presence "enable all";
+            description "Enable L2 protocol tunneling for all protocols";
           }
         }
       }
       container tunnel-destination-mac {
-        description "Tunnel destination mac to be used in L2PT packets";
         presence "enable tunnel-destination-mac";
+        description "Tunnel destination mac to be used in L2PT packets";
         leaf source {
-          type "jt:mac-multicast";
           description "L2 multicast mac to be used as tunnel destination mac";
+          type "jt:mac-multicast";
         }
       }
     }
@@ -6771,126 +7920,156 @@ module junos-conf-protocols {
       container file {
         description "Statistics file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       leaf interval {
-        type int32 {
-          range "60 .. 65535";
-        }
         description "Time to collect statistics (seconds)";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "60 .. 65535";
+          }
+        }
       }
       leaf sensor-based-stats {
-        type empty;
         description "Enable sensor based statistics collection";
+        type empty;
       }
       leaf no-penultimate-hop {
-        type empty;
         description "No penultimate hop statistics collection";
+        type empty;
       }
     }
     leaf preference {
-      type uint32;
       description "Route preference";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     container transport-address {
       description "Address used for TCP sessions";
       choice address-choice {
         case case_1 {
           leaf router-id {
-            type empty;
             description "Use router ID for TCP connections";
+            type empty;
           }
         }
         case case_2 {
           leaf interface {
-            type empty;
             description "Use interface address for TCP connections";
+            type empty;
           }
         }
         case case_3 {
           leaf address {
-            type "jt:ipaddr";
             description "Use specified address for TCP connections";
+            type "jt:ipaddr";
           }
         }
       }
     }
     list interface {
-      description "Enable LDP on this interface";
       key name;
+      description "Enable LDP on this interface";
       leaf name {
-        type "jt:interface-name";
         description "Interface name";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable LDP on this interface";
+            type empty;
           }
         }
       }
       leaf hello-interval {
-        type uint32 {
-          range "1 .. 65535";
-        }
         description "Hello interval (seconds)";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 65535";
+          }
+        }
       }
       leaf hold-time {
-        type uint32 {
-          range "1 .. 65535";
-        }
         description "Hello hold time (seconds)";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 65535";
+          }
+        }
       }
       container link-protection {
-        description "Enable link protection to protect interface for link faults only";
         presence "enable link-protection";
+        description "Enable link protection to protect interface for link faults only";
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable link-protection";
+              type empty;
             }
           }
         }
         leaf dynamic-rsvp-lsp {
-          type empty;
           description "Enable setup of dynamic rsvp lsp for link protection";
+          type empty;
         }
       }
       container transport-address {
@@ -6898,111 +8077,131 @@ module junos-conf-protocols {
         choice address-choice {
           case case_1 {
             leaf router-id {
-              type empty;
               description "Use router ID for TCP connections";
+              type empty;
             }
           }
           case case_2 {
             leaf interface {
-              type empty;
               description "Use interface address for TCP connections";
+              type empty;
             }
           }
           case case_3 {
             leaf address {
-              type "jt:ipaddr";
               description "Use specified address for TCP connections";
+              type "jt:ipaddr";
             }
           }
         }
       }
       choice allow-subnet-mismatch-choice {
         leaf allow-subnet-mismatch {
-          type empty;
           description "Allow subnet mismatch for source address in hello packet";
+          type empty;
         }
         leaf no-allow-subnet-mismatch {
-          type empty;
           description "Don't allow subnet mismatch for source address in hello packet";
+          type empty;
         }
       }
     }
   }
   grouping juniper-protocols-lmp {
     list te-link {
-      description "Traffic engineering link";
       key name;
       ordered-by user;
+      description "Traffic engineering link";
       leaf name {
-        type string;
         description "Name of TE link";
+        type string;
       }
       leaf local-address {
-        type "jt:ipaddr";
         description "Address of the local end of the link";
+        type "jt:ipaddr";
       }
       leaf remote-address {
-        type "jt:ipaddr";
         description "Address of the remote end of the link";
+        type "jt:ipaddr";
       }
       leaf remote-id {
-        type uint32 {
-          range "1 .. 4294967295";
-        }
         description "Link ID for the remote end of the link";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 4294967295";
+          }
+        }
       }
       leaf te-metric {
-        type uint32 {
-          range "1 .. 65535";
-        }
         description "Traffic engineering metric of the link";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 65535";
+          }
+        }
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable TE link";
+            type empty;
           }
         }
       }
       container ethernet-vlan {
-        description "TE link used for setup of  L2 VLAN LSP";
         presence "enable ethernet-vlan";
+        description "TE link used for setup of  L2 VLAN LSP";
         leaf-list vlan-id-range {
-          type "jt:vlan-range";
           description "VLAN id";
+          type "jt:vlan-range";
           max-elements 1;
         }
       }
       choice resource-option {
         case case_1 {
           list interface {
-            description "Member interface of TE link";
             key name;
             ordered-by user;
+            description "Member interface of TE link";
             leaf name {
-              type "jt:interface-device";
               description "Interface name";
+              type union {
+                type "jt:interface-device";
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
             leaf local-address {
-              type "jt:ipaddr";
               description "Local address of the resource";
+              type "jt:ipaddr";
             }
             leaf remote-address {
-              type "jt:ipaddr";
               description "Remote address of the resource";
+              type "jt:ipaddr";
             }
             leaf remote-id {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Interface ID for the remote end of the resource";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
             choice enable-disable {
               case case_1 {
                 leaf disable {
-                  type empty;
                   description "Disable resource on this TE link";
+                  type empty;
                 }
               }
             }
@@ -7010,33 +8209,38 @@ module junos-conf-protocols {
         }
         case case_2 {
           list label-switched-path {
-            description "Member forwarding adjacency LSP of TE link";
             key name;
-            max-elements 1;
             ordered-by user;
+            description "Member forwarding adjacency LSP of TE link";
+            max-elements 1;
             leaf name {
-              type string;
               description "Name of label-switched path";
+              type string;
             }
             leaf local-address {
-              type "jt:ipaddr";
               description "Local address of the resource";
+              type "jt:ipaddr";
             }
             leaf remote-address {
-              type "jt:ipaddr";
               description "Remote address of the resource";
+              type "jt:ipaddr";
             }
             leaf remote-id {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Interface ID for the remote end of the resource";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
             choice enable-disable {
               case case_1 {
                 leaf disable {
-                  type empty;
                   description "Disable resource on this TE link";
+                  type empty;
                 }
               }
             }
@@ -7045,67 +8249,92 @@ module junos-conf-protocols {
       }
     }
     list peer {
-      description "Define a network or LMP peer";
       key name;
       ordered-by user;
+      description "Define a network or LMP peer";
       leaf name {
-        type string;
         description "Name of peer";
+        type string;
       }
       leaf address {
-        type "jt:ipaddr";
         description "Address of peer";
+        type "jt:ipaddr";
       }
       container lmp-protocol {
-        description "LMP protocol attributes";
         presence "enable lmp-protocol";
+        description "LMP protocol attributes";
         leaf hello-interval {
-          type uint32 {
-            range "150 .. 21845";
-          }
           description "Interval between Hello messages";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "150 .. 21845";
+            }
+          }
         }
         leaf hello-dead-interval {
-          type uint32 {
-            range "500 .. 65535";
-          }
           description "Delay for control channel shutdown when no Hello received";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "500 .. 65535";
+            }
+          }
         }
         leaf retransmission-interval {
-          type uint32 {
-            range "500 .. 300000";
-          }
           description "Minimum time before retransmitting a message";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "500 .. 300000";
+            }
+          }
         }
         leaf retry-limit {
-          type uint32 {
-            range "3 .. 1000";
-          }
           description "Number of times to retransmit a message";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "3 .. 1000";
+            }
+          }
         }
         leaf passive {
-          type empty;
           description "Do not send Config messages to peer";
+          type empty;
         }
       }
       leaf-list control-channel {
-        type "jt:interface-name";
-        description "Control channel interfaces by priority";
         ordered-by user;
+        description "Control channel interfaces by priority";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       list lmp-control-channel {
-        description "Control channel IDs";
         key name;
         ordered-by user;
+        description "Control channel IDs";
         uses lmp_control_channel_type;
       }
       leaf-list te-link {
-        type string;
-        description "List of TE links managed by this peer";
         ordered-by user;
+        description "List of TE links managed by this peer";
+        type string;
       }
     }
     container traceoptions {
@@ -7113,47 +8342,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum init {
@@ -7195,24 +8429,24 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
           status deprecated;
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
           status deprecated;
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
           status deprecated;
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
           status deprecated;
+          type empty;
         }
       }
     }
@@ -7220,70 +8454,81 @@ module junos-conf-protocols {
   grouping juniper-protocols-mpls {
     description "Multiprotocol Label Switching options";
     leaf no-propagate-ttl {
-      type empty;
       description "Disable TTL propagation from IP to MPLS (on push) and MPLS to IP (on pop)";
+      type empty;
     }
     leaf ipv6-tunneling {
-      type empty;
       description "Allow MPLS LSPs to be used for tunneling IPv6 traffic";
+      type empty;
     }
     list interface {
-      description "MPLS interface options";
       key name;
       ordered-by user;
+      description "MPLS interface options";
       uses juniper-protocols-mpls-interface;
     }
   }
   grouping juniper-protocols-mpls-interface {
     leaf name {
-      type "jt:interface-name";
       description "Interface name";
+      type union {
+        type "jt:interface-name";
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable MPLS on this interface";
+          type empty;
         }
       }
     }
     leaf-list srlg {
-      type string;
-      description "SRLG Name";
-      max-elements 64;
       ordered-by user;
+      description "SRLG Name";
+      type string;
+      max-elements 64;
     }
     leaf always-mark-connection-protection-tlv {
-      type empty;
       description "Mark connection protection tlv on this interface";
+      type empty;
     }
     leaf switch-away-lsps {
-      type empty;
       description "Switch away protected LSPs to their bypass LSPs";
+      type empty;
     }
     leaf-list admin-group {
-      type string;
-      description "Administrative groups";
       ordered-by user;
+      description "Administrative groups";
+      type string;
     }
     leaf-list admin-group-extended {
-      type string;
-      description "Extended administrative groups";
       ordered-by user;
+      description "Extended administrative groups";
+      type string;
     }
     container static {
       description "Static label-switch path related configurations";
       leaf protection-revert-time {
-        type uint32 {
-          range "0 .. 65535";
-        }
         description "FRR revert wait time, 0 means disable";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 65535";
+          }
+        }
       }
     }
   }
   grouping juniper-protocols-msdp {
     leaf data-encapsulation {
+      description "Set encapsulation of data packets";
       type enumeration {
         enum disable {
           description "Disable data encapsulation";
@@ -7292,7 +8537,6 @@ module junos-conf-protocols {
           description "Enable data encapsulation";
         }
       }
-      description "Set encapsulation of data packets";
     }
     container rib-group {
       description "Routing table group";
@@ -7301,101 +8545,126 @@ module junos-conf-protocols {
     container active-source-limit {
       description "Limit the number of active sources accepted";
       leaf maximum {
-        type uint32 {
-          range "1 .. 1000000";
-        }
-        default "25000";
         description "Maximum number of active sources accepted";
+        default "25000";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 1000000";
+          }
+        }
       }
       leaf threshold {
-        type uint32 {
-          range "1 .. 1000000";
-        }
-        default "24000";
         description "RED threshold for active source acceptance";
+        default "24000";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 1000000";
+          }
+        }
       }
       leaf log-warning {
-        type uint32 {
-          range "1 .. 100";
-        }
-        default "100";
         description "Percentage of maximum at which to start generating warnings";
+        default "100";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100";
+          }
+        }
       }
       leaf log-interval {
-        type uint32 {
-          range "6 .. 32767";
-        }
         description "Time between log messages";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "6 .. 32767";
+          }
+        }
       }
     }
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable MSDP";
+          type empty;
         }
       }
     }
     leaf-list export {
-      type "jt:policy-algebra";
-      description "Export policy";
       ordered-by user;
+      description "Export policy";
+      type "jt:policy-algebra";
     }
     leaf-list import {
-      type "jt:policy-algebra";
-      description "Import policy";
       ordered-by user;
+      description "Import policy";
+      type "jt:policy-algebra";
     }
     leaf local-address {
-      type "jt:ipv4addr";
       description "Local address";
+      type "jt:ipv4addr";
     }
     container traceoptions {
       description "Trace options for MSDP";
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum packets {
@@ -7443,99 +8712,104 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     list peer {
-      description "Configure an MSDP peer";
       key name;
       ordered-by user;
+      description "Configure an MSDP peer";
       leaf name {
-        type "jt:ipv4addr";
         description "Peer address";
+        type "jt:ipv4addr";
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable MSDP";
+            type empty;
           }
         }
       }
       leaf-list export {
-        type "jt:policy-algebra";
-        description "Export policy";
         ordered-by user;
+        description "Export policy";
+        type "jt:policy-algebra";
       }
       leaf-list import {
-        type "jt:policy-algebra";
-        description "Import policy";
         ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
       }
       leaf local-address {
-        type "jt:ipv4addr";
         description "Local address";
+        type "jt:ipv4addr";
       }
       container traceoptions {
         description "Trace options for MSDP";
         container file {
           description "Trace file options";
           leaf filename {
+            description "Name of file in which to write trace information";
             type string {
               length "1 .. 1024";
             }
-            description "Name of file in which to write trace information";
           }
           leaf replace {
-            type empty;
             description "Replace trace file rather than appending to it";
             status deprecated;
+            type empty;
           }
           leaf size {
-            type string;
             description "Maximum trace file size";
+            type string;
           }
           leaf files {
-            type uint32 {
-              range "2 .. 1000";
-            }
-            default "10";
             description "Maximum number of trace files";
+            default "10";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 1000";
+              }
+            }
           }
           leaf no-stamp {
-            type empty;
             description "Do not timestamp trace file";
             status deprecated;
+            type empty;
           }
           choice world-readable-choice {
             leaf world-readable {
-              type empty;
               description "Allow any user to read the log file";
+              type empty;
             }
             leaf no-world-readable {
-              type empty;
               description "Don't allow any user to read the log file";
+              type empty;
             }
           }
         }
         list flag {
-          description "Tracing parameters";
           key name;
           ordered-by user;
+          description "Tracing parameters";
           leaf name {
             type enumeration {
               enum packets {
@@ -7583,154 +8857,226 @@ module junos-conf-protocols {
             }
           }
           leaf send {
-            type empty;
             description "Trace transmitted packets";
+            type empty;
           }
           leaf receive {
-            type empty;
             description "Trace received packets";
+            type empty;
           }
           leaf detail {
-            type empty;
             description "Trace detailed information";
+            type empty;
           }
           leaf disable {
-            type empty;
             description "Disable this trace flag";
+            type empty;
           }
         }
       }
       container active-source-limit {
         description "Limit the number of active sources accepted";
         leaf maximum {
-          type uint32 {
-            range "1 .. 1000000";
-          }
-          default "25000";
           description "Maximum number of active sources accepted";
+          default "25000";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 1000000";
+            }
+          }
         }
         leaf threshold {
-          type uint32 {
-            range "1 .. 1000000";
-          }
-          default "24000";
           description "RED threshold for active source acceptance";
+          default "24000";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 1000000";
+            }
+          }
         }
         leaf log-warning {
-          type uint32 {
-            range "1 .. 100";
-          }
-          default "100";
           description "Percentage of maximum at which to start generating warnings";
+          default "100";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 100";
+            }
+          }
         }
         leaf log-interval {
-          type uint32 {
-            range "6 .. 32767";
-          }
           description "Time between log messages";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "6 .. 32767";
+            }
+          }
         }
       }
       leaf keep-alive {
-        type uint32 {
-          range "10 .. 60";
-        }
         description "Time limit for sending out periodic keep alive to peer";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "10 .. 60";
+          }
+        }
       }
       leaf hold-time {
-        type uint32 {
-          range "15 .. 150";
-        }
         description "Max time to terminating a peer for having not received any message from ";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "15 .. 150";
+          }
+        }
       }
       leaf sa-hold-time {
-        type uint32 {
-          range "75 .. 300";
-        }
         description "Max time for holding a sa message before timing out";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "75 .. 300";
+          }
+        }
       }
       leaf default-peer {
-        type empty;
         description "Default RPF peer";
+        type empty;
       }
       leaf authentication-key {
+        description "MD5 authentication key";
         type string {
           length "1 .. 126";
         }
-        description "MD5 authentication key";
       }
     }
     leaf keep-alive {
-      type uint32 {
-        range "10 .. 60";
-      }
       description "Time limit for sending out periodic keep alive to peer";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "10 .. 60";
+        }
+      }
     }
     leaf hold-time {
-      type uint32 {
-        range "15 .. 150";
-      }
       description "Max time to terminating a peer for having not received any message from ";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "15 .. 150";
+        }
+      }
     }
     leaf sa-hold-time {
-      type uint32 {
-        range "75 .. 300";
-      }
       description "Max time for holding a sa message before timing out";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "75 .. 300";
+        }
+      }
     }
     list source {
-      description "Configure parameters for each source";
       key name;
       ordered-by user;
+      description "Configure parameters for each source";
       leaf name {
-        type "jt:ipprefix";
         description "Source address or prefix";
+        type "jt:ipprefix";
       }
       container active-source-limit {
         description "Limit the number of active sources accepted";
         leaf maximum {
-          type uint32 {
-            range "1 .. 1000000";
-          }
-          default "25000";
           description "Maximum number of active sources accepted";
+          default "25000";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 1000000";
+            }
+          }
         }
         leaf threshold {
-          type uint32 {
-            range "1 .. 1000000";
-          }
-          default "24000";
           description "RED threshold for active source acceptance";
+          default "24000";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 1000000";
+            }
+          }
         }
         leaf log-warning {
-          type uint32 {
-            range "1 .. 100";
-          }
-          default "100";
           description "Percentage of maximum at which to start generating warnings";
+          default "100";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 100";
+            }
+          }
         }
         leaf log-interval {
-          type uint32 {
-            range "6 .. 32767";
-          }
           description "Time between log messages";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "6 .. 32767";
+            }
+          }
         }
       }
     }
     list group {
-      description "Configure MSDP peer groups";
       key name;
       ordered-by user;
+      description "Configure MSDP peer groups";
       leaf name {
-        type string;
         description "MSDP peer group name";
+        type string;
       }
       leaf mode {
+        description "MSDP group source-active flooding mode";
+        default "standard";
         type enumeration {
           enum standard {
             description "Use standard MSDP source-active flooding rules";
@@ -7739,77 +9085,80 @@ module junos-conf-protocols {
             description "Group peers are mesh group members";
           }
         }
-        default "standard";
-        description "MSDP group source-active flooding mode";
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable MSDP";
+            type empty;
           }
         }
       }
       leaf-list export {
-        type "jt:policy-algebra";
-        description "Export policy";
         ordered-by user;
+        description "Export policy";
+        type "jt:policy-algebra";
       }
       leaf-list import {
-        type "jt:policy-algebra";
-        description "Import policy";
         ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
       }
       leaf local-address {
-        type "jt:ipv4addr";
         description "Local address";
+        type "jt:ipv4addr";
       }
       container traceoptions {
         description "Trace options for MSDP";
         container file {
           description "Trace file options";
           leaf filename {
+            description "Name of file in which to write trace information";
             type string {
               length "1 .. 1024";
             }
-            description "Name of file in which to write trace information";
           }
           leaf replace {
-            type empty;
             description "Replace trace file rather than appending to it";
             status deprecated;
+            type empty;
           }
           leaf size {
-            type string;
             description "Maximum trace file size";
+            type string;
           }
           leaf files {
-            type uint32 {
-              range "2 .. 1000";
-            }
-            default "10";
             description "Maximum number of trace files";
+            default "10";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 1000";
+              }
+            }
           }
           leaf no-stamp {
-            type empty;
             description "Do not timestamp trace file";
             status deprecated;
+            type empty;
           }
           choice world-readable-choice {
             leaf world-readable {
-              type empty;
               description "Allow any user to read the log file";
+              type empty;
             }
             leaf no-world-readable {
-              type empty;
               description "Don't allow any user to read the log file";
+              type empty;
             }
           }
         }
         list flag {
-          description "Tracing parameters";
           key name;
           ordered-by user;
+          description "Tracing parameters";
           leaf name {
             type enumeration {
               enum packets {
@@ -7857,99 +9206,104 @@ module junos-conf-protocols {
             }
           }
           leaf send {
-            type empty;
             description "Trace transmitted packets";
+            type empty;
           }
           leaf receive {
-            type empty;
             description "Trace received packets";
+            type empty;
           }
           leaf detail {
-            type empty;
             description "Trace detailed information";
+            type empty;
           }
           leaf disable {
-            type empty;
             description "Disable this trace flag";
+            type empty;
           }
         }
       }
       list peer {
-        description "Configure an MSDP peer";
         key name;
         ordered-by user;
+        description "Configure an MSDP peer";
         leaf name {
-          type "jt:ipv4addr";
           description "Peer address";
+          type "jt:ipv4addr";
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable MSDP";
+              type empty;
             }
           }
         }
         leaf-list export {
-          type "jt:policy-algebra";
-          description "Export policy";
           ordered-by user;
+          description "Export policy";
+          type "jt:policy-algebra";
         }
         leaf-list import {
-          type "jt:policy-algebra";
-          description "Import policy";
           ordered-by user;
+          description "Import policy";
+          type "jt:policy-algebra";
         }
         leaf local-address {
-          type "jt:ipv4addr";
           description "Local address";
+          type "jt:ipv4addr";
         }
         container traceoptions {
           description "Trace options for MSDP";
           container file {
             description "Trace file options";
             leaf filename {
+              description "Name of file in which to write trace information";
               type string {
                 length "1 .. 1024";
               }
-              description "Name of file in which to write trace information";
             }
             leaf replace {
-              type empty;
               description "Replace trace file rather than appending to it";
               status deprecated;
+              type empty;
             }
             leaf size {
-              type string;
               description "Maximum trace file size";
+              type string;
             }
             leaf files {
-              type uint32 {
-                range "2 .. 1000";
-              }
-              default "10";
               description "Maximum number of trace files";
+              default "10";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "2 .. 1000";
+                }
+              }
             }
             leaf no-stamp {
-              type empty;
               description "Do not timestamp trace file";
               status deprecated;
+              type empty;
             }
             choice world-readable-choice {
               leaf world-readable {
-                type empty;
                 description "Allow any user to read the log file";
+                type empty;
               }
               leaf no-world-readable {
-                type empty;
                 description "Don't allow any user to read the log file";
+                type empty;
               }
             }
           }
           list flag {
-            description "Tracing parameters";
             key name;
             ordered-by user;
+            description "Tracing parameters";
             leaf name {
               type enumeration {
                 enum packets {
@@ -7997,83 +9351,118 @@ module junos-conf-protocols {
               }
             }
             leaf send {
-              type empty;
               description "Trace transmitted packets";
+              type empty;
             }
             leaf receive {
-              type empty;
               description "Trace received packets";
+              type empty;
             }
             leaf detail {
-              type empty;
               description "Trace detailed information";
+              type empty;
             }
             leaf disable {
-              type empty;
               description "Disable this trace flag";
+              type empty;
             }
           }
         }
         container active-source-limit {
           description "Limit the number of active sources accepted";
           leaf maximum {
-            type uint32 {
-              range "1 .. 1000000";
-            }
-            default "25000";
             description "Maximum number of active sources accepted";
+            default "25000";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 1000000";
+              }
+            }
           }
           leaf threshold {
-            type uint32 {
-              range "1 .. 1000000";
-            }
-            default "24000";
             description "RED threshold for active source acceptance";
+            default "24000";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 1000000";
+              }
+            }
           }
           leaf log-warning {
-            type uint32 {
-              range "1 .. 100";
-            }
-            default "100";
             description "Percentage of maximum at which to start generating warnings";
+            default "100";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 100";
+              }
+            }
           }
           leaf log-interval {
-            type uint32 {
-              range "6 .. 32767";
-            }
             description "Time between log messages";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "6 .. 32767";
+              }
+            }
           }
         }
         leaf keep-alive {
-          type uint32 {
-            range "10 .. 60";
-          }
           description "Time limit for sending out periodic keep alive to peer";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "10 .. 60";
+            }
+          }
         }
         leaf hold-time {
-          type uint32 {
-            range "15 .. 150";
-          }
           description "Max time to terminating a peer for having not received any message from ";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "15 .. 150";
+            }
+          }
         }
         leaf sa-hold-time {
-          type uint32 {
-            range "75 .. 300";
-          }
           description "Max time for holding a sa message before timing out";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "75 .. 300";
+            }
+          }
         }
         leaf default-peer {
-          type empty;
           description "Default RPF peer";
+          type empty;
         }
         leaf authentication-key {
+          description "MD5 authentication key";
           type string {
             length "1 .. 126";
           }
-          description "MD5 authentication key";
         }
       }
     }
@@ -8082,122 +9471,157 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable MSTP";
+          type empty;
         }
       }
     }
     leaf bpdu-destination-mac-address {
+      description "Destination MAC address in the spanning tree BPDUs";
       type enumeration {
         enum provider-bridge-group {
           description "802.1ad provider bridge group address";
         }
       }
-      description "Destination MAC address in the spanning tree BPDUs";
     }
     leaf configuration-name {
+      description "Configuration name (part of MST configuration identifier)";
       type string {
         length "1 .. 32";
       }
-      description "Configuration name (part of MST configuration identifier)";
     }
     leaf revision-level {
-      type uint16;
       description "Revision level (part of MST configuration identifier)";
+      type union {
+        type uint16;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf max-hops {
-      type uint16 {
-        range "1 .. 255";
-      }
       description "Maximum number of hops";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "1 .. 255";
+        }
+      }
     }
     leaf max-age {
-      type uint16 {
-        range "6 .. 40";
-      }
       description "Maximum age of received protocol bpdu";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "6 .. 40";
+        }
+      }
     }
     leaf hello-time {
-      type uint16 {
-        range "1 .. 10";
-      }
       description "Time interval between configuration BPDUs";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "1 .. 10";
+        }
+      }
     }
     leaf forward-delay {
-      type uint16 {
-        range "4 .. 30";
-      }
       description "Time spent in listening or learning state";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "4 .. 30";
+        }
+      }
     }
     leaf system-identifier {
-      type "jt:mac-unicast";
       description "Sytem identifier to represent this node";
+      type "jt:mac-unicast";
     }
     container traceoptions {
       description "Tracing options for debugging protocol operation";
       uses stp-trace-options;
     }
     leaf bridge-priority {
-      type string;
       description "Priority of the bridge (in increments of 4k - 0,4k,8k,..60k)";
+      type string;
     }
     leaf backup-bridge-priority {
-      type string;
       description "Priority of the bridge (in increments of 4k - 4k,8k,..60k)";
+      type string;
     }
     leaf bpdu-block-on-edge {
-      type empty;
       description "Block BPDU on all interfaces configured as edge (BPDU Protect)";
+      type empty;
     }
     leaf vpls-flush-on-topology-change {
-      type empty;
       description "Enable VPLS MAC flush on root protected CE interface receving topology change";
+      type empty;
     }
     leaf priority-hold-time {
-      type uint16 {
-        range "1 .. 255";
-      }
       description "Hold time before switching to primary priority when core domain becomes up";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "1 .. 255";
+        }
+      }
     }
     list system-id {
-      description "System ID to IP mapping";
       key name;
       ordered-by user;
+      description "System ID to IP mapping";
       uses system-id-ip-map;
     }
     list interface {
-      description "Interface options";
       key name;
+      description "Interface options";
       uses mstp-interface;
     }
     list msti {
-      description "Per-MSTI options";
       key name;
+      description "Per-MSTI options";
       leaf name {
-        type int32 {
-          range "1 .. 64";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "1 .. 64";
+          }
         }
       }
       leaf bridge-priority {
-        type string;
         description "Priority of the bridge (in increments of 4k - 0,4k,8k,..60k)";
+        type string;
       }
       leaf backup-bridge-priority {
-        type string;
         description "Priority of the bridge (in increments of 4k - 4k,8k,..60k)";
+        type string;
       }
       leaf-list vlan {
-        type string;
-        description "VLAN ID or VLAN ID range [1..4094]";
         ordered-by user;
+        description "VLAN ID or VLAN ID range [1..4094]";
+        type string;
       }
       list interface {
-        description "Interface options";
         key name;
+        description "Interface options";
         uses mstp-interface;
       }
     }
@@ -8209,47 +9633,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum error {
@@ -8321,20 +9750,20 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
@@ -8344,19 +9773,19 @@ module junos-conf-protocols {
       container intra-as {
         description "Intra-AS autodiscovery options";
         leaf inclusive {
-          type empty;
           description "Inclusive provider tunnel autodiscovery";
+          type empty;
         }
       }
     }
     container family {
       description "BGP-MVPN address family";
       container any {
-        description "BGP-MVPN properties for all families";
         presence "enable any";
+        description "BGP-MVPN properties for all families";
         leaf disable {
-          type empty;
           description "Disable all families";
+          type empty;
         }
       }
       container inet {
@@ -8366,122 +9795,142 @@ module junos-conf-protocols {
           container intra-as {
             description "Intra-AS autodiscovery options";
             leaf inclusive {
-              type empty;
               description "Inclusive provider tunnel autodiscovery";
+              type empty;
             }
           }
         }
         leaf disable {
-          type empty;
           description "Disable family IPv4";
+          type empty;
         }
       }
       container inet6 {
-        description "IPv6 BGP-MVPN properties";
         presence "enable inet6";
+        description "IPv6 BGP-MVPN properties";
         container autodiscovery-only {
           description "Use MVPN exclusively for PE router autodiscovery";
           container intra-as {
             description "Intra-AS autodiscovery options";
             leaf inclusive {
-              type empty;
               description "Inclusive provider tunnel autodiscovery";
+              type empty;
             }
           }
         }
         leaf disable {
-          type empty;
           description "Disable family IPv6";
+          type empty;
         }
       }
     }
     choice sender-receiver-site-choice {
       case case_1 {
         leaf receiver-site {
-          type empty;
           description "MVPN instance has sites only with multicast receivers";
+          type empty;
         }
       }
       case case_2 {
         leaf sender-site {
-          type empty;
           description "MVPN instance has sites only with multicast sources";
+          type empty;
         }
       }
     }
     leaf unicast-umh-election {
-      type empty;
       description "Upstream Multicast Hop election based on unicast route preference";
+      type empty;
     }
     container static-umh {
       description "Upstream Multicast Hop election based on static configuration";
       leaf primary {
-        type "jt:ipv4addr";
         description "Primary Upstream Multicast Hop";
+        type "jt:ipv4addr";
       }
       leaf backup {
-        type "jt:ipv4addr";
         description "Secondary Upstream Multicast Hop";
+        type "jt:ipv4addr";
       }
       choice source-tree_choice {
         case case_1 {
           leaf source-tree {
-            type empty;
             description "Mandatory attribute - static-umh applies only to MVPN source-tree c-multicast joins";
+            type empty;
           }
         }
       }
     }
     leaf cmcast-joins-limit-inet {
-      type uint32 {
-        range "0 .. 15000";
-      }
       description "Maximum number of cmcast entries for v4";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 15000";
+        }
+      }
     }
     leaf cmcast-joins-limit-inet6 {
-      type uint32 {
-        range "0 .. 15000";
-      }
       description "Maximum number of cmcast entries for v6";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 15000";
+        }
+      }
     }
     container mvpn-mode {
       description "MVPN mode of operation";
       choice mode {
         case case_1 {
           container rpt-spt {
-            description "MVPN works in multicast RPT and SPT mode";
             presence "enable rpt-spt";
+            description "MVPN works in multicast RPT and SPT mode";
             leaf spt-switch-timer {
-              type uint32 {
-                range "0 .. 60";
-              }
               description "Timeout before a PE router switches between RPT and SPT";
               units seconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "0 .. 60";
+                }
+              }
             }
           }
         }
         case case_2 {
           container spt-only {
-            description "MVPN works in multicast SPT only mode (default mode)";
             presence "enable spt-only";
+            description "MVPN works in multicast SPT only mode (default mode)";
             container source-active-advertisement {
               description "Attributes associated with advertising Source-Active A-D routes";
               leaf dampen {
-                type uint32 {
-                  range "1 .. 30";
-                }
                 description "Time to wait before re-advertising source-active route";
                 units minutes;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "1 .. 30";
+                  }
+                }
               }
               leaf min-rate {
-                type string;
                 description "Minimum traffic rate required to advertise Source-Active route";
                 units "bits per second";
+                type string;
               }
             }
             leaf convert-sa-to-msdp {
-              type empty;
               description "Turn on MVPN SA route to MSDP SA conversion";
+              type empty;
             }
           }
         }
@@ -8492,40 +9941,40 @@ module junos-conf-protocols {
       container import-target {
         description "Target communities used when importing routes";
         container unicast {
-          description "Use the same target community as configured for unicast";
           presence "enable unicast";
+          description "Use the same target community as configured for unicast";
           choice receiver-sender-target-choice {
             case case_1 {
               leaf receiver {
-                type empty;
                 description "Target community used when importing receiver site routes";
+                type empty;
               }
             }
             case case_2 {
               leaf sender {
-                type empty;
                 description "Target community used when importing sender site routes";
+                type empty;
               }
             }
           }
         }
         container target {
-          description "Target community";
           presence "enable target";
+          description "Target community";
           leaf target-value {
             type string;
           }
           choice receiver-sender-target-choice {
             case case_1 {
               leaf receiver {
-                type empty;
                 description "Target community used when importing receiver site routes";
+                type empty;
               }
             }
             case case_2 {
               leaf sender {
-                type empty;
                 description "Target community used when importing sender site routes";
+                type empty;
               }
             }
           }
@@ -8534,12 +9983,12 @@ module junos-conf-protocols {
       container export-target {
         description "Target communities used when exporting routes";
         leaf unicast {
-          type empty;
           description "Use the same target community as configured for unicast";
+          type empty;
         }
         leaf target {
-          type string;
           description "Target community";
+          type string;
         }
       }
     }
@@ -8548,71 +9997,76 @@ module junos-conf-protocols {
       choice algorithm {
         case case_1 {
           container bytewise-xor-hash {
-            description "Upstream selection using bytewise XOR hash";
             presence "enable bytewise-xor-hash";
+            description "Upstream selection using bytewise XOR hash";
           }
         }
       }
     }
     leaf install-discard {
-      type empty;
       description "Install MVPN discard forwarding entries";
+      type empty;
     }
     leaf sender-based-rpf {
-      type empty;
       description "Forward multicast traffic only from a selected sender PE";
+      type empty;
     }
     container hot-root-standby {
       description "MVPN live-live - hot root standby";
       choice tree {
         case case_1 {
           container source-tree {
-            description "MVPN live-live - hot root standby for source tree";
             presence "enable source-tree";
+            description "MVPN live-live - hot root standby for source tree";
           }
         }
       }
       container min-rate {
         description "Minimum traffic rate for the provider tunnel below which switchover is initiated (in bps)";
         leaf rate {
-          type string;
           description "Minium traffic rate for the provider tunnel below which switchover is initiated (in bps)";
           units "bits per second";
+          type string;
         }
         leaf revert-delay {
-          type uint32 {
-            range "0 .. 20";
-          }
           description "Time to delay updating of multicast routes to allow for multicast convergence";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 20";
+            }
+          }
         }
       }
     }
     leaf hierarchical-nexthop {
-      type empty;
       description "Enable hierarchical nexthop usage";
+      type empty;
     }
     leaf no-nexthop-sharing-for-selective-tunnel {
-      type empty;
       description "Disable Tunnel nexthops from getting shared for selective tunnel";
+      type empty;
     }
     container inter-region-template {
       description "MVPN inter-region tunnel mapping template";
       list template {
-        description "Define a inter-region template";
         key name;
         ordered-by user;
+        description "Define a inter-region template";
         leaf name {
-          type string;
           description "MVPN Template Name";
+          type string;
         }
         list region {
-          description "BGP peer group names used as region";
           key name;
           ordered-by user;
+          description "BGP peer group names used as region";
           leaf name {
-            type string;
             description "Region name";
+            type string;
           }
           choice tunnel-type {
             case case_1 {
@@ -8621,8 +10075,8 @@ module junos-conf-protocols {
                 choice static-or-dynamic {
                   case case_1 {
                     leaf static-lsp {
-                      type string;
                       description "Name of point-to-multipoint LSP";
+                      type string;
                     }
                   }
                   case case_2 {
@@ -8631,14 +10085,14 @@ module junos-conf-protocols {
                       choice dynamic-template {
                         case case_1 {
                           leaf template-name {
-                            type string;
                             description "Name of point-to-multipoint LSP template";
+                            type string;
                           }
                         }
                         case case_2 {
                           leaf default-template {
-                            type empty;
                             description "Use default parameters";
+                            type empty;
                           }
                         }
                       }
@@ -8649,33 +10103,33 @@ module junos-conf-protocols {
             }
             case case_2 {
               container ldp-p2mp {
-                description "LDP point-to-multipoint LSP for flooding";
                 presence "enable ldp-p2mp";
+                description "LDP point-to-multipoint LSP for flooding";
               }
             }
             case case_3 {
               container ingress-replication {
                 description "Ingress replication tunnel";
                 leaf create-new-ucast-tunnel {
-                  type empty;
                   description "Create new unicast tunnel for ingress replication";
+                  type empty;
                 }
                 container label-switched-path {
-                  description "Point-to-point LSP unicast tunnel";
                   presence "enable label-switched-path";
+                  description "Point-to-point LSP unicast tunnel";
                   container label-switched-path-template {
                     description "Template for dynamic point-to-point LSP parameters";
                     choice dynamic-template {
                       case case_1 {
                         leaf template-name {
-                          type string;
                           description "Name of point-to-point LSP template";
+                          type string;
                         }
                       }
                       case case_2 {
                         leaf default-template {
-                          type empty;
                           description "Use default parameters";
+                          type empty;
                         }
                       }
                     }
@@ -8685,8 +10139,8 @@ module junos-conf-protocols {
             }
             case case_4 {
               leaf incoming {
-                type empty;
                 description "Same as incoming provider tunnel";
+                type empty;
               }
             }
           }
@@ -8700,8 +10154,8 @@ module junos-conf-protocols {
                 choice static-or-dynamic {
                   case case_1 {
                     leaf static-lsp {
-                      type string;
                       description "Name of point-to-multipoint LSP";
+                      type string;
                     }
                   }
                   case case_2 {
@@ -8710,14 +10164,14 @@ module junos-conf-protocols {
                       choice dynamic-template {
                         case case_1 {
                           leaf template-name {
-                            type string;
                             description "Name of point-to-multipoint LSP template";
+                            type string;
                           }
                         }
                         case case_2 {
                           leaf default-template {
-                            type empty;
                             description "Use default parameters";
+                            type empty;
                           }
                         }
                       }
@@ -8728,33 +10182,33 @@ module junos-conf-protocols {
             }
             case case_2 {
               container ldp-p2mp {
-                description "LDP point-to-multipoint LSP for flooding";
                 presence "enable ldp-p2mp";
+                description "LDP point-to-multipoint LSP for flooding";
               }
             }
             case case_3 {
               container ingress-replication {
                 description "Ingress replication tunnel";
                 leaf create-new-ucast-tunnel {
-                  type empty;
                   description "Create new unicast tunnel for ingress replication";
+                  type empty;
                 }
                 container label-switched-path {
-                  description "Point-to-point LSP unicast tunnel";
                   presence "enable label-switched-path";
+                  description "Point-to-point LSP unicast tunnel";
                   container label-switched-path-template {
                     description "Template for dynamic point-to-point LSP parameters";
                     choice dynamic-template {
                       case case_1 {
                         leaf template-name {
-                          type string;
                           description "Name of point-to-point LSP template";
+                          type string;
                         }
                       }
                       case case_2 {
                         leaf default-template {
-                          type empty;
                           description "Use default parameters";
+                          type empty;
                         }
                       }
                     }
@@ -8764,8 +10218,8 @@ module junos-conf-protocols {
             }
             case case_4 {
               leaf incoming {
-                type empty;
                 description "Same as incoming provider tunnel";
+                type empty;
               }
             }
           }
@@ -8773,18 +10227,18 @@ module junos-conf-protocols {
       }
     }
     leaf source-redundancy {
-      type empty;
       description "Assume all the sources for a particular group is sending same data";
+      type empty;
     }
     container umh-selection-additional-input {
       description "Additional parameters to consider during UMH";
       leaf source-active-preference {
-        type empty;
         description "Use the preference set in the source active route";
+        type empty;
       }
       leaf tunnel-status {
-        type empty;
         description "Use the RSVP tunnel status";
+        type empty;
       }
     }
   }
@@ -8795,79 +10249,116 @@ module junos-conf-protocols {
       uses mrp-trace-options;
     }
     leaf join-timer {
-      type uint16 {
-        range "100 .. 500";
-      }
-      default "200";
       description "Join timer interval";
+      default "200";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "100 .. 500";
+        }
+      }
     }
     leaf leave-timer {
-      type uint16 {
-        range "300 .. 1000";
-      }
-      default "800";
       description "Leave timer interval";
+      default "800";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "300 .. 1000";
+        }
+      }
     }
     leaf leaveall-timer {
-      type uint16 {
-        range "10 .. 60";
-      }
-      default "10";
       description "Leaveall timer interval";
+      default "10";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "10 .. 60";
+        }
+      }
     }
     leaf no-dynamic-vlan {
-      type empty;
       description "Disable dynamic VLAN creation";
+      type empty;
     }
     leaf no-attribute-length-in-pdu {
-      type empty;
       description "No attribute length while sending pdu ";
+      type empty;
     }
     leaf bpdu-destination-mac-address {
+      description "Destination MAC address in the MVRP BPDUs";
       type enumeration {
         enum provider-bridge-group {
           description "802.1ad provider bridge group address";
         }
       }
-      description "Destination MAC address in the MVRP BPDUs";
     }
     list interface {
-      description "Configure interface options";
       key name;
       ordered-by user;
+      description "Configure interface options";
       leaf name {
-        type "jt:interface-device";
         description "Interface name";
+        type union {
+          type "jt:interface-device";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf join-timer {
-        type uint16 {
-          range "100 .. 500";
-        }
         description "Join timer interval";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "100 .. 500";
+          }
+        }
       }
       leaf leave-timer {
-        type uint16 {
-          range "300 .. 1000";
-        }
         description "Leave timer interval";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "300 .. 1000";
+          }
+        }
       }
       leaf leaveall-timer {
-        type uint16 {
-          range "10 .. 60";
-        }
         description "Leaveall timer interval";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "10 .. 60";
+          }
+        }
       }
       leaf point-to-point {
-        type empty;
         description "Port is point to point";
+        type empty;
       }
       leaf registration {
+        description "Registration mode";
+        default "normal";
         type enumeration {
           enum normal {
             description "Normal registration mode";
@@ -8879,61 +10370,74 @@ module junos-conf-protocols {
             description "Forbidden registration mode";
           }
         }
-        default "normal";
-        description "Registration mode";
       }
     }
   }
   grouping juniper-protocols-openflow {
     list switch {
-      description "OpenFlow switch";
       key name;
-      max-elements 1;
       ordered-by user;
+      description "OpenFlow switch";
+      max-elements 1;
       leaf name {
+        description "Switch name";
         type string {
           length "1 .. 64";
         }
-        description "Switch name";
       }
       container default-action {
         description "Action for packets that not have a matching flow entry";
         choice drop-pktin {
           case case_1 {
             leaf drop {
-              type empty;
               description "Drop all packets that do not have a matching flow entry";
+              type empty;
             }
           }
           case case_2 {
             leaf packet-in {
-              type empty;
               description "Send packets to client if no matching flow entry";
+              type empty;
             }
           }
         }
       }
       list interfaces {
-        description "Interfaces configured for use with Openflow";
         key name;
         ordered-by user;
+        description "Interfaces configured for use with Openflow";
         leaf name {
-          type "jt:interface-name";
           description "Interface name";
+          type union {
+            type "jt:interface-name";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         leaf port-id {
-          type int32 {
-            range "1 .. 32640";
-          }
           description "Openflow port ID";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type int32 {
+              range "1 .. 32640";
+            }
+          }
         }
       }
       leaf purge-flow-timer {
-        type uint32 {
-          range "0 .. 300";
-        }
         description "Purge timer value for invalid flows";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 300";
+          }
+        }
       }
       container controller {
         description "OpenFlow controller's IP address, port and protocol";
@@ -8942,75 +10446,90 @@ module junos-conf-protocols {
           container tcp {
             description "Set protocol type to 'TCP' (default)";
             leaf port {
-              type int32 {
-                range "1024 .. 65535";
-              }
               description "Controller's port number (default 6633)";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type int32 {
+                  range "1024 .. 65535";
+                }
+              }
             }
           }
         }
         leaf role {
+          description "Controller role";
           type enumeration {
             enum equal {
               description "Set role to 'equal'";
             }
           }
-          description "Controller role";
         }
         leaf address {
-          type "jt:ipaddr";
           description "Controller's IPv4 address";
+          type "jt:ipaddr";
         }
         leaf id {
-          type uint32;
           description "Controller id";
+          type union {
+            type uint32;
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
       }
     }
     container traceoptions {
       description "OpenFlow switch daemon trace options";
       leaf no-remote-trace {
-        type empty;
         description "Disable remote tracing";
+        type empty;
       }
       container file {
         description "Trace file information";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "3";
           description "Maximum number of trace files";
+          default "3";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
         leaf match {
-          type "jt:regular-expression";
           description "Regular expression for lines to be logged";
+          type "jt:regular-expression";
         }
       }
       list flag {
-        description "Tracing flag parameters";
         key name;
         ordered-by user;
+        description "Tracing flag parameters";
         leaf name {
           type enumeration {
             enum switch {
@@ -9059,154 +10578,204 @@ module junos-conf-protocols {
   }
   grouping juniper-protocols-ospf {
     list topology {
-      description "Topology parameters";
       key name;
       ordered-by user;
+      description "Topology parameters";
       leaf name {
-        type string;
         description "Topology name";
+        type string;
       }
       leaf disable {
-        type empty;
         description "Disable this topology";
+        type empty;
       }
       leaf topology-id {
-        type uint8 {
-          range "32 .. 127";
-        }
         description "Topology identifier";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint8 {
+            range "32 .. 127";
+          }
+        }
       }
       leaf overload {
-        type empty;
         description "Set the overload mode (repel transit traffic)";
+        type empty;
       }
       leaf rib-group {
-        type string;
         description "Routing table group for importing routes";
+        type string;
       }
       container spf-options {
         description "Configure options for SPF";
         container microloop-avoidance {
           description "Configure microloop avoidance mechanism";
           container post-convergence-path {
-            description "Temporarily install post-convergence path for routes potentially affected by microloops";
             presence "enable post-convergence-path";
+            description "Temporarily install post-convergence path for routes potentially affected by microloops";
             leaf delay {
-              type uint32 {
-                range "500 .. 60000";
-              }
               description "Time after which temporary post-convergence paths are removed";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "500 .. 60000";
+                }
+              }
             }
             leaf maximum-labels {
-              type uint32 {
-                range "2 .. 8";
-              }
               description "Maximum number of labels installed for post-convergence paths";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "2 .. 8";
+                }
+              }
             }
           }
         }
         leaf delay {
-          type uint32 {
-            range "50 .. 8000";
-          }
           description "Time to wait before running an SPF";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "50 .. 8000";
+            }
+          }
         }
         leaf holddown {
-          type uint32 {
-            range "2000 .. 20000";
-          }
           description "Time to hold down before running an SPF";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2000 .. 20000";
+            }
+          }
         }
         leaf rapid-runs {
-          type uint32 {
-            range "1 .. 10";
-          }
           description "Number of maximum rapid SPF runs before holddown";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 10";
+            }
+          }
         }
         leaf no-ignore-our-externals {
-          type empty;
           description "Do not ignore self-generated external and NSSA LSAs";
+          type empty;
         }
       }
       container backup-spf-options {
         description "Configure options for backup SPF";
         container remote-backup-calculation {
-          description "Calculate Remote LFA backup nexthops";
           presence "enable remote-backup-calculation";
+          description "Calculate Remote LFA backup nexthops";
           container pq-nodes-nearest-to-source {
             description "PQ nodes selection based upon nearest to source";
             leaf percent {
-              type uint32 {
-                range "10 .. 100";
-              }
               description "Selection percentage for nearest to source";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "10 .. 100";
+                }
+              }
             }
           }
         }
         container use-post-convergence-lfa {
-          description "Calculate post-convergence backup paths";
           presence "enable use-post-convergence-lfa";
+          description "Calculate post-convergence backup paths";
           leaf maximum-labels {
-            type uint32 {
-              range "2 .. 8";
-            }
             description "Maximum number of labels installed for post-convergence paths";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 8";
+              }
+            }
           }
           leaf maximum-backup-paths {
-            type uint32 {
-              range "1 .. 8";
-            }
             description "Maximum number of equal-cost post-convergence paths installed";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 8";
+              }
+            }
           }
         }
         leaf use-source-packet-routing {
-          type empty;
           description "Use spring backup paths for inet.0 routes";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Do not run backup SPF";
+          type empty;
         }
         leaf no-install {
-          type empty;
           description "Do not install backup nexthops into the RIB";
+          type empty;
         }
         leaf downstream-paths-only {
-          type empty;
           description "Use only downstream backup paths";
+          type empty;
         }
         container per-prefix-calculation {
           description "Calculate backup nexthops for non-best prefix originators";
           leaf stubs {
-            type empty;
             description "Per prefix calculation for stubs only";
+            type empty;
           }
           leaf summary {
-            type empty;
             description "Per prefix calculation for summary originators only";
+            type empty;
           }
           leaf externals {
-            type empty;
             description "Per prefix calculation for externals";
+            type empty;
           }
           leaf all {
-            type empty;
             description "Per prefix calculation for all";
+            type empty;
           }
         }
         leaf node-link-degradation {
-          type empty;
           description "Degrade to link protection when nodelink protection not available";
+          type empty;
         }
       }
       leaf prefix-export-limit {
-        type uint32 {
-          range "0 .. 4294967295";
-        }
         description "Maximum number of prefixes that can be exported";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 4294967295";
+          }
+        }
       }
     }
     container spf-options {
@@ -9214,158 +10783,198 @@ module junos-conf-protocols {
       container microloop-avoidance {
         description "Configure microloop avoidance mechanism";
         container post-convergence-path {
-          description "Temporarily install post-convergence path for routes potentially affected by microloops";
           presence "enable post-convergence-path";
+          description "Temporarily install post-convergence path for routes potentially affected by microloops";
           leaf delay {
-            type uint32 {
-              range "500 .. 60000";
-            }
             description "Time after which temporary post-convergence paths are removed";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "500 .. 60000";
+              }
+            }
           }
           leaf maximum-labels {
-            type uint32 {
-              range "2 .. 8";
-            }
             description "Maximum number of labels installed for post-convergence paths";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 8";
+              }
+            }
           }
         }
       }
       leaf delay {
-        type uint32 {
-          range "50 .. 8000";
-        }
         description "Time to wait before running an SPF";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "50 .. 8000";
+          }
+        }
       }
       leaf holddown {
-        type uint32 {
-          range "2000 .. 20000";
-        }
         description "Time to hold down before running an SPF";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2000 .. 20000";
+          }
+        }
       }
       leaf rapid-runs {
-        type uint32 {
-          range "1 .. 10";
-        }
         description "Number of maximum rapid SPF runs before holddown";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 10";
+          }
+        }
       }
       leaf no-ignore-our-externals {
-        type empty;
         description "Do not ignore self-generated external and NSSA LSAs";
+        type empty;
       }
     }
     container backup-spf-options {
       description "Configure options for backup SPF";
       container remote-backup-calculation {
-        description "Calculate Remote LFA backup nexthops";
         presence "enable remote-backup-calculation";
+        description "Calculate Remote LFA backup nexthops";
         container pq-nodes-nearest-to-source {
           description "PQ nodes selection based upon nearest to source";
           leaf percent {
-            type uint32 {
-              range "10 .. 100";
-            }
             description "Selection percentage for nearest to source";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "10 .. 100";
+              }
+            }
           }
         }
       }
       container use-post-convergence-lfa {
-        description "Calculate post-convergence backup paths";
         presence "enable use-post-convergence-lfa";
+        description "Calculate post-convergence backup paths";
         leaf maximum-labels {
-          type uint32 {
-            range "2 .. 8";
-          }
           description "Maximum number of labels installed for post-convergence paths";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 8";
+            }
+          }
         }
         leaf maximum-backup-paths {
-          type uint32 {
-            range "1 .. 8";
-          }
           description "Maximum number of equal-cost post-convergence paths installed";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 8";
+            }
+          }
         }
       }
       leaf use-source-packet-routing {
-        type empty;
         description "Use spring backup paths for inet.0 routes";
+        type empty;
       }
       leaf disable {
-        type empty;
         description "Do not run backup SPF";
+        type empty;
       }
       leaf no-install {
-        type empty;
         description "Do not install backup nexthops into the RIB";
+        type empty;
       }
       leaf downstream-paths-only {
-        type empty;
         description "Use only downstream backup paths";
+        type empty;
       }
       container per-prefix-calculation {
         description "Calculate backup nexthops for non-best prefix originators";
         leaf stubs {
-          type empty;
           description "Per prefix calculation for stubs only";
+          type empty;
         }
         leaf summary {
-          type empty;
           description "Per prefix calculation for summary originators only";
+          type empty;
         }
         leaf externals {
-          type empty;
           description "Per prefix calculation for externals";
+          type empty;
         }
         leaf all {
-          type empty;
           description "Per prefix calculation for all";
+          type empty;
         }
       }
       leaf node-link-degradation {
-        type empty;
         description "Degrade to link protection when nodelink protection not available";
+        type empty;
       }
     }
     container traffic-engineering {
-      description "Configure traffic engineering attributes";
       presence "enable traffic-engineering";
+      description "Configure traffic engineering attributes";
       leaf no-topology {
-        type empty;
         description "Disable dissemination of TE link-state topology information";
+        type empty;
       }
       leaf multicast-rpf-routes {
-        type empty;
         description "Install routes for multicast RPF checks into inet.2";
+        type empty;
       }
       leaf l3-unicast-topology {
-        type empty;
         description "Download IGP topology into TED";
+        type empty;
       }
       container ignore-lsp-metrics {
-        description "Ignore label-switched path metrics when doing shortcuts";
         presence "enable ignore-lsp-metrics";
+        description "Ignore label-switched path metrics when doing shortcuts";
         leaf unconfigured-only {
-          type empty;
           description "Ignore lsp metrics for unconfigured only";
+          type empty;
         }
       }
       container shortcuts {
-        description "Use label-switched paths as next hops, if possible";
         presence "enable shortcuts";
+        description "Use label-switched paths as next hops, if possible";
         leaf ignore-lsp-metrics {
-          type empty;
           description "Ignore label-switched path metrics when doing shortcuts";
           status deprecated;
+          type empty;
         }
         leaf lsp-metric-into-summary {
-          type empty;
           description "Advertise LSP metric into summary LSAs";
+          type empty;
         }
         list family {
-          description "Address family specific traffic-engineering attributes";
           key name;
           ordered-by user;
+          description "Address family specific traffic-engineering attributes";
           leaf name {
             type enumeration {
               enum inet {
@@ -9379,251 +10988,326 @@ module junos-conf-protocols {
         }
       }
       leaf advertise-unnumbered-interfaces {
-        type empty;
         description "Advertise unnumbered interfaces";
+        type empty;
       }
       leaf credibility-protocol-preference {
-        type empty;
         description "TED protocol credibility follows protocol preference";
+        type empty;
       }
       container advertisement {
         description "Advertise TE parameters even if RSVP is not turned on";
         leaf always {
-          type empty;
           description "Advertise TE parameters in TE LSAs";
+          type empty;
         }
       }
       container tunnel-source-protocol {
         description "Protocols from which to pick label-switched paths";
         container rsvp {
-          description "Pick label-switched paths from rsvp";
           presence "enable rsvp";
+          description "Pick label-switched paths from rsvp";
           leaf preference {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Preference for label-switched paths from this protocol";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
         }
         container spring-te {
-          description "Pick label-switched paths from spring-te";
           presence "enable spring-te";
+          description "Pick label-switched paths from spring-te";
           leaf preference {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Preference for label-switched paths from this protocol";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
         }
       }
     }
     container source-packet-routing {
-      description "Enable source packet routing (SPRING)";
       presence "enable source-packet-routing";
+      description "Enable source packet routing (SPRING)";
       container adjacency-segment {
         description "Attributes for adjacency segments in spring";
         leaf hold-time {
-          type uint32 {
-            range "180000 .. 900000";
-          }
           description "Retain time of Adjacency segment after isolating from an interface";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "180000 .. 900000";
+            }
+          }
         }
       }
       leaf-list prefix-segment {
-        type "jt:policy-algebra";
-        description "Prefix Segment policy";
         ordered-by user;
+        description "Prefix Segment policy";
+        type "jt:policy-algebra";
       }
       leaf explicit-null {
-        type empty;
         description "Set E and P bits in all Prefix SID advertisements";
+        type empty;
       }
       container node-segment {
-        description "Enable support for Node segments in SPRING";
         presence "enable node-segment";
+        description "Enable support for Node segments in SPRING";
         leaf ipv4-index {
-          type uint32 {
-            range "0 .. 199999";
-          }
           description "Set ipv4 node segment index";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 199999";
+            }
+          }
         }
         leaf index-range {
-          type uint32 {
-            range "32 .. 16385";
-          }
           description "Set range of node segment indices allowed";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "32 .. 16385";
+            }
+          }
         }
       }
       container srgb {
         description "Set the SRGB global block in SPRING";
         leaf start-label {
-          type uint32;
           description "Start range for SRGB label block";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32;
+          }
         }
         leaf index-range {
-          type uint32;
           description "Index to the SRGB start label block";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32;
+          }
         }
       }
       leaf mapping-server {
-        type string;
         description "Mapping server name";
+        type string;
       }
       leaf install-prefix-sid-for-best-route {
-        type empty;
         description "For best route install a exact prefix sid route";
+        type empty;
       }
       leaf ldp-stitching {
-        type empty;
         description "Enable SR to LDP stitching";
+        type empty;
       }
       leaf-list flex-algorithm {
-        type uint32 {
-          range "128 .. 255";
-        }
         description "Flex-algorithms we would like to participate in";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "128 .. 255";
+          }
+        }
         max-elements 16;
       }
       leaf strict-asla-based-flex-algorithm {
-        type empty;
         description "Flex-Algorithm to ignore links not having ASLA sub-TLVs";
+        type empty;
       }
       container sensor-based-stats {
         description "Configure sensor based stats in SPRING";
         container per-interface-per-member-link {
           description "Configure sensor based stats per nexthop";
           leaf ingress {
-            type empty;
             description "Enable sensor based stats on ingress interface";
+            type empty;
           }
           leaf egress {
-            type empty;
             description "Enable sensor based stats on egress interface";
+            type empty;
           }
         }
         container per-sid {
           description "Configure sensor based stats per spring route";
           leaf ingress {
-            type empty;
             description "Enable sensor based stats for per-sid ingress accounting";
+            type empty;
           }
           leaf egress {
-            type empty;
             description "Enable sensor based stats for IP-MPLS egress accounting";
+            type empty;
           }
         }
       }
     }
     list area {
-      description "Configure an OSPF area";
       key name;
       ordered-by user;
+      description "Configure an OSPF area";
       leaf name {
-        type "jt:areaid";
         description "Area ID";
+        type "jt:areaid";
       }
       choice stub-option {
         case case_1 {
           container stub {
-            description "Configure a stub area";
             presence "enable stub";
+            description "Configure a stub area";
             leaf default-metric {
-              type uint32 {
-                range "1 .. 16777215";
-              }
               description "Metric for the default route in this stub area";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 16777215";
+                }
+              }
             }
             choice summaries-choice {
               leaf summaries {
-                type empty;
                 description "Flood summary LSAs into this stub area";
+                type empty;
               }
               leaf no-summaries {
-                type empty;
                 description "Don't flood summary LSAs into this stub area";
+                type empty;
               }
             }
           }
         }
         case case_2 {
           container nssa {
-            description "Configure a not-so-stubby area";
             presence "enable nssa";
+            description "Configure a not-so-stubby area";
             container default-lsa {
-              description "Configure a default LSA";
               presence "enable default-lsa";
+              description "Configure a default LSA";
               leaf default-metric {
-                type uint32 {
-                  range "1 .. 16777215";
-                }
                 description "Metric for the default route in this area";
-              }
-              leaf metric-type {
-                type uint32 {
-                  range "1 .. 2";
-                }
-                description "External metric type for the default type 7 LSA";
-              }
-              leaf type-7 {
-                type empty;
-                description "Flood type 7 default LSA if no-summaries is configured";
-              }
-            }
-            leaf default-metric {
-              type uint32 {
-                range "1 .. 16777215";
-              }
-              description "Metric for the default route in this area";
-              status deprecated;
-            }
-            leaf metric-type {
-              type uint32 {
-                range "1 .. 2";
-              }
-              description "External metric type for the default type 7 LSA";
-              status deprecated;
-            }
-            choice summaries-choice {
-              leaf summaries {
-                type empty;
-                description "Flood summary LSAs into this NSSA area";
-              }
-              leaf no-summaries {
-                type empty;
-                description "Don't flood summary LSAs into this NSSA area";
-              }
-            }
-            list area-range {
-              description "Configure NSSA area ranges";
-              key name;
-              ordered-by user;
-              leaf name {
-                type "jt:ipprefix";
-                description "Range to summarize NSSA routes in this area";
-              }
-              leaf restrict {
-                type empty;
-                description "Restrict advertisement of this area range";
-              }
-              leaf exact {
-                type empty;
-                description "Enforce exact match for advertisement of this area range";
-              }
-              container override-metric {
-                description "Override the dynamic metric for this area-range";
-                presence "enable override-metric";
-                leaf metric {
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
                   type uint32 {
                     range "1 .. 16777215";
                   }
-                  description "Metric value";
                 }
-                leaf metric-type {
+              }
+              leaf metric-type {
+                description "External metric type for the default type 7 LSA";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
                   type uint32 {
                     range "1 .. 2";
                   }
-                  default "1";
+                }
+              }
+              leaf type-7 {
+                description "Flood type 7 default LSA if no-summaries is configured";
+                type empty;
+              }
+            }
+            leaf default-metric {
+              description "Metric for the default route in this area";
+              status deprecated;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 16777215";
+                }
+              }
+            }
+            leaf metric-type {
+              description "External metric type for the default type 7 LSA";
+              status deprecated;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 2";
+                }
+              }
+            }
+            choice summaries-choice {
+              leaf summaries {
+                description "Flood summary LSAs into this NSSA area";
+                type empty;
+              }
+              leaf no-summaries {
+                description "Don't flood summary LSAs into this NSSA area";
+                type empty;
+              }
+            }
+            list area-range {
+              key name;
+              ordered-by user;
+              description "Configure NSSA area ranges";
+              leaf name {
+                description "Range to summarize NSSA routes in this area";
+                type "jt:ipprefix";
+              }
+              leaf restrict {
+                description "Restrict advertisement of this area range";
+                type empty;
+              }
+              leaf exact {
+                description "Enforce exact match for advertisement of this area range";
+                type empty;
+              }
+              container override-metric {
+                presence "enable override-metric";
+                description "Override the dynamic metric for this area-range";
+                leaf metric {
+                  description "Metric value";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "1 .. 16777215";
+                    }
+                  }
+                }
+                leaf metric-type {
                   description "Set the metric type for the override metric";
+                  default "1";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "1 .. 2";
+                    }
+                  }
                 }
               }
             }
@@ -9631,49 +11315,56 @@ module junos-conf-protocols {
         }
       }
       list area-range {
-        description "Configure area ranges";
         key name;
         ordered-by user;
+        description "Configure area ranges";
         leaf name {
-          type "jt:ipprefix";
           description "Range to summarize routes in this area";
+          type "jt:ipprefix";
         }
         leaf restrict {
-          type empty;
           description "Restrict advertisement of this area range";
+          type empty;
         }
         leaf exact {
-          type empty;
           description "Enforce exact match for advertisement of this area range";
+          type empty;
         }
         leaf override-metric {
-          type uint32 {
-            range "1 .. 16777215";
-          }
           description "Override the dynamic metric for this area-range";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 16777215";
+            }
+          }
         }
       }
       leaf-list network-summary-export {
-        type "jt:policy-algebra";
-        description "Export policy for Type 3 Summary LSAs";
         ordered-by user;
+        description "Export policy for Type 3 Summary LSAs";
+        type "jt:policy-algebra";
       }
       leaf-list network-summary-import {
-        type "jt:policy-algebra";
-        description "Import policy for Type 3 Summary LSAs";
         ordered-by user;
+        description "Import policy for Type 3 Summary LSAs";
+        type "jt:policy-algebra";
       }
       leaf-list inter-area-prefix-export {
-        type "jt:policy-algebra";
-        description "Export policy for Inter Area Prefix LSAs";
         ordered-by user;
+        description "Export policy for Inter Area Prefix LSAs";
+        type "jt:policy-algebra";
       }
       leaf-list inter-area-prefix-import {
-        type "jt:policy-algebra";
-        description "Import policy for Inter Area Prefix LSAs";
         ordered-by user;
+        description "Import policy for Inter Area Prefix LSAs";
+        type "jt:policy-algebra";
       }
       leaf authentication-type {
+        description "Authentication type";
+        status deprecated;
         type enumeration {
           enum none {
             description "No authentication";
@@ -9688,58 +11379,81 @@ module junos-conf-protocols {
             status deprecated;
           }
         }
-        description "Authentication type";
-        status deprecated;
       }
       list virtual-link {
-        description "Configure virtual links";
         key "neighbor-id transit-area";
         ordered-by user;
+        description "Configure virtual links";
         leaf neighbor-id {
-          type "jt:ipv4addr";
           description "Router ID of a virtual neighbor";
+          type "jt:ipv4addr";
         }
         leaf transit-area {
-          type "jt:areaid";
           description "Transit area in common with virtual neighbor";
+          type "jt:areaid";
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable this virtual link";
+              type empty;
             }
           }
         }
         leaf retransmit-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Retransmission interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf transit-delay {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Transit delay (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf hello-interval {
-          type uint32 {
-            range "1 .. 255";
-          }
           description "Hello interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255";
+            }
+          }
         }
         leaf dead-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Dead interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf mtu {
-          type uint32 {
-            range "128 .. 65535";
-          }
           description "Maximum OSPF packet size";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "128 .. 65535";
+            }
+          }
         }
         choice auth {
           case case_1 {
@@ -9752,153 +11466,189 @@ module junos-conf-protocols {
               description "Authentication key";
               status deprecated;
               leaf keyname {
-                type "jt:unreadable";
                 description "Authentication key value";
+                type "jt:unreadable";
               }
               leaf key-id {
-                type uint32 {
-                  range "0 .. 255";
-                }
                 description "Key ID for MD5 authentication";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 255";
+                  }
+                }
               }
             }
           }
         }
         leaf demand-circuit {
-          type empty;
           description "Interface functions as a demand circuit";
+          type empty;
         }
         leaf flood-reduction {
-          type empty;
           description "Enable flood reduction";
+          type empty;
         }
         leaf no-neighbor-down-notification {
-          type empty;
           description "Don't inform other protocols about neighbor down events";
+          type empty;
         }
         leaf ipsec-sa {
+          description "IPSec security association name";
           type string {
             length "1 .. 32";
           }
-          description "IPSec security association name";
         }
         list topology {
-          description "Topology specific attributes";
           key name;
           ordered-by user;
+          description "Topology specific attributes";
           leaf name {
-            type string;
             description "Topology name";
+            type string;
           }
           leaf disable {
-            type empty;
             description "Disable this topology";
+            type empty;
           }
           leaf metric {
-            type uint16 {
-              range "1 .. 65535";
-            }
             description "Topology metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
         }
       }
       list sham-link-remote {
-        description "Configure parameters for remote sham link endpoint";
         key name;
         ordered-by user;
+        description "Configure parameters for remote sham link endpoint";
         leaf name {
-          type "jt:ipaddr";
           description "Remote sham link endpoint address";
+          type "jt:ipaddr";
         }
         leaf metric {
-          type uint16 {
-            range "1 .. 65535";
-          }
           description "Sham link metric";
-        }
-        leaf ipsec-sa {
-          type string {
-            length "1 .. 32";
-          }
-          description "IPSec security association name";
-        }
-        leaf demand-circuit {
-          type empty;
-          description "Interface functions as a demand circuit";
-        }
-        leaf flood-reduction {
-          type empty;
-          description "Enable flood reduction";
-        }
-        list topology {
-          description "Topology specific attributes";
-          key name;
-          ordered-by user;
-          leaf name {
-            type string;
-            description "Topology name";
-          }
-          leaf disable {
-            type empty;
-            description "Disable this topology";
-          }
-          leaf metric {
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
             type uint16 {
               range "1 .. 65535";
             }
+          }
+        }
+        leaf ipsec-sa {
+          description "IPSec security association name";
+          type string {
+            length "1 .. 32";
+          }
+        }
+        leaf demand-circuit {
+          description "Interface functions as a demand circuit";
+          type empty;
+        }
+        leaf flood-reduction {
+          description "Enable flood reduction";
+          type empty;
+        }
+        list topology {
+          key name;
+          ordered-by user;
+          description "Topology specific attributes";
+          leaf name {
+            description "Topology name";
+            type string;
+          }
+          leaf disable {
+            description "Disable this topology";
+            type empty;
+          }
+          leaf metric {
             description "Topology metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
         }
       }
       list interface {
-        description "Include an interface in this area";
         key name;
         ordered-by user;
+        description "Include an interface in this area";
         leaf name {
-          type "jt:ipv4addr-or-interface";
           description "Interface name";
+          type union {
+            type "jt:ipv4addr-or-interface";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable OSPF on this interface";
+              type empty;
             }
           }
         }
         leaf interface-type {
+          description "Type of interface";
           type enumeration {
             enum nbma {
               description "Nonbroadcast multiaccess";
@@ -9913,110 +11663,149 @@ module junos-conf-protocols {
               description "Point-to-multipoint over LAN mode";
             }
           }
-          description "Type of interface";
         }
         choice protection-type {
           case case_1 {
             leaf link-protection {
-              type empty;
               description "Protect interface from link faults only";
+              type empty;
             }
           }
           case case_2 {
             leaf node-link-protection {
-              type empty;
               description "Protect interface from both link and node faults";
+              type empty;
             }
           }
         }
         leaf no-eligible-backup {
-          type empty;
           description "Not eligible to backup traffic from protected interfaces";
+          type empty;
         }
         leaf no-eligible-remote-backup {
-          type empty;
           description "Not eligible for Remote-LFA backup traffic from protected interfaces";
+          type empty;
         }
         container passive {
-          description "Do not run OSPF, but advertise it";
           presence "enable passive";
+          description "Do not run OSPF, but advertise it";
           container traffic-engineering {
             description "Advertise TE link information";
             leaf remote-node-id {
-              type "jt:ipaddr";
               description "Remote address of the link";
+              type "jt:ipaddr";
             }
             leaf remote-node-router-id {
-              type "jt:ipv4addr";
               description "TE Router-ID of the remote node";
+              type "jt:ipv4addr";
             }
           }
         }
         leaf secondary {
-          type empty;
           description "Treat interface as secondary";
+          type empty;
         }
         leaf own-router-lsa {
-          type empty;
           description "Generate a separate router LSA for this interface";
+          type empty;
         }
         container bandwidth-based-metrics {
           description "Configure bandwidth based metrics";
           list bandwidth {
-            description "Bandwidth threshold";
             key name;
+            description "Bandwidth threshold";
             leaf name {
               type string;
             }
             leaf metric {
-              type uint16 {
-                range "1 .. 65535";
-              }
               description "Metric associated with specified bandwidth";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 65535";
+                }
+              }
             }
           }
         }
         leaf metric {
-          type uint16 {
-            range "1 .. 65535";
-          }
           description "Interface metric";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf priority {
-          type uint32 {
-            range "0 .. 255";
-          }
           description "Designated router priority";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 255";
+            }
+          }
         }
         leaf retransmit-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Retransmission interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf transit-delay {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Transit delay (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf hello-interval {
-          type uint32 {
-            range "1 .. 255";
-          }
           description "Hello interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255";
+            }
+          }
         }
         leaf dead-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Dead interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf mtu {
-          type uint32 {
-            range "128 .. 65535";
-          }
           description "Maximum OSPF packet size";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "128 .. 65535";
+            }
+          }
         }
         choice auth {
           case case_1 {
@@ -10029,81 +11818,103 @@ module junos-conf-protocols {
               description "Authentication key";
               status deprecated;
               leaf keyname {
-                type "jt:unreadable";
                 description "Authentication key value";
+                type "jt:unreadable";
               }
               leaf key-id {
-                type uint32 {
-                  range "0 .. 255";
-                }
                 description "Key ID for MD5 authentication";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 255";
+                  }
+                }
               }
             }
           }
         }
         leaf demand-circuit {
-          type empty;
           description "Interface functions as a demand circuit";
+          type empty;
         }
         leaf flood-reduction {
-          type empty;
           description "Enable flood reduction";
+          type empty;
         }
         leaf no-neighbor-down-notification {
-          type empty;
           description "Don't inform other protocols about neighbor down events";
+          type empty;
         }
         leaf ipsec-sa {
+          description "IPSec security association name";
           type string {
             length "1 .. 32";
           }
-          description "IPSec security association name";
         }
         list topology {
-          description "Topology specific attributes";
           key name;
           ordered-by user;
+          description "Topology specific attributes";
           leaf name {
-            type string;
             description "Topology name";
+            type string;
           }
           leaf disable {
-            type empty;
             description "Disable this topology";
+            type empty;
           }
           leaf metric {
-            type uint16 {
-              range "1 .. 65535";
-            }
             description "Topology metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
         }
         leaf transmit-interval {
-          type uint32 {
-            range "1 .. 4294967295";
-          }
           description "OSPF packet transmit interval (milliseconds)";
           status deprecated;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 4294967295";
+            }
+          }
         }
         container bfd-liveness-detection {
           description "Bidirectional Forwarding Detection options";
           leaf version {
+            description "BFD protocol version number";
+            default "automatic";
             type enumeration {
               enum 0 {
                 description "BFD version 0 (deprecated)";
@@ -10115,87 +11926,126 @@ module junos-conf-protocols {
                 description "Choose BFD version automatically";
               }
             }
-            default "automatic";
-            description "BFD protocol version number";
           }
           leaf minimum-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit and receive interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf minimum-transmit-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit interval";
             status deprecated;
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf minimum-receive-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum receive interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf multiplier {
-            type uint32 {
-              range "1 .. 255";
-            }
-            default "3";
             description "Detection time multiplier";
+            default "3";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf inline-disable {
-            type empty;
             description "Disable inline mode for this BFD session";
+            type empty;
           }
           leaf pdu-size {
-            type uint32 {
-              range "24 .. 9000";
-            }
-            default "24";
             description "BFD transport protocol payload size";
+            default "24";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "24 .. 9000";
+              }
+            }
           }
           choice adaptation-choice {
             case case_1 {
               leaf no-adaptation {
-                type empty;
                 description "Disable adaptation";
+                type empty;
               }
             }
           }
           container transmit-interval {
             description "Transmit-interval options";
             leaf minimum-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf threshold {
-              type uint32;
               description "High transmit interval triggering a trap";
               units milliseconds;
+              type union {
+                type uint32;
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
           }
           container detection-time {
             description "Detection-time options";
             leaf threshold {
-              type uint32;
               description "High detection-time triggering a trap";
               units milliseconds;
+              type union {
+                type uint32;
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
           }
           container authentication {
             description "Authentication options";
             leaf key-chain {
-              type string;
               description "Key chain name";
+              type string;
             }
             leaf algorithm {
+              description "Algorithm name";
               type enumeration {
                 enum simple-password {
                   description "Simple password";
@@ -10213,107 +12063,136 @@ module junos-conf-protocols {
                   description "Meticulous keyed secure hash algorithm (SHA1) ";
                 }
               }
-              description "Algorithm name";
             }
             leaf loose-check {
-              type empty;
               description "Verify authentication only if authentication is negotiated";
+              type empty;
             }
           }
           container echo {
             description "Echo mode parameters";
             leaf minimum-interval {
-              type uint32 {
-                range "100 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "100 .. 255000";
+                }
+              }
             }
           }
           container echo-lite {
             description "Echo-lite more parameters";
             leaf minimum-interval {
-              type uint32 {
-                range "100 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "100 .. 255000";
+                }
+              }
             }
           }
           leaf full-neighbors-only {
-            type empty;
             description "Setup BFD sessions only to Full neighbors";
+            type empty;
           }
           leaf holddown-interval {
-            type uint32 {
-              range "0 .. 255000";
-            }
             description "Time to hold the session-UP notification to the client";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 255000";
+              }
+            }
           }
         }
         leaf dynamic-neighbors {
-          type empty;
           description "Learn neighbors dynamically on a p2mp interface";
+          type empty;
         }
         leaf no-advertise-adjacency-segment {
-          type empty;
           description "Do not advertise an adjacency segment for this interface";
+          type empty;
         }
         list neighbor {
-          description "NBMA neighbor";
           key name;
           ordered-by user;
+          description "NBMA neighbor";
           leaf name {
-            type "jt:ipaddr";
             description "Address of neighbor";
+            type "jt:ipaddr";
           }
           leaf eligible {
-            type empty;
             description "Eligible to be DR on an NBMA network";
+            type empty;
           }
         }
         leaf poll-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Poll interval for NBMA interfaces";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf no-interface-state-traps {
-          type empty;
           description "Do not send interface state change traps";
+          type empty;
         }
         leaf strict-bfd {
-          type empty;
           description "Enable strict bfd over this interface";
+          type empty;
         }
         container post-convergence-lfa {
-          description "Protect interface using post-convergence backup path";
           presence "enable post-convergence-lfa";
+          description "Protect interface using post-convergence backup path";
           container node-protection {
-            description "Compute backup path assuming node failure";
             presence "enable node-protection";
+            description "Compute backup path assuming node failure";
             leaf cost {
-              type uint16 {
-                range "1 .. 65535";
-              }
               description "Cost for node protection";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 65535";
+                }
+              }
             }
           }
           leaf srlg-protection {
-            type empty;
             description "Compute backup path assuming SRLG failure";
+            type empty;
           }
           leaf fate-sharing-protection {
-            type empty;
             description "Compute backup path assuming fate-sharing group failure";
+            type empty;
           }
         }
         leaf te-metric {
-          type uint32 {
-            range "1 .. 4294967295";
-          }
           description "Traffic engineering metric";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 4294967295";
+            }
+          }
         }
         container ldp-synchronization {
           description "Advertise maximum metric until LDP is operational";
@@ -10329,24 +12208,34 @@ module junos-conf-protocols {
                 container index {
                   description "Adjacency SID indexed from SRGB";
                   leaf index-number {
-                    type uint32 {
-                      range "0 .. 199999";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "0 .. 199999";
+                      }
                     }
                   }
                 }
               }
               case case_2 {
                 leaf label {
-                  type uint32 {
-                    range "16 .. 1048575";
-                  }
                   description "Adjacency SID from static label pool";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "16 .. 1048575";
+                    }
+                  }
                 }
               }
               case case_3 {
                 leaf dynamic {
-                  type empty;
                   description "Dynamically allocate an adjacency segment";
+                  type empty;
                 }
               }
             }
@@ -10358,36 +12247,46 @@ module junos-conf-protocols {
                 container index {
                   description "Adjacency SID indexed from SRGB";
                   leaf index-number {
-                    type uint32 {
-                      range "0 .. 199999";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "0 .. 199999";
+                      }
                     }
                   }
                 }
               }
               case case_2 {
                 leaf label {
-                  type uint32 {
-                    range "16 .. 1048575";
-                  }
                   description "Adjacency SID from static label pool";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "16 .. 1048575";
+                    }
+                  }
                 }
               }
               case case_3 {
                 leaf dynamic {
-                  type empty;
                   description "Dynamically allocate an adjacency segment";
+                  type empty;
                 }
               }
             }
           }
         }
         list lan-neighbor {
-          description "Configuration specific to a LAN neighbor";
           key name;
           ordered-by user;
+          description "Configuration specific to a LAN neighbor";
           leaf name {
-            type "jt:ipaddr";
             description "Address of neighbor";
+            type "jt:ipaddr";
           }
           container ipv4-adjacency-segment {
             description "Configure ipv4 adjacency segment";
@@ -10398,24 +12297,34 @@ module junos-conf-protocols {
                   container index {
                     description "Adjacency SID indexed from SRGB";
                     leaf index-number {
-                      type uint32 {
-                        range "0 .. 199999";
+                      type union {
+                        type string {
+                          pattern "<.*>|$.*";
+                        }
+                        type uint32 {
+                          range "0 .. 199999";
+                        }
                       }
                     }
                   }
                 }
                 case case_2 {
                   leaf label {
-                    type uint32 {
-                      range "16 .. 1048575";
-                    }
                     description "Adjacency SID from static label pool";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "16 .. 1048575";
+                      }
+                    }
                   }
                 }
                 case case_3 {
                   leaf dynamic {
-                    type empty;
                     description "Dynamically allocate an adjacency segment";
+                    type empty;
                   }
                 }
               }
@@ -10427,24 +12336,34 @@ module junos-conf-protocols {
                   container index {
                     description "Adjacency SID indexed from SRGB";
                     leaf index-number {
-                      type uint32 {
-                        range "0 .. 199999";
+                      type union {
+                        type string {
+                          pattern "<.*>|$.*";
+                        }
+                        type uint32 {
+                          range "0 .. 199999";
+                        }
                       }
                     }
                   }
                 }
                 case case_2 {
                   leaf label {
-                    type uint32 {
-                      range "16 .. 1048575";
-                    }
                     description "Adjacency SID from static label pool";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "16 .. 1048575";
+                      }
+                    }
                   }
                 }
                 case case_3 {
                   leaf dynamic {
-                    type empty;
                     description "Dynamically allocate an adjacency segment";
+                    type empty;
                   }
                 }
               }
@@ -10452,56 +12371,86 @@ module junos-conf-protocols {
           }
         }
         leaf delay-metric {
-          type uint32 {
-            range "0 .. 16777215";
-          }
           description "Delay metric";
           units microseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 16777215";
+            }
+          }
         }
         container delay-measurement {
-          description "Enable delay measurement";
           presence "enable delay-measurement";
+          description "Enable delay measurement";
           leaf probe-interval {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Probe interval";
             units seconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf probe-count {
-            type uint32 {
-              range "1 .. 15";
-            }
             description "Probe count";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 15";
+              }
+            }
           }
           container advertisement {
             description "Delay advertisement";
             container periodic {
               description "Periodic advertisement parameters";
               leaf threshold {
-                type uint32 {
-                  range "0 .. 100";
-                }
                 description "Threshold";
                 units percentage;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 100";
+                  }
+                }
               }
               leaf interval {
-                type uint32 {
-                  range "30 .. 3600";
-                }
                 description "Interval";
                 units seconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "30 .. 3600";
+                  }
+                }
               }
             }
             container accelerated {
-              description "Accelerated advertisement parameters";
               presence "enable accelerated";
+              description "Accelerated advertisement parameters";
               leaf threshold {
-                type uint32 {
-                  range "0 .. 100";
-                }
                 description "Threshold";
                 units percentage;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 100";
+                  }
+                }
               }
             }
           }
@@ -10509,96 +12458,131 @@ module junos-conf-protocols {
         container application-specific {
           description "Advertise application-specific TE attributes";
           list attribute-group {
-            description "Link attribute group name";
             key name;
-            max-elements 1;
             ordered-by user;
+            description "Link attribute group name";
+            max-elements 1;
             leaf name {
-              type string;
               description "Link attribute group name";
+              type string;
             }
             leaf te-metric {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Traffic engineering metric for this attribute group";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
             leaf-list admin-group {
-              type string;
-              description "Administrative groups for this attribute-group";
-              max-elements 16;
               ordered-by user;
+              description "Administrative groups for this attribute-group";
+              type string;
+              max-elements 16;
             }
             leaf delay-metric {
-              type uint32 {
-                range "0 .. 16777215";
-              }
               description "Delay metric for this attribute-group";
               units microseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "0 .. 16777215";
+                }
+              }
             }
             leaf advertise-interface-delay {
-              type empty;
               description "Use interface specific static/dynamic delay values as applicable in ASLA Sub-TLVs";
+              type empty;
             }
             container application {
               description "Standard Applications part of this attribute-group";
               leaf flex-algorithm {
-                type empty;
                 description "Set X flag in standard application bit mask";
+                type empty;
               }
             }
           }
         }
       }
       leaf no-context-identifier-advertisement {
-        type empty;
         description "Disable context identifier advertisments in this area";
+        type empty;
       }
       list peer-interface {
-        description "Configuration for peer interface";
         key name;
         ordered-by user;
+        description "Configuration for peer interface";
         leaf name {
-          type string;
           description "Name of peer interface";
+          type string;
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable OSPF on this control peer";
+              type empty;
             }
           }
         }
         leaf retransmit-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Retransmission interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf transit-delay {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Transit delay (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf hello-interval {
-          type uint32 {
-            range "1 .. 255";
-          }
           description "Hello interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255";
+            }
+          }
         }
         leaf dead-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Dead interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf mtu {
-          type uint32 {
-            range "128 .. 65535";
-          }
           description "Maximum OSPF packet size";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "128 .. 65535";
+            }
+          }
         }
         choice auth {
           case case_1 {
@@ -10611,99 +12595,119 @@ module junos-conf-protocols {
               description "Authentication key";
               status deprecated;
               leaf keyname {
-                type "jt:unreadable";
                 description "Authentication key value";
+                type "jt:unreadable";
               }
               leaf key-id {
-                type uint32 {
-                  range "0 .. 255";
-                }
                 description "Key ID for MD5 authentication";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 255";
+                  }
+                }
               }
             }
           }
         }
         leaf demand-circuit {
-          type empty;
           description "Interface functions as a demand circuit";
+          type empty;
         }
         leaf flood-reduction {
-          type empty;
           description "Enable flood reduction";
+          type empty;
         }
         leaf no-neighbor-down-notification {
-          type empty;
           description "Don't inform other protocols about neighbor down events";
+          type empty;
         }
       }
       leaf no-source-packet-routing {
-        type empty;
         description "Disable SPRING in this area";
+        type empty;
       }
       list context-identifier {
-        description "Configure context identifier in support of edge protection";
         key name;
         ordered-by user;
+        description "Configure context identifier in support of edge protection";
         leaf name {
-          type "jt:ipv4addr";
           description "Context identifier";
+          type "jt:ipv4addr";
         }
       }
       list label-switched-path {
-        description "Configuration for advertisement of a label-switched path";
         key name;
         ordered-by user;
+        description "Configuration for advertisement of a label-switched path";
         leaf name {
+          description "Name of label-switched path to be advertised";
           type string {
             length "1 .. 64";
           }
-          description "Name of label-switched path to be advertised";
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable OSPF on this label-switched path";
+              type empty;
             }
           }
         }
         leaf metric {
-          type uint16 {
-            range "1 .. 65535";
-          }
           description "Interface metric";
-        }
-        list topology {
-          description "Topology specific attributes";
-          key name;
-          ordered-by user;
-          leaf name {
-            type string;
-            description "Topology name";
-          }
-          leaf disable {
-            type empty;
-            description "Disable this topology";
-          }
-          leaf metric {
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
             type uint16 {
               range "1 .. 65535";
             }
+          }
+        }
+        list topology {
+          key name;
+          ordered-by user;
+          description "Topology specific attributes";
+          leaf name {
+            description "Topology name";
+            type string;
+          }
+          leaf disable {
+            description "Disable this topology";
+            type empty;
+          }
+          leaf metric {
             description "Topology metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
@@ -10713,8 +12717,8 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable OSPF";
+          type empty;
         }
       }
     }
@@ -10723,47 +12727,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum spf {
@@ -10862,110 +12871,145 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf prefix-export-limit {
-      type uint32 {
-        range "0 .. 4294967295";
-      }
       description "Maximum number of prefixes that can be exported";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 4294967295";
+        }
+      }
     }
     container rib-groups {
       description "Routing table groups for importing OSPF routes";
       leaf inet {
-        type string;
         description "Name of the IPv4/v6 routing table group";
+        type string;
       }
       leaf inet3 {
-        type string;
         description "Name of the IPv4/v6 inet.3 routing table group";
+        type string;
       }
     }
     leaf job-stats {
-      type empty;
       description "Collect job statistics";
+      type empty;
     }
     container overload {
-      description "Set the overload mode (repel transit traffic)";
       presence "enable overload";
+      description "Set the overload mode (repel transit traffic)";
       leaf timeout {
-        type uint32 {
-          range "60 .. 3600";
-        }
         description "Time after which overload mode is reset";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "60 .. 3600";
+          }
+        }
       }
       leaf allow-route-leaking {
-        type empty;
         description "Allow routes to be leaked when overload is configured";
+        type empty;
       }
       leaf stub-network {
-        type empty;
         description "Advertise Stub Network with maximum metric";
+        type empty;
       }
       leaf intra-area-prefix {
-        type empty;
         description "Advertise Intra Area Prefix with maximum metric";
+        type empty;
       }
       leaf as-external {
-        type empty;
         description "Advertise As External with maximum usable metric";
+        type empty;
       }
     }
     container database-protection {
-      description "Configure database protection attributes";
       presence "enable database-protection";
+      description "Configure database protection attributes";
       leaf maximum-lsa {
-        type uint32 {
-          range "1 .. 1000000";
-        }
         description "Maximum allowed non self-generated LSAs";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 1000000";
+          }
+        }
       }
       leaf warning-only {
-        type empty;
         description "Emit only a warning when LSA maximum limit is exceeded";
+        type empty;
       }
       leaf warning-threshold {
-        type uint8 {
-          range "30 .. 100";
-        }
         description "Percentage of LSA maximum above which to trigger warning";
         units percent;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint8 {
+            range "30 .. 100";
+          }
+        }
       }
       leaf ignore-count {
-        type uint8 {
-          range "1 .. 32";
-        }
         description "Maximum number of times to go into ignore state";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint8 {
+            range "1 .. 32";
+          }
+        }
       }
       leaf ignore-time {
-        type uint16 {
-          range "30 .. 3600";
-        }
         description "Time to stay in ignore state and ignore all neighbors";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "30 .. 3600";
+          }
+        }
       }
       leaf reset-time {
-        type uint32 {
-          range "60 .. 86400";
-        }
         description "Time after which the ignore count gets reset to zero";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "60 .. 86400";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -10973,55 +13017,66 @@ module junos-conf-protocols {
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable OSPF graceful restart capability";
+            type empty;
           }
         }
       }
       leaf restart-duration {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Time for all neighbors to become full";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
       leaf notify-duration {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Time to send all max-aged grace LSAs";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
       container helper-disable {
-        description "Disable graceful restart helper capability";
         presence "enable helper-disable";
+        description "Disable graceful restart helper capability";
         choice disable-choices {
           case case_1 {
             leaf standard {
-              type empty;
               description "Disable helper-mode for rfc3623 based GR";
+              type empty;
             }
           }
           case case_2 {
             leaf restart-signaling {
-              type empty;
               description "Disable helper mode for restart-signaling ";
+              type empty;
             }
           }
           case case_3 {
             leaf both {
-              type empty;
               description "Disable helper mode for both the types of GR";
+              type empty;
             }
           }
         }
       }
       leaf no-strict-lsa-checking {
-        type empty;
         description "Do not abort graceful helper mode upon LSA changes";
+        type empty;
       }
     }
     leaf route-type-community {
+      description "Specify BGP extended community value to encode OSPF route type";
       type enumeration {
         enum iana {
           description "BGP extended community value used is 0x0306";
@@ -11030,21 +13085,20 @@ module junos-conf-protocols {
           description "Vendor BGP extended community value used is 0x8000";
         }
       }
-      description "Specify BGP extended community value to encode OSPF route type";
     }
     container domain-id {
       description "Configure domain ID";
       choice domain_id_or_disable {
         case case_1 {
           leaf domain-id {
-            type string;
             description "Domain ID";
+            type string;
           }
         }
         case case_2 {
           leaf disable {
-            type empty;
             description "Disable domain ID";
+            type empty;
           }
         }
       }
@@ -11052,87 +13106,117 @@ module junos-conf-protocols {
     choice domain_vpn_tag_or_disable {
       case case_1 {
         leaf domain-vpn-tag {
-          type uint32 {
-            range "0 .. 4294967295";
-          }
           description "Domain VPN tag for external LSA";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 4294967295";
+            }
+          }
         }
       }
       case case_2 {
         leaf no-domain-vpn-tag {
-          type empty;
           description "Disable domain VPN tag";
+          type empty;
         }
       }
     }
     leaf preference {
-      type uint32;
       description "Preference of internal routes";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf external-preference {
-      type uint32;
       description "Preference of external routes";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf labeled-preference {
-      type uint32;
       description "Preference of labeled routes";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf-list export {
-      type "jt:policy-algebra";
-      description "Export policy";
       ordered-by user;
+      description "Export policy";
+      type "jt:policy-algebra";
     }
     leaf-list import {
-      type "jt:policy-algebra";
-      description "Import policy (for external routes or setting priority)";
       ordered-by user;
+      description "Import policy (for external routes or setting priority)";
+      type "jt:policy-algebra";
     }
     leaf reference-bandwidth {
-      type string;
       description "Bandwidth for calculating metric defaults";
+      type string;
     }
     leaf lsa-refresh-interval {
-      type uint32 {
-        range "25 .. 50";
-      }
-      default "50";
       description "LSA refresh interval (minutes)";
+      default "50";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "25 .. 50";
+        }
+      }
     }
     leaf spf-delay {
-      type uint32 {
-        range "50 .. 8000";
-      }
       description "Time to wait before running an SPF";
       status deprecated;
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "50 .. 8000";
+        }
+      }
     }
     leaf no-rfc-1583 {
-      type empty;
       description "Disable RFC1583 compatibility";
+      type empty;
     }
     leaf forwarding-address-to-broadcast {
-      type empty;
       description "Set forwarding address in Type 5 LSA in broadcast network";
+      type empty;
     }
     choice nssa-abr-option {
       case case_1 {
         leaf no-nssa-abr {
-          type empty;
           description "Disable full NSSA functionality at ABR";
+          type empty;
         }
       }
     }
     container sham-link {
-      description "Configure parameters for sham links";
       presence "enable sham-link";
+      description "Configure parameters for sham links";
       leaf local {
-        type "jt:ipaddr";
         description "Local sham link endpoint address";
+        type "jt:ipaddr";
       }
       leaf no-advertise-local {
-        type empty;
         description "Don't advertise local sham link endpoint as stub in router LSA";
         status deprecated;
+        type empty;
       }
     }
   }
@@ -11141,68 +13225,79 @@ module junos-conf-protocols {
     choice authentication-type {
       case case_1 {
         leaf simple-password {
-          type "jt:unreadable";
           description "Authentication key";
+          type "jt:unreadable";
         }
       }
       case case_2 {
         list md5 {
-          description "MD5 authentication key";
           key name;
           ordered-by user;
+          description "MD5 authentication key";
           leaf name {
-            type uint32 {
-              range "0 .. 255";
-            }
             description "Key ID for MD5 authentication";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 255";
+              }
+            }
           }
           leaf key {
-            type "jt:unreadable";
             description "MD5 authentication key value";
+            type "jt:unreadable";
           }
           leaf start-time {
-            type "jt:time";
             description "Start time for key transmission (YYYY-MM-DD.HH:MM)";
+            type "jt:time";
           }
         }
       }
       case case_3 {
         list multi-active-md5 {
-          description "Authentication Multiple active MD5 keys";
           key name;
           ordered-by user;
+          description "Authentication Multiple active MD5 keys";
           leaf name {
-            type uint32 {
-              range "0 .. 255";
-            }
             description "Key ID for MD5 authentication";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 255";
+              }
+            }
           }
           leaf key {
-            type "jt:unreadable";
             description "MD5 authentication key value";
+            type "jt:unreadable";
           }
           leaf delete-if-not-inuse {
-            type empty;
             description "Delete this key if not in use";
+            type empty;
           }
         }
       }
       case case_4 {
         leaf keychain {
+          description "Key chain name";
           type string {
             length "1 .. 128";
           }
-          description "Key chain name";
         }
       }
     }
   }
   grouping juniper-protocols-ospf3 {
     list realm {
-      description "OSPFv3 realm configuration";
       key name;
       ordered-by user;
+      description "OSPFv3 realm configuration";
       leaf name {
+        description "OSPFv3 realm name";
         type enumeration {
           enum ipv6-unicast {
             description "IPv6 unicast realm";
@@ -11217,157 +13312,206 @@ module junos-conf-protocols {
             description "IPv4 multicast realm";
           }
         }
-        description "OSPFv3 realm name";
       }
       list topology {
-        description "Topology parameters";
         key name;
         ordered-by user;
+        description "Topology parameters";
         leaf name {
-          type string;
           description "Topology name";
+          type string;
         }
         leaf disable {
-          type empty;
           description "Disable this topology";
+          type empty;
         }
         leaf topology-id {
-          type uint8 {
-            range "32 .. 127";
-          }
           description "Topology identifier";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint8 {
+              range "32 .. 127";
+            }
+          }
         }
         leaf overload {
-          type empty;
           description "Set the overload mode (repel transit traffic)";
+          type empty;
         }
         leaf rib-group {
-          type string;
           description "Routing table group for importing routes";
+          type string;
         }
         container spf-options {
           description "Configure options for SPF";
           container microloop-avoidance {
             description "Configure microloop avoidance mechanism";
             container post-convergence-path {
-              description "Temporarily install post-convergence path for routes potentially affected by microloops";
               presence "enable post-convergence-path";
+              description "Temporarily install post-convergence path for routes potentially affected by microloops";
               leaf delay {
-                type uint32 {
-                  range "500 .. 60000";
-                }
                 description "Time after which temporary post-convergence paths are removed";
                 units milliseconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "500 .. 60000";
+                  }
+                }
               }
               leaf maximum-labels {
-                type uint32 {
-                  range "2 .. 8";
-                }
                 description "Maximum number of labels installed for post-convergence paths";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "2 .. 8";
+                  }
+                }
               }
             }
           }
           leaf delay {
-            type uint32 {
-              range "50 .. 8000";
-            }
             description "Time to wait before running an SPF";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "50 .. 8000";
+              }
+            }
           }
           leaf holddown {
-            type uint32 {
-              range "2000 .. 20000";
-            }
             description "Time to hold down before running an SPF";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2000 .. 20000";
+              }
+            }
           }
           leaf rapid-runs {
-            type uint32 {
-              range "1 .. 10";
-            }
             description "Number of maximum rapid SPF runs before holddown";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 10";
+              }
+            }
           }
           leaf no-ignore-our-externals {
-            type empty;
             description "Do not ignore self-generated external and NSSA LSAs";
+            type empty;
           }
         }
         container backup-spf-options {
           description "Configure options for backup SPF";
           container remote-backup-calculation {
-            description "Calculate Remote LFA backup nexthops";
             presence "enable remote-backup-calculation";
+            description "Calculate Remote LFA backup nexthops";
             container pq-nodes-nearest-to-source {
               description "PQ nodes selection based upon nearest to source";
               leaf percent {
-                type uint32 {
-                  range "10 .. 100";
-                }
                 description "Selection percentage for nearest to source";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "10 .. 100";
+                  }
+                }
               }
             }
           }
           container use-post-convergence-lfa {
-            description "Calculate post-convergence backup paths";
             presence "enable use-post-convergence-lfa";
+            description "Calculate post-convergence backup paths";
             leaf maximum-labels {
-              type uint32 {
-                range "2 .. 8";
-              }
               description "Maximum number of labels installed for post-convergence paths";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "2 .. 8";
+                }
+              }
             }
             leaf maximum-backup-paths {
-              type uint32 {
-                range "1 .. 8";
-              }
               description "Maximum number of equal-cost post-convergence paths installed";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 8";
+                }
+              }
             }
           }
           leaf use-source-packet-routing {
-            type empty;
             description "Use spring backup paths for inet.0 routes";
+            type empty;
           }
           leaf disable {
-            type empty;
             description "Do not run backup SPF";
+            type empty;
           }
           leaf no-install {
-            type empty;
             description "Do not install backup nexthops into the RIB";
+            type empty;
           }
           leaf downstream-paths-only {
-            type empty;
             description "Use only downstream backup paths";
+            type empty;
           }
           container per-prefix-calculation {
             description "Calculate backup nexthops for non-best prefix originators";
             leaf stubs {
-              type empty;
               description "Per prefix calculation for stubs only";
+              type empty;
             }
             leaf summary {
-              type empty;
               description "Per prefix calculation for summary originators only";
+              type empty;
             }
             leaf externals {
-              type empty;
               description "Per prefix calculation for externals";
+              type empty;
             }
             leaf all {
-              type empty;
               description "Per prefix calculation for all";
+              type empty;
             }
           }
           leaf node-link-degradation {
-            type empty;
             description "Degrade to link protection when nodelink protection not available";
+            type empty;
           }
         }
         leaf prefix-export-limit {
-          type uint32 {
-            range "0 .. 4294967295";
-          }
           description "Maximum number of prefixes that can be exported";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 4294967295";
+            }
+          }
         }
       }
       container spf-options {
@@ -11375,158 +13519,198 @@ module junos-conf-protocols {
         container microloop-avoidance {
           description "Configure microloop avoidance mechanism";
           container post-convergence-path {
-            description "Temporarily install post-convergence path for routes potentially affected by microloops";
             presence "enable post-convergence-path";
+            description "Temporarily install post-convergence path for routes potentially affected by microloops";
             leaf delay {
-              type uint32 {
-                range "500 .. 60000";
-              }
               description "Time after which temporary post-convergence paths are removed";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "500 .. 60000";
+                }
+              }
             }
             leaf maximum-labels {
-              type uint32 {
-                range "2 .. 8";
-              }
               description "Maximum number of labels installed for post-convergence paths";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "2 .. 8";
+                }
+              }
             }
           }
         }
         leaf delay {
-          type uint32 {
-            range "50 .. 8000";
-          }
           description "Time to wait before running an SPF";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "50 .. 8000";
+            }
+          }
         }
         leaf holddown {
-          type uint32 {
-            range "2000 .. 20000";
-          }
           description "Time to hold down before running an SPF";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2000 .. 20000";
+            }
+          }
         }
         leaf rapid-runs {
-          type uint32 {
-            range "1 .. 10";
-          }
           description "Number of maximum rapid SPF runs before holddown";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 10";
+            }
+          }
         }
         leaf no-ignore-our-externals {
-          type empty;
           description "Do not ignore self-generated external and NSSA LSAs";
+          type empty;
         }
       }
       container backup-spf-options {
         description "Configure options for backup SPF";
         container remote-backup-calculation {
-          description "Calculate Remote LFA backup nexthops";
           presence "enable remote-backup-calculation";
+          description "Calculate Remote LFA backup nexthops";
           container pq-nodes-nearest-to-source {
             description "PQ nodes selection based upon nearest to source";
             leaf percent {
-              type uint32 {
-                range "10 .. 100";
-              }
               description "Selection percentage for nearest to source";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "10 .. 100";
+                }
+              }
             }
           }
         }
         container use-post-convergence-lfa {
-          description "Calculate post-convergence backup paths";
           presence "enable use-post-convergence-lfa";
+          description "Calculate post-convergence backup paths";
           leaf maximum-labels {
-            type uint32 {
-              range "2 .. 8";
-            }
             description "Maximum number of labels installed for post-convergence paths";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 8";
+              }
+            }
           }
           leaf maximum-backup-paths {
-            type uint32 {
-              range "1 .. 8";
-            }
             description "Maximum number of equal-cost post-convergence paths installed";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 8";
+              }
+            }
           }
         }
         leaf use-source-packet-routing {
-          type empty;
           description "Use spring backup paths for inet.0 routes";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Do not run backup SPF";
+          type empty;
         }
         leaf no-install {
-          type empty;
           description "Do not install backup nexthops into the RIB";
+          type empty;
         }
         leaf downstream-paths-only {
-          type empty;
           description "Use only downstream backup paths";
+          type empty;
         }
         container per-prefix-calculation {
           description "Calculate backup nexthops for non-best prefix originators";
           leaf stubs {
-            type empty;
             description "Per prefix calculation for stubs only";
+            type empty;
           }
           leaf summary {
-            type empty;
             description "Per prefix calculation for summary originators only";
+            type empty;
           }
           leaf externals {
-            type empty;
             description "Per prefix calculation for externals";
+            type empty;
           }
           leaf all {
-            type empty;
             description "Per prefix calculation for all";
+            type empty;
           }
         }
         leaf node-link-degradation {
-          type empty;
           description "Degrade to link protection when nodelink protection not available";
+          type empty;
         }
       }
       container traffic-engineering {
-        description "Configure traffic engineering attributes";
         presence "enable traffic-engineering";
+        description "Configure traffic engineering attributes";
         leaf no-topology {
-          type empty;
           description "Disable dissemination of TE link-state topology information";
+          type empty;
         }
         leaf multicast-rpf-routes {
-          type empty;
           description "Install routes for multicast RPF checks into inet.2";
+          type empty;
         }
         leaf l3-unicast-topology {
-          type empty;
           description "Download IGP topology into TED";
+          type empty;
         }
         container ignore-lsp-metrics {
-          description "Ignore label-switched path metrics when doing shortcuts";
           presence "enable ignore-lsp-metrics";
+          description "Ignore label-switched path metrics when doing shortcuts";
           leaf unconfigured-only {
-            type empty;
             description "Ignore lsp metrics for unconfigured only";
+            type empty;
           }
         }
         container shortcuts {
-          description "Use label-switched paths as next hops, if possible";
           presence "enable shortcuts";
+          description "Use label-switched paths as next hops, if possible";
           leaf ignore-lsp-metrics {
-            type empty;
             description "Ignore label-switched path metrics when doing shortcuts";
             status deprecated;
+            type empty;
           }
           leaf lsp-metric-into-summary {
-            type empty;
             description "Advertise LSP metric into summary LSAs";
+            type empty;
           }
           list family {
-            description "Address family specific traffic-engineering attributes";
             key name;
             ordered-by user;
+            description "Address family specific traffic-engineering attributes";
             leaf name {
               type enumeration {
                 enum inet {
@@ -11540,251 +13724,326 @@ module junos-conf-protocols {
           }
         }
         leaf advertise-unnumbered-interfaces {
-          type empty;
           description "Advertise unnumbered interfaces";
+          type empty;
         }
         leaf credibility-protocol-preference {
-          type empty;
           description "TED protocol credibility follows protocol preference";
+          type empty;
         }
         container advertisement {
           description "Advertise TE parameters even if RSVP is not turned on";
           leaf always {
-            type empty;
             description "Advertise TE parameters in TE LSAs";
+            type empty;
           }
         }
         container tunnel-source-protocol {
           description "Protocols from which to pick label-switched paths";
           container rsvp {
-            description "Pick label-switched paths from rsvp";
             presence "enable rsvp";
+            description "Pick label-switched paths from rsvp";
             leaf preference {
-              type uint32 {
-                range "1 .. 255";
-              }
               description "Preference for label-switched paths from this protocol";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255";
+                }
+              }
             }
           }
           container spring-te {
-            description "Pick label-switched paths from spring-te";
             presence "enable spring-te";
+            description "Pick label-switched paths from spring-te";
             leaf preference {
-              type uint32 {
-                range "1 .. 255";
-              }
               description "Preference for label-switched paths from this protocol";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255";
+                }
+              }
             }
           }
         }
       }
       container source-packet-routing {
-        description "Enable source packet routing (SPRING)";
         presence "enable source-packet-routing";
+        description "Enable source packet routing (SPRING)";
         container adjacency-segment {
           description "Attributes for adjacency segments in spring";
           leaf hold-time {
-            type uint32 {
-              range "180000 .. 900000";
-            }
             description "Retain time of Adjacency segment after isolating from an interface";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "180000 .. 900000";
+              }
+            }
           }
         }
         leaf-list prefix-segment {
-          type "jt:policy-algebra";
-          description "Prefix Segment policy";
           ordered-by user;
+          description "Prefix Segment policy";
+          type "jt:policy-algebra";
         }
         leaf explicit-null {
-          type empty;
           description "Set E and P bits in all Prefix SID advertisements";
+          type empty;
         }
         container node-segment {
-          description "Enable support for Node segments in SPRING";
           presence "enable node-segment";
+          description "Enable support for Node segments in SPRING";
           leaf ipv4-index {
-            type uint32 {
-              range "0 .. 199999";
-            }
             description "Set ipv4 node segment index";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 199999";
+              }
+            }
           }
           leaf index-range {
-            type uint32 {
-              range "32 .. 16385";
-            }
             description "Set range of node segment indices allowed";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "32 .. 16385";
+              }
+            }
           }
         }
         container srgb {
           description "Set the SRGB global block in SPRING";
           leaf start-label {
-            type uint32;
             description "Start range for SRGB label block";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32;
+            }
           }
           leaf index-range {
-            type uint32;
             description "Index to the SRGB start label block";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32;
+            }
           }
         }
         leaf mapping-server {
-          type string;
           description "Mapping server name";
+          type string;
         }
         leaf install-prefix-sid-for-best-route {
-          type empty;
           description "For best route install a exact prefix sid route";
+          type empty;
         }
         leaf ldp-stitching {
-          type empty;
           description "Enable SR to LDP stitching";
+          type empty;
         }
         leaf-list flex-algorithm {
-          type uint32 {
-            range "128 .. 255";
-          }
           description "Flex-algorithms we would like to participate in";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "128 .. 255";
+            }
+          }
           max-elements 16;
         }
         leaf strict-asla-based-flex-algorithm {
-          type empty;
           description "Flex-Algorithm to ignore links not having ASLA sub-TLVs";
+          type empty;
         }
         container sensor-based-stats {
           description "Configure sensor based stats in SPRING";
           container per-interface-per-member-link {
             description "Configure sensor based stats per nexthop";
             leaf ingress {
-              type empty;
               description "Enable sensor based stats on ingress interface";
+              type empty;
             }
             leaf egress {
-              type empty;
               description "Enable sensor based stats on egress interface";
+              type empty;
             }
           }
           container per-sid {
             description "Configure sensor based stats per spring route";
             leaf ingress {
-              type empty;
               description "Enable sensor based stats for per-sid ingress accounting";
+              type empty;
             }
             leaf egress {
-              type empty;
               description "Enable sensor based stats for IP-MPLS egress accounting";
+              type empty;
             }
           }
         }
       }
       list area {
-        description "Configure an OSPF area";
         key name;
         ordered-by user;
+        description "Configure an OSPF area";
         leaf name {
-          type "jt:areaid";
           description "Area ID";
+          type "jt:areaid";
         }
         choice stub-option {
           case case_1 {
             container stub {
-              description "Configure a stub area";
               presence "enable stub";
+              description "Configure a stub area";
               leaf default-metric {
-                type uint32 {
-                  range "1 .. 16777215";
-                }
                 description "Metric for the default route in this stub area";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "1 .. 16777215";
+                  }
+                }
               }
               choice summaries-choice {
                 leaf summaries {
-                  type empty;
                   description "Flood summary LSAs into this stub area";
+                  type empty;
                 }
                 leaf no-summaries {
-                  type empty;
                   description "Don't flood summary LSAs into this stub area";
+                  type empty;
                 }
               }
             }
           }
           case case_2 {
             container nssa {
-              description "Configure a not-so-stubby area";
               presence "enable nssa";
+              description "Configure a not-so-stubby area";
               container default-lsa {
-                description "Configure a default LSA";
                 presence "enable default-lsa";
+                description "Configure a default LSA";
                 leaf default-metric {
-                  type uint32 {
-                    range "1 .. 16777215";
-                  }
                   description "Metric for the default route in this area";
-                }
-                leaf metric-type {
-                  type uint32 {
-                    range "1 .. 2";
-                  }
-                  description "External metric type for the default type 7 LSA";
-                }
-                leaf type-7 {
-                  type empty;
-                  description "Flood type 7 default LSA if no-summaries is configured";
-                }
-              }
-              leaf default-metric {
-                type uint32 {
-                  range "1 .. 16777215";
-                }
-                description "Metric for the default route in this area";
-                status deprecated;
-              }
-              leaf metric-type {
-                type uint32 {
-                  range "1 .. 2";
-                }
-                description "External metric type for the default type 7 LSA";
-                status deprecated;
-              }
-              choice summaries-choice {
-                leaf summaries {
-                  type empty;
-                  description "Flood summary LSAs into this NSSA area";
-                }
-                leaf no-summaries {
-                  type empty;
-                  description "Don't flood summary LSAs into this NSSA area";
-                }
-              }
-              list area-range {
-                description "Configure NSSA area ranges";
-                key name;
-                ordered-by user;
-                leaf name {
-                  type "jt:ipprefix";
-                  description "Range to summarize NSSA routes in this area";
-                }
-                leaf restrict {
-                  type empty;
-                  description "Restrict advertisement of this area range";
-                }
-                leaf exact {
-                  type empty;
-                  description "Enforce exact match for advertisement of this area range";
-                }
-                container override-metric {
-                  description "Override the dynamic metric for this area-range";
-                  presence "enable override-metric";
-                  leaf metric {
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
                     type uint32 {
                       range "1 .. 16777215";
                     }
-                    description "Metric value";
                   }
-                  leaf metric-type {
+                }
+                leaf metric-type {
+                  description "External metric type for the default type 7 LSA";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
                     type uint32 {
                       range "1 .. 2";
                     }
-                    default "1";
+                  }
+                }
+                leaf type-7 {
+                  description "Flood type 7 default LSA if no-summaries is configured";
+                  type empty;
+                }
+              }
+              leaf default-metric {
+                description "Metric for the default route in this area";
+                status deprecated;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "1 .. 16777215";
+                  }
+                }
+              }
+              leaf metric-type {
+                description "External metric type for the default type 7 LSA";
+                status deprecated;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "1 .. 2";
+                  }
+                }
+              }
+              choice summaries-choice {
+                leaf summaries {
+                  description "Flood summary LSAs into this NSSA area";
+                  type empty;
+                }
+                leaf no-summaries {
+                  description "Don't flood summary LSAs into this NSSA area";
+                  type empty;
+                }
+              }
+              list area-range {
+                key name;
+                ordered-by user;
+                description "Configure NSSA area ranges";
+                leaf name {
+                  description "Range to summarize NSSA routes in this area";
+                  type "jt:ipprefix";
+                }
+                leaf restrict {
+                  description "Restrict advertisement of this area range";
+                  type empty;
+                }
+                leaf exact {
+                  description "Enforce exact match for advertisement of this area range";
+                  type empty;
+                }
+                container override-metric {
+                  presence "enable override-metric";
+                  description "Override the dynamic metric for this area-range";
+                  leaf metric {
+                    description "Metric value";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "1 .. 16777215";
+                      }
+                    }
+                  }
+                  leaf metric-type {
                     description "Set the metric type for the override metric";
+                    default "1";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "1 .. 2";
+                      }
+                    }
                   }
                 }
               }
@@ -11792,49 +14051,56 @@ module junos-conf-protocols {
           }
         }
         list area-range {
-          description "Configure area ranges";
           key name;
           ordered-by user;
+          description "Configure area ranges";
           leaf name {
-            type "jt:ipprefix";
             description "Range to summarize routes in this area";
+            type "jt:ipprefix";
           }
           leaf restrict {
-            type empty;
             description "Restrict advertisement of this area range";
+            type empty;
           }
           leaf exact {
-            type empty;
             description "Enforce exact match for advertisement of this area range";
+            type empty;
           }
           leaf override-metric {
-            type uint32 {
-              range "1 .. 16777215";
-            }
             description "Override the dynamic metric for this area-range";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 16777215";
+              }
+            }
           }
         }
         leaf-list network-summary-export {
-          type "jt:policy-algebra";
-          description "Export policy for Type 3 Summary LSAs";
           ordered-by user;
+          description "Export policy for Type 3 Summary LSAs";
+          type "jt:policy-algebra";
         }
         leaf-list network-summary-import {
-          type "jt:policy-algebra";
-          description "Import policy for Type 3 Summary LSAs";
           ordered-by user;
+          description "Import policy for Type 3 Summary LSAs";
+          type "jt:policy-algebra";
         }
         leaf-list inter-area-prefix-export {
-          type "jt:policy-algebra";
-          description "Export policy for Inter Area Prefix LSAs";
           ordered-by user;
+          description "Export policy for Inter Area Prefix LSAs";
+          type "jt:policy-algebra";
         }
         leaf-list inter-area-prefix-import {
-          type "jt:policy-algebra";
-          description "Import policy for Inter Area Prefix LSAs";
           ordered-by user;
+          description "Import policy for Inter Area Prefix LSAs";
+          type "jt:policy-algebra";
         }
         leaf authentication-type {
+          description "Authentication type";
+          status deprecated;
           type enumeration {
             enum none {
               description "No authentication";
@@ -11849,58 +14115,81 @@ module junos-conf-protocols {
               status deprecated;
             }
           }
-          description "Authentication type";
-          status deprecated;
         }
         list virtual-link {
-          description "Configure virtual links";
           key "neighbor-id transit-area";
           ordered-by user;
+          description "Configure virtual links";
           leaf neighbor-id {
-            type "jt:ipv4addr";
             description "Router ID of a virtual neighbor";
+            type "jt:ipv4addr";
           }
           leaf transit-area {
-            type "jt:areaid";
             description "Transit area in common with virtual neighbor";
+            type "jt:areaid";
           }
           choice enable-disable {
             case case_1 {
               leaf disable {
-                type empty;
                 description "Disable this virtual link";
+                type empty;
               }
             }
           }
           leaf retransmit-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Retransmission interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf transit-delay {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Transit delay (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf hello-interval {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Hello interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf dead-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Dead interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf mtu {
-            type uint32 {
-              range "128 .. 65535";
-            }
             description "Maximum OSPF packet size";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "128 .. 65535";
+              }
+            }
           }
           choice auth {
             case case_1 {
@@ -11913,153 +14202,189 @@ module junos-conf-protocols {
                 description "Authentication key";
                 status deprecated;
                 leaf keyname {
-                  type "jt:unreadable";
                   description "Authentication key value";
+                  type "jt:unreadable";
                 }
                 leaf key-id {
-                  type uint32 {
-                    range "0 .. 255";
-                  }
                   description "Key ID for MD5 authentication";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "0 .. 255";
+                    }
+                  }
                 }
               }
             }
           }
           leaf demand-circuit {
-            type empty;
             description "Interface functions as a demand circuit";
+            type empty;
           }
           leaf flood-reduction {
-            type empty;
             description "Enable flood reduction";
+            type empty;
           }
           leaf no-neighbor-down-notification {
-            type empty;
             description "Don't inform other protocols about neighbor down events";
+            type empty;
           }
           leaf ipsec-sa {
+            description "IPSec security association name";
             type string {
               length "1 .. 32";
             }
-            description "IPSec security association name";
           }
           list topology {
-            description "Topology specific attributes";
             key name;
             ordered-by user;
+            description "Topology specific attributes";
             leaf name {
-              type string;
               description "Topology name";
+              type string;
             }
             leaf disable {
-              type empty;
               description "Disable this topology";
+              type empty;
             }
             leaf metric {
-              type uint16 {
-                range "1 .. 65535";
-              }
               description "Topology metric";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 65535";
+                }
+              }
             }
             container bandwidth-based-metrics {
               description "Configure bandwidth based metrics";
               list bandwidth {
-                description "Bandwidth threshold";
                 key name;
+                description "Bandwidth threshold";
                 leaf name {
                   type string;
                 }
                 leaf metric {
-                  type uint16 {
-                    range "1 .. 65535";
-                  }
                   description "Metric associated with specified bandwidth";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint16 {
+                      range "1 .. 65535";
+                    }
+                  }
                 }
               }
             }
           }
         }
         list sham-link-remote {
-          description "Configure parameters for remote sham link endpoint";
           key name;
           ordered-by user;
+          description "Configure parameters for remote sham link endpoint";
           leaf name {
-            type "jt:ipaddr";
             description "Remote sham link endpoint address";
+            type "jt:ipaddr";
           }
           leaf metric {
-            type uint16 {
-              range "1 .. 65535";
-            }
             description "Sham link metric";
-          }
-          leaf ipsec-sa {
-            type string {
-              length "1 .. 32";
-            }
-            description "IPSec security association name";
-          }
-          leaf demand-circuit {
-            type empty;
-            description "Interface functions as a demand circuit";
-          }
-          leaf flood-reduction {
-            type empty;
-            description "Enable flood reduction";
-          }
-          list topology {
-            description "Topology specific attributes";
-            key name;
-            ordered-by user;
-            leaf name {
-              type string;
-              description "Topology name";
-            }
-            leaf disable {
-              type empty;
-              description "Disable this topology";
-            }
-            leaf metric {
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
               type uint16 {
                 range "1 .. 65535";
               }
+            }
+          }
+          leaf ipsec-sa {
+            description "IPSec security association name";
+            type string {
+              length "1 .. 32";
+            }
+          }
+          leaf demand-circuit {
+            description "Interface functions as a demand circuit";
+            type empty;
+          }
+          leaf flood-reduction {
+            description "Enable flood reduction";
+            type empty;
+          }
+          list topology {
+            key name;
+            ordered-by user;
+            description "Topology specific attributes";
+            leaf name {
+              description "Topology name";
+              type string;
+            }
+            leaf disable {
+              description "Disable this topology";
+              type empty;
+            }
+            leaf metric {
               description "Topology metric";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 65535";
+                }
+              }
             }
             container bandwidth-based-metrics {
               description "Configure bandwidth based metrics";
               list bandwidth {
-                description "Bandwidth threshold";
                 key name;
+                description "Bandwidth threshold";
                 leaf name {
                   type string;
                 }
                 leaf metric {
-                  type uint16 {
-                    range "1 .. 65535";
-                  }
                   description "Metric associated with specified bandwidth";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint16 {
+                      range "1 .. 65535";
+                    }
+                  }
                 }
               }
             }
           }
         }
         list interface {
-          description "Include an interface in this area";
           key name;
           ordered-by user;
+          description "Include an interface in this area";
           leaf name {
-            type "jt:ipv4addr-or-interface";
             description "Interface name";
+            type union {
+              type "jt:ipv4addr-or-interface";
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
           choice enable-disable {
             case case_1 {
               leaf disable {
-                type empty;
                 description "Disable OSPF on this interface";
+                type empty;
               }
             }
           }
           leaf interface-type {
+            description "Type of interface";
             type enumeration {
               enum nbma {
                 description "Nonbroadcast multiaccess";
@@ -12074,110 +14399,149 @@ module junos-conf-protocols {
                 description "Point-to-multipoint over LAN mode";
               }
             }
-            description "Type of interface";
           }
           choice protection-type {
             case case_1 {
               leaf link-protection {
-                type empty;
                 description "Protect interface from link faults only";
+                type empty;
               }
             }
             case case_2 {
               leaf node-link-protection {
-                type empty;
                 description "Protect interface from both link and node faults";
+                type empty;
               }
             }
           }
           leaf no-eligible-backup {
-            type empty;
             description "Not eligible to backup traffic from protected interfaces";
+            type empty;
           }
           leaf no-eligible-remote-backup {
-            type empty;
             description "Not eligible for Remote-LFA backup traffic from protected interfaces";
+            type empty;
           }
           container passive {
-            description "Do not run OSPF, but advertise it";
             presence "enable passive";
+            description "Do not run OSPF, but advertise it";
             container traffic-engineering {
               description "Advertise TE link information";
               leaf remote-node-id {
-                type "jt:ipaddr";
                 description "Remote address of the link";
+                type "jt:ipaddr";
               }
               leaf remote-node-router-id {
-                type "jt:ipv4addr";
                 description "TE Router-ID of the remote node";
+                type "jt:ipv4addr";
               }
             }
           }
           leaf secondary {
-            type empty;
             description "Treat interface as secondary";
+            type empty;
           }
           leaf own-router-lsa {
-            type empty;
             description "Generate a separate router LSA for this interface";
+            type empty;
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
           leaf metric {
-            type uint16 {
-              range "1 .. 65535";
-            }
             description "Interface metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf priority {
-            type uint32 {
-              range "0 .. 255";
-            }
             description "Designated router priority";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 255";
+              }
+            }
           }
           leaf retransmit-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Retransmission interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf transit-delay {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Transit delay (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf hello-interval {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Hello interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf dead-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Dead interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf mtu {
-            type uint32 {
-              range "128 .. 65535";
-            }
             description "Maximum OSPF packet size";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "128 .. 65535";
+              }
+            }
           }
           choice auth {
             case case_1 {
@@ -12190,81 +14554,103 @@ module junos-conf-protocols {
                 description "Authentication key";
                 status deprecated;
                 leaf keyname {
-                  type "jt:unreadable";
                   description "Authentication key value";
+                  type "jt:unreadable";
                 }
                 leaf key-id {
-                  type uint32 {
-                    range "0 .. 255";
-                  }
                   description "Key ID for MD5 authentication";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "0 .. 255";
+                    }
+                  }
                 }
               }
             }
           }
           leaf demand-circuit {
-            type empty;
             description "Interface functions as a demand circuit";
+            type empty;
           }
           leaf flood-reduction {
-            type empty;
             description "Enable flood reduction";
+            type empty;
           }
           leaf no-neighbor-down-notification {
-            type empty;
             description "Don't inform other protocols about neighbor down events";
+            type empty;
           }
           leaf ipsec-sa {
+            description "IPSec security association name";
             type string {
               length "1 .. 32";
             }
-            description "IPSec security association name";
           }
           list topology {
-            description "Topology specific attributes";
             key name;
             ordered-by user;
+            description "Topology specific attributes";
             leaf name {
-              type string;
               description "Topology name";
+              type string;
             }
             leaf disable {
-              type empty;
               description "Disable this topology";
+              type empty;
             }
             leaf metric {
-              type uint16 {
-                range "1 .. 65535";
-              }
               description "Topology metric";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 65535";
+                }
+              }
             }
             container bandwidth-based-metrics {
               description "Configure bandwidth based metrics";
               list bandwidth {
-                description "Bandwidth threshold";
                 key name;
+                description "Bandwidth threshold";
                 leaf name {
                   type string;
                 }
                 leaf metric {
-                  type uint16 {
-                    range "1 .. 65535";
-                  }
                   description "Metric associated with specified bandwidth";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint16 {
+                      range "1 .. 65535";
+                    }
+                  }
                 }
               }
             }
           }
           leaf transmit-interval {
-            type uint32 {
-              range "1 .. 4294967295";
-            }
             description "OSPF packet transmit interval (milliseconds)";
             status deprecated;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 4294967295";
+              }
+            }
           }
           container bfd-liveness-detection {
             description "Bidirectional Forwarding Detection options";
             leaf version {
+              description "BFD protocol version number";
+              default "automatic";
               type enumeration {
                 enum 0 {
                   description "BFD version 0 (deprecated)";
@@ -12276,87 +14662,126 @@ module junos-conf-protocols {
                   description "Choose BFD version automatically";
                 }
               }
-              default "automatic";
-              description "BFD protocol version number";
             }
             leaf minimum-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf minimum-transmit-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit interval";
               status deprecated;
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf minimum-receive-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf multiplier {
-              type uint32 {
-                range "1 .. 255";
-              }
-              default "3";
               description "Detection time multiplier";
+              default "3";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255";
+                }
+              }
             }
             leaf inline-disable {
-              type empty;
               description "Disable inline mode for this BFD session";
+              type empty;
             }
             leaf pdu-size {
-              type uint32 {
-                range "24 .. 9000";
-              }
-              default "24";
               description "BFD transport protocol payload size";
+              default "24";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "24 .. 9000";
+                }
+              }
             }
             choice adaptation-choice {
               case case_1 {
                 leaf no-adaptation {
-                  type empty;
                   description "Disable adaptation";
+                  type empty;
                 }
               }
             }
             container transmit-interval {
               description "Transmit-interval options";
               leaf minimum-interval {
-                type uint32 {
-                  range "1 .. 255000";
-                }
                 description "Minimum transmit interval";
                 units milliseconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "1 .. 255000";
+                  }
+                }
               }
               leaf threshold {
-                type uint32;
                 description "High transmit interval triggering a trap";
                 units milliseconds;
+                type union {
+                  type uint32;
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                }
               }
             }
             container detection-time {
               description "Detection-time options";
               leaf threshold {
-                type uint32;
                 description "High detection-time triggering a trap";
                 units milliseconds;
+                type union {
+                  type uint32;
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                }
               }
             }
             container authentication {
               description "Authentication options";
               leaf key-chain {
-                type string;
                 description "Key chain name";
+                type string;
               }
               leaf algorithm {
+                description "Algorithm name";
                 type enumeration {
                   enum simple-password {
                     description "Simple password";
@@ -12374,107 +14799,136 @@ module junos-conf-protocols {
                     description "Meticulous keyed secure hash algorithm (SHA1) ";
                   }
                 }
-                description "Algorithm name";
               }
               leaf loose-check {
-                type empty;
                 description "Verify authentication only if authentication is negotiated";
+                type empty;
               }
             }
             container echo {
               description "Echo mode parameters";
               leaf minimum-interval {
-                type uint32 {
-                  range "100 .. 255000";
-                }
                 description "Minimum transmit and receive interval";
                 units milliseconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "100 .. 255000";
+                  }
+                }
               }
             }
             container echo-lite {
               description "Echo-lite more parameters";
               leaf minimum-interval {
-                type uint32 {
-                  range "100 .. 255000";
-                }
                 description "Minimum transmit and receive interval";
                 units milliseconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "100 .. 255000";
+                  }
+                }
               }
             }
             leaf full-neighbors-only {
-              type empty;
               description "Setup BFD sessions only to Full neighbors";
+              type empty;
             }
             leaf holddown-interval {
-              type uint32 {
-                range "0 .. 255000";
-              }
               description "Time to hold the session-UP notification to the client";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "0 .. 255000";
+                }
+              }
             }
           }
           leaf dynamic-neighbors {
-            type empty;
             description "Learn neighbors dynamically on a p2mp interface";
+            type empty;
           }
           leaf no-advertise-adjacency-segment {
-            type empty;
             description "Do not advertise an adjacency segment for this interface";
+            type empty;
           }
           list neighbor {
-            description "NBMA neighbor";
             key name;
             ordered-by user;
+            description "NBMA neighbor";
             leaf name {
-              type "jt:ipaddr";
               description "Address of neighbor";
+              type "jt:ipaddr";
             }
             leaf eligible {
-              type empty;
               description "Eligible to be DR on an NBMA network";
+              type empty;
             }
           }
           leaf poll-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Poll interval for NBMA interfaces";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf no-interface-state-traps {
-            type empty;
             description "Do not send interface state change traps";
+            type empty;
           }
           leaf strict-bfd {
-            type empty;
             description "Enable strict bfd over this interface";
+            type empty;
           }
           container post-convergence-lfa {
-            description "Protect interface using post-convergence backup path";
             presence "enable post-convergence-lfa";
+            description "Protect interface using post-convergence backup path";
             container node-protection {
-              description "Compute backup path assuming node failure";
               presence "enable node-protection";
+              description "Compute backup path assuming node failure";
               leaf cost {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Cost for node protection";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
             leaf srlg-protection {
-              type empty;
               description "Compute backup path assuming SRLG failure";
+              type empty;
             }
             leaf fate-sharing-protection {
-              type empty;
               description "Compute backup path assuming fate-sharing group failure";
+              type empty;
             }
           }
           leaf te-metric {
-            type uint32 {
-              range "1 .. 4294967295";
-            }
             description "Traffic engineering metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 4294967295";
+              }
+            }
           }
           container ldp-synchronization {
             description "Advertise maximum metric until LDP is operational";
@@ -12490,24 +14944,34 @@ module junos-conf-protocols {
                   container index {
                     description "Adjacency SID indexed from SRGB";
                     leaf index-number {
-                      type uint32 {
-                        range "0 .. 199999";
+                      type union {
+                        type string {
+                          pattern "<.*>|$.*";
+                        }
+                        type uint32 {
+                          range "0 .. 199999";
+                        }
                       }
                     }
                   }
                 }
                 case case_2 {
                   leaf label {
-                    type uint32 {
-                      range "16 .. 1048575";
-                    }
                     description "Adjacency SID from static label pool";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "16 .. 1048575";
+                      }
+                    }
                   }
                 }
                 case case_3 {
                   leaf dynamic {
-                    type empty;
                     description "Dynamically allocate an adjacency segment";
+                    type empty;
                   }
                 }
               }
@@ -12519,36 +14983,46 @@ module junos-conf-protocols {
                   container index {
                     description "Adjacency SID indexed from SRGB";
                     leaf index-number {
-                      type uint32 {
-                        range "0 .. 199999";
+                      type union {
+                        type string {
+                          pattern "<.*>|$.*";
+                        }
+                        type uint32 {
+                          range "0 .. 199999";
+                        }
                       }
                     }
                   }
                 }
                 case case_2 {
                   leaf label {
-                    type uint32 {
-                      range "16 .. 1048575";
-                    }
                     description "Adjacency SID from static label pool";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "16 .. 1048575";
+                      }
+                    }
                   }
                 }
                 case case_3 {
                   leaf dynamic {
-                    type empty;
                     description "Dynamically allocate an adjacency segment";
+                    type empty;
                   }
                 }
               }
             }
           }
           list lan-neighbor {
-            description "Configuration specific to a LAN neighbor";
             key name;
             ordered-by user;
+            description "Configuration specific to a LAN neighbor";
             leaf name {
-              type "jt:ipaddr";
               description "Address of neighbor";
+              type "jt:ipaddr";
             }
             container ipv4-adjacency-segment {
               description "Configure ipv4 adjacency segment";
@@ -12559,24 +15033,34 @@ module junos-conf-protocols {
                     container index {
                       description "Adjacency SID indexed from SRGB";
                       leaf index-number {
-                        type uint32 {
-                          range "0 .. 199999";
+                        type union {
+                          type string {
+                            pattern "<.*>|$.*";
+                          }
+                          type uint32 {
+                            range "0 .. 199999";
+                          }
                         }
                       }
                     }
                   }
                   case case_2 {
                     leaf label {
-                      type uint32 {
-                        range "16 .. 1048575";
-                      }
                       description "Adjacency SID from static label pool";
+                      type union {
+                        type string {
+                          pattern "<.*>|$.*";
+                        }
+                        type uint32 {
+                          range "16 .. 1048575";
+                        }
+                      }
                     }
                   }
                   case case_3 {
                     leaf dynamic {
-                      type empty;
                       description "Dynamically allocate an adjacency segment";
+                      type empty;
                     }
                   }
                 }
@@ -12588,24 +15072,34 @@ module junos-conf-protocols {
                     container index {
                       description "Adjacency SID indexed from SRGB";
                       leaf index-number {
-                        type uint32 {
-                          range "0 .. 199999";
+                        type union {
+                          type string {
+                            pattern "<.*>|$.*";
+                          }
+                          type uint32 {
+                            range "0 .. 199999";
+                          }
                         }
                       }
                     }
                   }
                   case case_2 {
                     leaf label {
-                      type uint32 {
-                        range "16 .. 1048575";
-                      }
                       description "Adjacency SID from static label pool";
+                      type union {
+                        type string {
+                          pattern "<.*>|$.*";
+                        }
+                        type uint32 {
+                          range "16 .. 1048575";
+                        }
+                      }
                     }
                   }
                   case case_3 {
                     leaf dynamic {
-                      type empty;
                       description "Dynamically allocate an adjacency segment";
+                      type empty;
                     }
                   }
                 }
@@ -12613,56 +15107,86 @@ module junos-conf-protocols {
             }
           }
           leaf delay-metric {
-            type uint32 {
-              range "0 .. 16777215";
-            }
             description "Delay metric";
             units microseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 16777215";
+              }
+            }
           }
           container delay-measurement {
-            description "Enable delay measurement";
             presence "enable delay-measurement";
+            description "Enable delay measurement";
             leaf probe-interval {
-              type uint32 {
-                range "1 .. 255";
-              }
               description "Probe interval";
               units seconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255";
+                }
+              }
             }
             leaf probe-count {
-              type uint32 {
-                range "1 .. 15";
-              }
               description "Probe count";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 15";
+                }
+              }
             }
             container advertisement {
               description "Delay advertisement";
               container periodic {
                 description "Periodic advertisement parameters";
                 leaf threshold {
-                  type uint32 {
-                    range "0 .. 100";
-                  }
                   description "Threshold";
                   units percentage;
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "0 .. 100";
+                    }
+                  }
                 }
                 leaf interval {
-                  type uint32 {
-                    range "30 .. 3600";
-                  }
                   description "Interval";
                   units seconds;
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "30 .. 3600";
+                    }
+                  }
                 }
               }
               container accelerated {
-                description "Accelerated advertisement parameters";
                 presence "enable accelerated";
+                description "Accelerated advertisement parameters";
                 leaf threshold {
-                  type uint32 {
-                    range "0 .. 100";
-                  }
                   description "Threshold";
                   units percentage;
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "0 .. 100";
+                    }
+                  }
                 }
               }
             }
@@ -12670,96 +15194,131 @@ module junos-conf-protocols {
           container application-specific {
             description "Advertise application-specific TE attributes";
             list attribute-group {
-              description "Link attribute group name";
               key name;
-              max-elements 1;
               ordered-by user;
+              description "Link attribute group name";
+              max-elements 1;
               leaf name {
-                type string;
                 description "Link attribute group name";
+                type string;
               }
               leaf te-metric {
-                type uint32 {
-                  range "1 .. 4294967295";
-                }
                 description "Traffic engineering metric for this attribute group";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "1 .. 4294967295";
+                  }
+                }
               }
               leaf-list admin-group {
-                type string;
-                description "Administrative groups for this attribute-group";
-                max-elements 16;
                 ordered-by user;
+                description "Administrative groups for this attribute-group";
+                type string;
+                max-elements 16;
               }
               leaf delay-metric {
-                type uint32 {
-                  range "0 .. 16777215";
-                }
                 description "Delay metric for this attribute-group";
                 units microseconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 16777215";
+                  }
+                }
               }
               leaf advertise-interface-delay {
-                type empty;
                 description "Use interface specific static/dynamic delay values as applicable in ASLA Sub-TLVs";
+                type empty;
               }
               container application {
                 description "Standard Applications part of this attribute-group";
                 leaf flex-algorithm {
-                  type empty;
                   description "Set X flag in standard application bit mask";
+                  type empty;
                 }
               }
             }
           }
         }
         leaf no-context-identifier-advertisement {
-          type empty;
           description "Disable context identifier advertisments in this area";
+          type empty;
         }
         list peer-interface {
-          description "Configuration for peer interface";
           key name;
           ordered-by user;
+          description "Configuration for peer interface";
           leaf name {
-            type string;
             description "Name of peer interface";
+            type string;
           }
           choice enable-disable {
             case case_1 {
               leaf disable {
-                type empty;
                 description "Disable OSPF on this control peer";
+                type empty;
               }
             }
           }
           leaf retransmit-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Retransmission interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf transit-delay {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Transit delay (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf hello-interval {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Hello interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf dead-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Dead interval (seconds)";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf mtu {
-            type uint32 {
-              range "128 .. 65535";
-            }
             description "Maximum OSPF packet size";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "128 .. 65535";
+              }
+            }
           }
           choice auth {
             case case_1 {
@@ -12772,99 +15331,119 @@ module junos-conf-protocols {
                 description "Authentication key";
                 status deprecated;
                 leaf keyname {
-                  type "jt:unreadable";
                   description "Authentication key value";
+                  type "jt:unreadable";
                 }
                 leaf key-id {
-                  type uint32 {
-                    range "0 .. 255";
-                  }
                   description "Key ID for MD5 authentication";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "0 .. 255";
+                    }
+                  }
                 }
               }
             }
           }
           leaf demand-circuit {
-            type empty;
             description "Interface functions as a demand circuit";
+            type empty;
           }
           leaf flood-reduction {
-            type empty;
             description "Enable flood reduction";
+            type empty;
           }
           leaf no-neighbor-down-notification {
-            type empty;
             description "Don't inform other protocols about neighbor down events";
+            type empty;
           }
         }
         leaf no-source-packet-routing {
-          type empty;
           description "Disable SPRING in this area";
+          type empty;
         }
         list context-identifier {
-          description "Configure context identifier in support of edge protection";
           key name;
           ordered-by user;
+          description "Configure context identifier in support of edge protection";
           leaf name {
-            type "jt:ipv4addr";
             description "Context identifier";
+            type "jt:ipv4addr";
           }
         }
         list label-switched-path {
-          description "Configuration for advertisement of a label-switched path";
           key name;
           ordered-by user;
+          description "Configuration for advertisement of a label-switched path";
           leaf name {
+            description "Name of label-switched path to be advertised";
             type string {
               length "1 .. 64";
             }
-            description "Name of label-switched path to be advertised";
           }
           choice enable-disable {
             case case_1 {
               leaf disable {
-                type empty;
                 description "Disable OSPF on this label-switched path";
+                type empty;
               }
             }
           }
           leaf metric {
-            type uint16 {
-              range "1 .. 65535";
-            }
             description "Interface metric";
-          }
-          list topology {
-            description "Topology specific attributes";
-            key name;
-            ordered-by user;
-            leaf name {
-              type string;
-              description "Topology name";
-            }
-            leaf disable {
-              type empty;
-              description "Disable this topology";
-            }
-            leaf metric {
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
               type uint16 {
                 range "1 .. 65535";
               }
+            }
+          }
+          list topology {
+            key name;
+            ordered-by user;
+            description "Topology specific attributes";
+            leaf name {
+              description "Topology name";
+              type string;
+            }
+            leaf disable {
+              description "Disable this topology";
+              type empty;
+            }
+            leaf metric {
               description "Topology metric";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 65535";
+                }
+              }
             }
             container bandwidth-based-metrics {
               description "Configure bandwidth based metrics";
               list bandwidth {
-                description "Bandwidth threshold";
                 key name;
+                description "Bandwidth threshold";
                 leaf name {
                   type string;
                 }
                 leaf metric {
-                  type uint16 {
-                    range "1 .. 65535";
-                  }
                   description "Metric associated with specified bandwidth";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint16 {
+                      range "1 .. 65535";
+                    }
+                  }
                 }
               }
             }
@@ -12874,8 +15453,8 @@ module junos-conf-protocols {
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable OSPF";
+            type empty;
           }
         }
       }
@@ -12884,47 +15463,52 @@ module junos-conf-protocols {
         container file {
           description "Trace file options";
           leaf filename {
+            description "Name of file in which to write trace information";
             type string {
               length "1 .. 1024";
             }
-            description "Name of file in which to write trace information";
           }
           leaf replace {
-            type empty;
             description "Replace trace file rather than appending to it";
             status deprecated;
+            type empty;
           }
           leaf size {
-            type string;
             description "Maximum trace file size";
+            type string;
           }
           leaf files {
-            type uint32 {
-              range "2 .. 1000";
-            }
-            default "10";
             description "Maximum number of trace files";
+            default "10";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 1000";
+              }
+            }
           }
           leaf no-stamp {
-            type empty;
             description "Do not timestamp trace file";
             status deprecated;
+            type empty;
           }
           choice world-readable-choice {
             leaf world-readable {
-              type empty;
               description "Allow any user to read the log file";
+              type empty;
             }
             leaf no-world-readable {
-              type empty;
               description "Don't allow any user to read the log file";
+              type empty;
             }
           }
         }
         list flag {
-          description "Tracing parameters";
           key name;
           ordered-by user;
+          description "Tracing parameters";
           leaf name {
             type enumeration {
               enum spf {
@@ -13023,110 +15607,145 @@ module junos-conf-protocols {
             }
           }
           leaf send {
-            type empty;
             description "Trace transmitted packets";
+            type empty;
           }
           leaf receive {
-            type empty;
             description "Trace received packets";
+            type empty;
           }
           leaf detail {
-            type empty;
             description "Trace detailed information";
+            type empty;
           }
           leaf disable {
-            type empty;
             description "Disable this trace flag";
+            type empty;
           }
         }
       }
       leaf prefix-export-limit {
-        type uint32 {
-          range "0 .. 4294967295";
-        }
         description "Maximum number of prefixes that can be exported";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 4294967295";
+          }
+        }
       }
       container rib-groups {
         description "Routing table groups for importing OSPF routes";
         leaf inet {
-          type string;
           description "Name of the IPv4/v6 routing table group";
+          type string;
         }
         leaf inet3 {
-          type string;
           description "Name of the IPv4/v6 inet.3 routing table group";
+          type string;
         }
       }
       leaf job-stats {
-        type empty;
         description "Collect job statistics";
+        type empty;
       }
       container overload {
-        description "Set the overload mode (repel transit traffic)";
         presence "enable overload";
+        description "Set the overload mode (repel transit traffic)";
         leaf timeout {
-          type uint32 {
-            range "60 .. 3600";
-          }
           description "Time after which overload mode is reset";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "60 .. 3600";
+            }
+          }
         }
         leaf allow-route-leaking {
-          type empty;
           description "Allow routes to be leaked when overload is configured";
+          type empty;
         }
         leaf stub-network {
-          type empty;
           description "Advertise Stub Network with maximum metric";
+          type empty;
         }
         leaf intra-area-prefix {
-          type empty;
           description "Advertise Intra Area Prefix with maximum metric";
+          type empty;
         }
         leaf as-external {
-          type empty;
           description "Advertise As External with maximum usable metric";
+          type empty;
         }
       }
       container database-protection {
-        description "Configure database protection attributes";
         presence "enable database-protection";
+        description "Configure database protection attributes";
         leaf maximum-lsa {
-          type uint32 {
-            range "1 .. 1000000";
-          }
           description "Maximum allowed non self-generated LSAs";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 1000000";
+            }
+          }
         }
         leaf warning-only {
-          type empty;
           description "Emit only a warning when LSA maximum limit is exceeded";
+          type empty;
         }
         leaf warning-threshold {
-          type uint8 {
-            range "30 .. 100";
-          }
           description "Percentage of LSA maximum above which to trigger warning";
           units percent;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint8 {
+              range "30 .. 100";
+            }
+          }
         }
         leaf ignore-count {
-          type uint8 {
-            range "1 .. 32";
-          }
           description "Maximum number of times to go into ignore state";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint8 {
+              range "1 .. 32";
+            }
+          }
         }
         leaf ignore-time {
-          type uint16 {
-            range "30 .. 3600";
-          }
           description "Time to stay in ignore state and ignore all neighbors";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "30 .. 3600";
+            }
+          }
         }
         leaf reset-time {
-          type uint32 {
-            range "60 .. 86400";
-          }
           description "Time after which the ignore count gets reset to zero";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "60 .. 86400";
+            }
+          }
         }
       }
       container graceful-restart {
@@ -13134,55 +15753,66 @@ module junos-conf-protocols {
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable OSPF graceful restart capability";
+              type empty;
             }
           }
         }
         leaf restart-duration {
-          type uint32 {
-            range "1 .. 3600";
-          }
           description "Time for all neighbors to become full";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 3600";
+            }
+          }
         }
         leaf notify-duration {
-          type uint32 {
-            range "1 .. 3600";
-          }
           description "Time to send all max-aged grace LSAs";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 3600";
+            }
+          }
         }
         container helper-disable {
-          description "Disable graceful restart helper capability";
           presence "enable helper-disable";
+          description "Disable graceful restart helper capability";
           choice disable-choices {
             case case_1 {
               leaf standard {
-                type empty;
                 description "Disable helper-mode for rfc3623 based GR";
+                type empty;
               }
             }
             case case_2 {
               leaf restart-signaling {
-                type empty;
                 description "Disable helper mode for restart-signaling ";
+                type empty;
               }
             }
             case case_3 {
               leaf both {
-                type empty;
                 description "Disable helper mode for both the types of GR";
+                type empty;
               }
             }
           }
         }
         leaf no-strict-lsa-checking {
-          type empty;
           description "Do not abort graceful helper mode upon LSA changes";
+          type empty;
         }
       }
       leaf route-type-community {
+        description "Specify BGP extended community value to encode OSPF route type";
         type enumeration {
           enum iana {
             description "BGP extended community value used is 0x0306";
@@ -13191,21 +15821,20 @@ module junos-conf-protocols {
             description "Vendor BGP extended community value used is 0x8000";
           }
         }
-        description "Specify BGP extended community value to encode OSPF route type";
       }
       container domain-id {
         description "Configure domain ID";
         choice domain_id_or_disable {
           case case_1 {
             leaf domain-id {
-              type string;
               description "Domain ID";
+              type string;
             }
           }
           case case_2 {
             leaf disable {
-              type empty;
               description "Disable domain ID";
+              type empty;
             }
           }
         }
@@ -13213,239 +15842,319 @@ module junos-conf-protocols {
       choice domain_vpn_tag_or_disable {
         case case_1 {
           leaf domain-vpn-tag {
-            type uint32 {
-              range "0 .. 4294967295";
-            }
             description "Domain VPN tag for external LSA";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 4294967295";
+              }
+            }
           }
         }
         case case_2 {
           leaf no-domain-vpn-tag {
-            type empty;
             description "Disable domain VPN tag";
+            type empty;
           }
         }
       }
       leaf preference {
-        type uint32;
         description "Preference of internal routes";
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf external-preference {
-        type uint32;
         description "Preference of external routes";
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf labeled-preference {
-        type uint32;
         description "Preference of labeled routes";
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf-list export {
-        type "jt:policy-algebra";
-        description "Export policy";
         ordered-by user;
+        description "Export policy";
+        type "jt:policy-algebra";
       }
       leaf-list import {
-        type "jt:policy-algebra";
-        description "Import policy (for external routes or setting priority)";
         ordered-by user;
+        description "Import policy (for external routes or setting priority)";
+        type "jt:policy-algebra";
       }
       leaf reference-bandwidth {
-        type string;
         description "Bandwidth for calculating metric defaults";
+        type string;
       }
       leaf lsa-refresh-interval {
-        type uint32 {
-          range "25 .. 50";
-        }
-        default "50";
         description "LSA refresh interval (minutes)";
+        default "50";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "25 .. 50";
+          }
+        }
       }
       leaf spf-delay {
-        type uint32 {
-          range "50 .. 8000";
-        }
         description "Time to wait before running an SPF";
         status deprecated;
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "50 .. 8000";
+          }
+        }
       }
       leaf no-rfc-1583 {
-        type empty;
         description "Disable RFC1583 compatibility";
+        type empty;
       }
       leaf forwarding-address-to-broadcast {
-        type empty;
         description "Set forwarding address in Type 5 LSA in broadcast network";
+        type empty;
       }
       choice nssa-abr-option {
         case case_1 {
           leaf no-nssa-abr {
-            type empty;
             description "Disable full NSSA functionality at ABR";
+            type empty;
           }
         }
       }
       container sham-link {
-        description "Configure parameters for sham links";
         presence "enable sham-link";
+        description "Configure parameters for sham links";
         leaf local {
-          type "jt:ipaddr";
           description "Local sham link endpoint address";
+          type "jt:ipaddr";
         }
         leaf no-advertise-local {
-          type empty;
           description "Don't advertise local sham link endpoint as stub in router LSA";
           status deprecated;
+          type empty;
         }
       }
     }
     list topology {
-      description "Topology parameters";
       key name;
       ordered-by user;
+      description "Topology parameters";
       leaf name {
-        type string;
         description "Topology name";
+        type string;
       }
       leaf disable {
-        type empty;
         description "Disable this topology";
+        type empty;
       }
       leaf topology-id {
-        type uint8 {
-          range "32 .. 127";
-        }
         description "Topology identifier";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint8 {
+            range "32 .. 127";
+          }
+        }
       }
       leaf overload {
-        type empty;
         description "Set the overload mode (repel transit traffic)";
+        type empty;
       }
       leaf rib-group {
-        type string;
         description "Routing table group for importing routes";
+        type string;
       }
       container spf-options {
         description "Configure options for SPF";
         container microloop-avoidance {
           description "Configure microloop avoidance mechanism";
           container post-convergence-path {
-            description "Temporarily install post-convergence path for routes potentially affected by microloops";
             presence "enable post-convergence-path";
+            description "Temporarily install post-convergence path for routes potentially affected by microloops";
             leaf delay {
-              type uint32 {
-                range "500 .. 60000";
-              }
               description "Time after which temporary post-convergence paths are removed";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "500 .. 60000";
+                }
+              }
             }
             leaf maximum-labels {
-              type uint32 {
-                range "2 .. 8";
-              }
               description "Maximum number of labels installed for post-convergence paths";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "2 .. 8";
+                }
+              }
             }
           }
         }
         leaf delay {
-          type uint32 {
-            range "50 .. 8000";
-          }
           description "Time to wait before running an SPF";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "50 .. 8000";
+            }
+          }
         }
         leaf holddown {
-          type uint32 {
-            range "2000 .. 20000";
-          }
           description "Time to hold down before running an SPF";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2000 .. 20000";
+            }
+          }
         }
         leaf rapid-runs {
-          type uint32 {
-            range "1 .. 10";
-          }
           description "Number of maximum rapid SPF runs before holddown";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 10";
+            }
+          }
         }
         leaf no-ignore-our-externals {
-          type empty;
           description "Do not ignore self-generated external and NSSA LSAs";
+          type empty;
         }
       }
       container backup-spf-options {
         description "Configure options for backup SPF";
         container remote-backup-calculation {
-          description "Calculate Remote LFA backup nexthops";
           presence "enable remote-backup-calculation";
+          description "Calculate Remote LFA backup nexthops";
           container pq-nodes-nearest-to-source {
             description "PQ nodes selection based upon nearest to source";
             leaf percent {
-              type uint32 {
-                range "10 .. 100";
-              }
               description "Selection percentage for nearest to source";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "10 .. 100";
+                }
+              }
             }
           }
         }
         container use-post-convergence-lfa {
-          description "Calculate post-convergence backup paths";
           presence "enable use-post-convergence-lfa";
+          description "Calculate post-convergence backup paths";
           leaf maximum-labels {
-            type uint32 {
-              range "2 .. 8";
-            }
             description "Maximum number of labels installed for post-convergence paths";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 8";
+              }
+            }
           }
           leaf maximum-backup-paths {
-            type uint32 {
-              range "1 .. 8";
-            }
             description "Maximum number of equal-cost post-convergence paths installed";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 8";
+              }
+            }
           }
         }
         leaf use-source-packet-routing {
-          type empty;
           description "Use spring backup paths for inet.0 routes";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Do not run backup SPF";
+          type empty;
         }
         leaf no-install {
-          type empty;
           description "Do not install backup nexthops into the RIB";
+          type empty;
         }
         leaf downstream-paths-only {
-          type empty;
           description "Use only downstream backup paths";
+          type empty;
         }
         container per-prefix-calculation {
           description "Calculate backup nexthops for non-best prefix originators";
           leaf stubs {
-            type empty;
             description "Per prefix calculation for stubs only";
+            type empty;
           }
           leaf summary {
-            type empty;
             description "Per prefix calculation for summary originators only";
+            type empty;
           }
           leaf externals {
-            type empty;
             description "Per prefix calculation for externals";
+            type empty;
           }
           leaf all {
-            type empty;
             description "Per prefix calculation for all";
+            type empty;
           }
         }
         leaf node-link-degradation {
-          type empty;
           description "Degrade to link protection when nodelink protection not available";
+          type empty;
         }
       }
       leaf prefix-export-limit {
-        type uint32 {
-          range "0 .. 4294967295";
-        }
         description "Maximum number of prefixes that can be exported";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 4294967295";
+          }
+        }
       }
     }
     container spf-options {
@@ -13453,158 +16162,198 @@ module junos-conf-protocols {
       container microloop-avoidance {
         description "Configure microloop avoidance mechanism";
         container post-convergence-path {
-          description "Temporarily install post-convergence path for routes potentially affected by microloops";
           presence "enable post-convergence-path";
+          description "Temporarily install post-convergence path for routes potentially affected by microloops";
           leaf delay {
-            type uint32 {
-              range "500 .. 60000";
-            }
             description "Time after which temporary post-convergence paths are removed";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "500 .. 60000";
+              }
+            }
           }
           leaf maximum-labels {
-            type uint32 {
-              range "2 .. 8";
-            }
             description "Maximum number of labels installed for post-convergence paths";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 8";
+              }
+            }
           }
         }
       }
       leaf delay {
-        type uint32 {
-          range "50 .. 8000";
-        }
         description "Time to wait before running an SPF";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "50 .. 8000";
+          }
+        }
       }
       leaf holddown {
-        type uint32 {
-          range "2000 .. 20000";
-        }
         description "Time to hold down before running an SPF";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2000 .. 20000";
+          }
+        }
       }
       leaf rapid-runs {
-        type uint32 {
-          range "1 .. 10";
-        }
         description "Number of maximum rapid SPF runs before holddown";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 10";
+          }
+        }
       }
       leaf no-ignore-our-externals {
-        type empty;
         description "Do not ignore self-generated external and NSSA LSAs";
+        type empty;
       }
     }
     container backup-spf-options {
       description "Configure options for backup SPF";
       container remote-backup-calculation {
-        description "Calculate Remote LFA backup nexthops";
         presence "enable remote-backup-calculation";
+        description "Calculate Remote LFA backup nexthops";
         container pq-nodes-nearest-to-source {
           description "PQ nodes selection based upon nearest to source";
           leaf percent {
-            type uint32 {
-              range "10 .. 100";
-            }
             description "Selection percentage for nearest to source";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "10 .. 100";
+              }
+            }
           }
         }
       }
       container use-post-convergence-lfa {
-        description "Calculate post-convergence backup paths";
         presence "enable use-post-convergence-lfa";
+        description "Calculate post-convergence backup paths";
         leaf maximum-labels {
-          type uint32 {
-            range "2 .. 8";
-          }
           description "Maximum number of labels installed for post-convergence paths";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 8";
+            }
+          }
         }
         leaf maximum-backup-paths {
-          type uint32 {
-            range "1 .. 8";
-          }
           description "Maximum number of equal-cost post-convergence paths installed";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 8";
+            }
+          }
         }
       }
       leaf use-source-packet-routing {
-        type empty;
         description "Use spring backup paths for inet.0 routes";
+        type empty;
       }
       leaf disable {
-        type empty;
         description "Do not run backup SPF";
+        type empty;
       }
       leaf no-install {
-        type empty;
         description "Do not install backup nexthops into the RIB";
+        type empty;
       }
       leaf downstream-paths-only {
-        type empty;
         description "Use only downstream backup paths";
+        type empty;
       }
       container per-prefix-calculation {
         description "Calculate backup nexthops for non-best prefix originators";
         leaf stubs {
-          type empty;
           description "Per prefix calculation for stubs only";
+          type empty;
         }
         leaf summary {
-          type empty;
           description "Per prefix calculation for summary originators only";
+          type empty;
         }
         leaf externals {
-          type empty;
           description "Per prefix calculation for externals";
+          type empty;
         }
         leaf all {
-          type empty;
           description "Per prefix calculation for all";
+          type empty;
         }
       }
       leaf node-link-degradation {
-        type empty;
         description "Degrade to link protection when nodelink protection not available";
+        type empty;
       }
     }
     container traffic-engineering {
-      description "Configure traffic engineering attributes";
       presence "enable traffic-engineering";
+      description "Configure traffic engineering attributes";
       leaf no-topology {
-        type empty;
         description "Disable dissemination of TE link-state topology information";
+        type empty;
       }
       leaf multicast-rpf-routes {
-        type empty;
         description "Install routes for multicast RPF checks into inet.2";
+        type empty;
       }
       leaf l3-unicast-topology {
-        type empty;
         description "Download IGP topology into TED";
+        type empty;
       }
       container ignore-lsp-metrics {
-        description "Ignore label-switched path metrics when doing shortcuts";
         presence "enable ignore-lsp-metrics";
+        description "Ignore label-switched path metrics when doing shortcuts";
         leaf unconfigured-only {
-          type empty;
           description "Ignore lsp metrics for unconfigured only";
+          type empty;
         }
       }
       container shortcuts {
-        description "Use label-switched paths as next hops, if possible";
         presence "enable shortcuts";
+        description "Use label-switched paths as next hops, if possible";
         leaf ignore-lsp-metrics {
-          type empty;
           description "Ignore label-switched path metrics when doing shortcuts";
           status deprecated;
+          type empty;
         }
         leaf lsp-metric-into-summary {
-          type empty;
           description "Advertise LSP metric into summary LSAs";
+          type empty;
         }
         list family {
-          description "Address family specific traffic-engineering attributes";
           key name;
           ordered-by user;
+          description "Address family specific traffic-engineering attributes";
           leaf name {
             type enumeration {
               enum inet {
@@ -13618,251 +16367,326 @@ module junos-conf-protocols {
         }
       }
       leaf advertise-unnumbered-interfaces {
-        type empty;
         description "Advertise unnumbered interfaces";
+        type empty;
       }
       leaf credibility-protocol-preference {
-        type empty;
         description "TED protocol credibility follows protocol preference";
+        type empty;
       }
       container advertisement {
         description "Advertise TE parameters even if RSVP is not turned on";
         leaf always {
-          type empty;
           description "Advertise TE parameters in TE LSAs";
+          type empty;
         }
       }
       container tunnel-source-protocol {
         description "Protocols from which to pick label-switched paths";
         container rsvp {
-          description "Pick label-switched paths from rsvp";
           presence "enable rsvp";
+          description "Pick label-switched paths from rsvp";
           leaf preference {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Preference for label-switched paths from this protocol";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
         }
         container spring-te {
-          description "Pick label-switched paths from spring-te";
           presence "enable spring-te";
+          description "Pick label-switched paths from spring-te";
           leaf preference {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Preference for label-switched paths from this protocol";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
         }
       }
     }
     container source-packet-routing {
-      description "Enable source packet routing (SPRING)";
       presence "enable source-packet-routing";
+      description "Enable source packet routing (SPRING)";
       container adjacency-segment {
         description "Attributes for adjacency segments in spring";
         leaf hold-time {
-          type uint32 {
-            range "180000 .. 900000";
-          }
           description "Retain time of Adjacency segment after isolating from an interface";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "180000 .. 900000";
+            }
+          }
         }
       }
       leaf-list prefix-segment {
-        type "jt:policy-algebra";
-        description "Prefix Segment policy";
         ordered-by user;
+        description "Prefix Segment policy";
+        type "jt:policy-algebra";
       }
       leaf explicit-null {
-        type empty;
         description "Set E and P bits in all Prefix SID advertisements";
+        type empty;
       }
       container node-segment {
-        description "Enable support for Node segments in SPRING";
         presence "enable node-segment";
+        description "Enable support for Node segments in SPRING";
         leaf ipv4-index {
-          type uint32 {
-            range "0 .. 199999";
-          }
           description "Set ipv4 node segment index";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 199999";
+            }
+          }
         }
         leaf index-range {
-          type uint32 {
-            range "32 .. 16385";
-          }
           description "Set range of node segment indices allowed";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "32 .. 16385";
+            }
+          }
         }
       }
       container srgb {
         description "Set the SRGB global block in SPRING";
         leaf start-label {
-          type uint32;
           description "Start range for SRGB label block";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32;
+          }
         }
         leaf index-range {
-          type uint32;
           description "Index to the SRGB start label block";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32;
+          }
         }
       }
       leaf mapping-server {
-        type string;
         description "Mapping server name";
+        type string;
       }
       leaf install-prefix-sid-for-best-route {
-        type empty;
         description "For best route install a exact prefix sid route";
+        type empty;
       }
       leaf ldp-stitching {
-        type empty;
         description "Enable SR to LDP stitching";
+        type empty;
       }
       leaf-list flex-algorithm {
-        type uint32 {
-          range "128 .. 255";
-        }
         description "Flex-algorithms we would like to participate in";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "128 .. 255";
+          }
+        }
         max-elements 16;
       }
       leaf strict-asla-based-flex-algorithm {
-        type empty;
         description "Flex-Algorithm to ignore links not having ASLA sub-TLVs";
+        type empty;
       }
       container sensor-based-stats {
         description "Configure sensor based stats in SPRING";
         container per-interface-per-member-link {
           description "Configure sensor based stats per nexthop";
           leaf ingress {
-            type empty;
             description "Enable sensor based stats on ingress interface";
+            type empty;
           }
           leaf egress {
-            type empty;
             description "Enable sensor based stats on egress interface";
+            type empty;
           }
         }
         container per-sid {
           description "Configure sensor based stats per spring route";
           leaf ingress {
-            type empty;
             description "Enable sensor based stats for per-sid ingress accounting";
+            type empty;
           }
           leaf egress {
-            type empty;
             description "Enable sensor based stats for IP-MPLS egress accounting";
+            type empty;
           }
         }
       }
     }
     list area {
-      description "Configure an OSPF area";
       key name;
       ordered-by user;
+      description "Configure an OSPF area";
       leaf name {
-        type "jt:areaid";
         description "Area ID";
+        type "jt:areaid";
       }
       choice stub-option {
         case case_1 {
           container stub {
-            description "Configure a stub area";
             presence "enable stub";
+            description "Configure a stub area";
             leaf default-metric {
-              type uint32 {
-                range "1 .. 16777215";
-              }
               description "Metric for the default route in this stub area";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 16777215";
+                }
+              }
             }
             choice summaries-choice {
               leaf summaries {
-                type empty;
                 description "Flood summary LSAs into this stub area";
+                type empty;
               }
               leaf no-summaries {
-                type empty;
                 description "Don't flood summary LSAs into this stub area";
+                type empty;
               }
             }
           }
         }
         case case_2 {
           container nssa {
-            description "Configure a not-so-stubby area";
             presence "enable nssa";
+            description "Configure a not-so-stubby area";
             container default-lsa {
-              description "Configure a default LSA";
               presence "enable default-lsa";
+              description "Configure a default LSA";
               leaf default-metric {
-                type uint32 {
-                  range "1 .. 16777215";
-                }
                 description "Metric for the default route in this area";
-              }
-              leaf metric-type {
-                type uint32 {
-                  range "1 .. 2";
-                }
-                description "External metric type for the default type 7 LSA";
-              }
-              leaf type-7 {
-                type empty;
-                description "Flood type 7 default LSA if no-summaries is configured";
-              }
-            }
-            leaf default-metric {
-              type uint32 {
-                range "1 .. 16777215";
-              }
-              description "Metric for the default route in this area";
-              status deprecated;
-            }
-            leaf metric-type {
-              type uint32 {
-                range "1 .. 2";
-              }
-              description "External metric type for the default type 7 LSA";
-              status deprecated;
-            }
-            choice summaries-choice {
-              leaf summaries {
-                type empty;
-                description "Flood summary LSAs into this NSSA area";
-              }
-              leaf no-summaries {
-                type empty;
-                description "Don't flood summary LSAs into this NSSA area";
-              }
-            }
-            list area-range {
-              description "Configure NSSA area ranges";
-              key name;
-              ordered-by user;
-              leaf name {
-                type "jt:ipprefix";
-                description "Range to summarize NSSA routes in this area";
-              }
-              leaf restrict {
-                type empty;
-                description "Restrict advertisement of this area range";
-              }
-              leaf exact {
-                type empty;
-                description "Enforce exact match for advertisement of this area range";
-              }
-              container override-metric {
-                description "Override the dynamic metric for this area-range";
-                presence "enable override-metric";
-                leaf metric {
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
                   type uint32 {
                     range "1 .. 16777215";
                   }
-                  description "Metric value";
                 }
-                leaf metric-type {
+              }
+              leaf metric-type {
+                description "External metric type for the default type 7 LSA";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
                   type uint32 {
                     range "1 .. 2";
                   }
-                  default "1";
+                }
+              }
+              leaf type-7 {
+                description "Flood type 7 default LSA if no-summaries is configured";
+                type empty;
+              }
+            }
+            leaf default-metric {
+              description "Metric for the default route in this area";
+              status deprecated;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 16777215";
+                }
+              }
+            }
+            leaf metric-type {
+              description "External metric type for the default type 7 LSA";
+              status deprecated;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 2";
+                }
+              }
+            }
+            choice summaries-choice {
+              leaf summaries {
+                description "Flood summary LSAs into this NSSA area";
+                type empty;
+              }
+              leaf no-summaries {
+                description "Don't flood summary LSAs into this NSSA area";
+                type empty;
+              }
+            }
+            list area-range {
+              key name;
+              ordered-by user;
+              description "Configure NSSA area ranges";
+              leaf name {
+                description "Range to summarize NSSA routes in this area";
+                type "jt:ipprefix";
+              }
+              leaf restrict {
+                description "Restrict advertisement of this area range";
+                type empty;
+              }
+              leaf exact {
+                description "Enforce exact match for advertisement of this area range";
+                type empty;
+              }
+              container override-metric {
+                presence "enable override-metric";
+                description "Override the dynamic metric for this area-range";
+                leaf metric {
+                  description "Metric value";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "1 .. 16777215";
+                    }
+                  }
+                }
+                leaf metric-type {
                   description "Set the metric type for the override metric";
+                  default "1";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "1 .. 2";
+                    }
+                  }
                 }
               }
             }
@@ -13870,49 +16694,56 @@ module junos-conf-protocols {
         }
       }
       list area-range {
-        description "Configure area ranges";
         key name;
         ordered-by user;
+        description "Configure area ranges";
         leaf name {
-          type "jt:ipprefix";
           description "Range to summarize routes in this area";
+          type "jt:ipprefix";
         }
         leaf restrict {
-          type empty;
           description "Restrict advertisement of this area range";
+          type empty;
         }
         leaf exact {
-          type empty;
           description "Enforce exact match for advertisement of this area range";
+          type empty;
         }
         leaf override-metric {
-          type uint32 {
-            range "1 .. 16777215";
-          }
           description "Override the dynamic metric for this area-range";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 16777215";
+            }
+          }
         }
       }
       leaf-list network-summary-export {
-        type "jt:policy-algebra";
-        description "Export policy for Type 3 Summary LSAs";
         ordered-by user;
+        description "Export policy for Type 3 Summary LSAs";
+        type "jt:policy-algebra";
       }
       leaf-list network-summary-import {
-        type "jt:policy-algebra";
-        description "Import policy for Type 3 Summary LSAs";
         ordered-by user;
+        description "Import policy for Type 3 Summary LSAs";
+        type "jt:policy-algebra";
       }
       leaf-list inter-area-prefix-export {
-        type "jt:policy-algebra";
-        description "Export policy for Inter Area Prefix LSAs";
         ordered-by user;
+        description "Export policy for Inter Area Prefix LSAs";
+        type "jt:policy-algebra";
       }
       leaf-list inter-area-prefix-import {
-        type "jt:policy-algebra";
-        description "Import policy for Inter Area Prefix LSAs";
         ordered-by user;
+        description "Import policy for Inter Area Prefix LSAs";
+        type "jt:policy-algebra";
       }
       leaf authentication-type {
+        description "Authentication type";
+        status deprecated;
         type enumeration {
           enum none {
             description "No authentication";
@@ -13927,58 +16758,81 @@ module junos-conf-protocols {
             status deprecated;
           }
         }
-        description "Authentication type";
-        status deprecated;
       }
       list virtual-link {
-        description "Configure virtual links";
         key "neighbor-id transit-area";
         ordered-by user;
+        description "Configure virtual links";
         leaf neighbor-id {
-          type "jt:ipv4addr";
           description "Router ID of a virtual neighbor";
+          type "jt:ipv4addr";
         }
         leaf transit-area {
-          type "jt:areaid";
           description "Transit area in common with virtual neighbor";
+          type "jt:areaid";
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable this virtual link";
+              type empty;
             }
           }
         }
         leaf retransmit-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Retransmission interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf transit-delay {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Transit delay (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf hello-interval {
-          type uint32 {
-            range "1 .. 255";
-          }
           description "Hello interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255";
+            }
+          }
         }
         leaf dead-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Dead interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf mtu {
-          type uint32 {
-            range "128 .. 65535";
-          }
           description "Maximum OSPF packet size";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "128 .. 65535";
+            }
+          }
         }
         choice auth {
           case case_1 {
@@ -13991,153 +16845,189 @@ module junos-conf-protocols {
               description "Authentication key";
               status deprecated;
               leaf keyname {
-                type "jt:unreadable";
                 description "Authentication key value";
+                type "jt:unreadable";
               }
               leaf key-id {
-                type uint32 {
-                  range "0 .. 255";
-                }
                 description "Key ID for MD5 authentication";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 255";
+                  }
+                }
               }
             }
           }
         }
         leaf demand-circuit {
-          type empty;
           description "Interface functions as a demand circuit";
+          type empty;
         }
         leaf flood-reduction {
-          type empty;
           description "Enable flood reduction";
+          type empty;
         }
         leaf no-neighbor-down-notification {
-          type empty;
           description "Don't inform other protocols about neighbor down events";
+          type empty;
         }
         leaf ipsec-sa {
+          description "IPSec security association name";
           type string {
             length "1 .. 32";
           }
-          description "IPSec security association name";
         }
         list topology {
-          description "Topology specific attributes";
           key name;
           ordered-by user;
+          description "Topology specific attributes";
           leaf name {
-            type string;
             description "Topology name";
+            type string;
           }
           leaf disable {
-            type empty;
             description "Disable this topology";
+            type empty;
           }
           leaf metric {
-            type uint16 {
-              range "1 .. 65535";
-            }
             description "Topology metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
         }
       }
       list sham-link-remote {
-        description "Configure parameters for remote sham link endpoint";
         key name;
         ordered-by user;
+        description "Configure parameters for remote sham link endpoint";
         leaf name {
-          type "jt:ipaddr";
           description "Remote sham link endpoint address";
+          type "jt:ipaddr";
         }
         leaf metric {
-          type uint16 {
-            range "1 .. 65535";
-          }
           description "Sham link metric";
-        }
-        leaf ipsec-sa {
-          type string {
-            length "1 .. 32";
-          }
-          description "IPSec security association name";
-        }
-        leaf demand-circuit {
-          type empty;
-          description "Interface functions as a demand circuit";
-        }
-        leaf flood-reduction {
-          type empty;
-          description "Enable flood reduction";
-        }
-        list topology {
-          description "Topology specific attributes";
-          key name;
-          ordered-by user;
-          leaf name {
-            type string;
-            description "Topology name";
-          }
-          leaf disable {
-            type empty;
-            description "Disable this topology";
-          }
-          leaf metric {
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
             type uint16 {
               range "1 .. 65535";
             }
+          }
+        }
+        leaf ipsec-sa {
+          description "IPSec security association name";
+          type string {
+            length "1 .. 32";
+          }
+        }
+        leaf demand-circuit {
+          description "Interface functions as a demand circuit";
+          type empty;
+        }
+        leaf flood-reduction {
+          description "Enable flood reduction";
+          type empty;
+        }
+        list topology {
+          key name;
+          ordered-by user;
+          description "Topology specific attributes";
+          leaf name {
+            description "Topology name";
+            type string;
+          }
+          leaf disable {
+            description "Disable this topology";
+            type empty;
+          }
+          leaf metric {
             description "Topology metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
         }
       }
       list interface {
-        description "Include an interface in this area";
         key name;
         ordered-by user;
+        description "Include an interface in this area";
         leaf name {
-          type "jt:ipv4addr-or-interface";
           description "Interface name";
+          type union {
+            type "jt:ipv4addr-or-interface";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable OSPF on this interface";
+              type empty;
             }
           }
         }
         leaf interface-type {
+          description "Type of interface";
           type enumeration {
             enum nbma {
               description "Nonbroadcast multiaccess";
@@ -14152,110 +17042,149 @@ module junos-conf-protocols {
               description "Point-to-multipoint over LAN mode";
             }
           }
-          description "Type of interface";
         }
         choice protection-type {
           case case_1 {
             leaf link-protection {
-              type empty;
               description "Protect interface from link faults only";
+              type empty;
             }
           }
           case case_2 {
             leaf node-link-protection {
-              type empty;
               description "Protect interface from both link and node faults";
+              type empty;
             }
           }
         }
         leaf no-eligible-backup {
-          type empty;
           description "Not eligible to backup traffic from protected interfaces";
+          type empty;
         }
         leaf no-eligible-remote-backup {
-          type empty;
           description "Not eligible for Remote-LFA backup traffic from protected interfaces";
+          type empty;
         }
         container passive {
-          description "Do not run OSPF, but advertise it";
           presence "enable passive";
+          description "Do not run OSPF, but advertise it";
           container traffic-engineering {
             description "Advertise TE link information";
             leaf remote-node-id {
-              type "jt:ipaddr";
               description "Remote address of the link";
+              type "jt:ipaddr";
             }
             leaf remote-node-router-id {
-              type "jt:ipv4addr";
               description "TE Router-ID of the remote node";
+              type "jt:ipv4addr";
             }
           }
         }
         leaf secondary {
-          type empty;
           description "Treat interface as secondary";
+          type empty;
         }
         leaf own-router-lsa {
-          type empty;
           description "Generate a separate router LSA for this interface";
+          type empty;
         }
         container bandwidth-based-metrics {
           description "Configure bandwidth based metrics";
           list bandwidth {
-            description "Bandwidth threshold";
             key name;
+            description "Bandwidth threshold";
             leaf name {
               type string;
             }
             leaf metric {
-              type uint16 {
-                range "1 .. 65535";
-              }
               description "Metric associated with specified bandwidth";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 65535";
+                }
+              }
             }
           }
         }
         leaf metric {
-          type uint16 {
-            range "1 .. 65535";
-          }
           description "Interface metric";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf priority {
-          type uint32 {
-            range "0 .. 255";
-          }
           description "Designated router priority";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 255";
+            }
+          }
         }
         leaf retransmit-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Retransmission interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf transit-delay {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Transit delay (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf hello-interval {
-          type uint32 {
-            range "1 .. 255";
-          }
           description "Hello interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255";
+            }
+          }
         }
         leaf dead-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Dead interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf mtu {
-          type uint32 {
-            range "128 .. 65535";
-          }
           description "Maximum OSPF packet size";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "128 .. 65535";
+            }
+          }
         }
         choice auth {
           case case_1 {
@@ -14268,81 +17197,103 @@ module junos-conf-protocols {
               description "Authentication key";
               status deprecated;
               leaf keyname {
-                type "jt:unreadable";
                 description "Authentication key value";
+                type "jt:unreadable";
               }
               leaf key-id {
-                type uint32 {
-                  range "0 .. 255";
-                }
                 description "Key ID for MD5 authentication";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 255";
+                  }
+                }
               }
             }
           }
         }
         leaf demand-circuit {
-          type empty;
           description "Interface functions as a demand circuit";
+          type empty;
         }
         leaf flood-reduction {
-          type empty;
           description "Enable flood reduction";
+          type empty;
         }
         leaf no-neighbor-down-notification {
-          type empty;
           description "Don't inform other protocols about neighbor down events";
+          type empty;
         }
         leaf ipsec-sa {
+          description "IPSec security association name";
           type string {
             length "1 .. 32";
           }
-          description "IPSec security association name";
         }
         list topology {
-          description "Topology specific attributes";
           key name;
           ordered-by user;
+          description "Topology specific attributes";
           leaf name {
-            type string;
             description "Topology name";
+            type string;
           }
           leaf disable {
-            type empty;
             description "Disable this topology";
+            type empty;
           }
           leaf metric {
-            type uint16 {
-              range "1 .. 65535";
-            }
             description "Topology metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
         }
         leaf transmit-interval {
-          type uint32 {
-            range "1 .. 4294967295";
-          }
           description "OSPF packet transmit interval (milliseconds)";
           status deprecated;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 4294967295";
+            }
+          }
         }
         container bfd-liveness-detection {
           description "Bidirectional Forwarding Detection options";
           leaf version {
+            description "BFD protocol version number";
+            default "automatic";
             type enumeration {
               enum 0 {
                 description "BFD version 0 (deprecated)";
@@ -14354,87 +17305,126 @@ module junos-conf-protocols {
                 description "Choose BFD version automatically";
               }
             }
-            default "automatic";
-            description "BFD protocol version number";
           }
           leaf minimum-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit and receive interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf minimum-transmit-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit interval";
             status deprecated;
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf minimum-receive-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum receive interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf multiplier {
-            type uint32 {
-              range "1 .. 255";
-            }
-            default "3";
             description "Detection time multiplier";
+            default "3";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf inline-disable {
-            type empty;
             description "Disable inline mode for this BFD session";
+            type empty;
           }
           leaf pdu-size {
-            type uint32 {
-              range "24 .. 9000";
-            }
-            default "24";
             description "BFD transport protocol payload size";
+            default "24";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "24 .. 9000";
+              }
+            }
           }
           choice adaptation-choice {
             case case_1 {
               leaf no-adaptation {
-                type empty;
                 description "Disable adaptation";
+                type empty;
               }
             }
           }
           container transmit-interval {
             description "Transmit-interval options";
             leaf minimum-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf threshold {
-              type uint32;
               description "High transmit interval triggering a trap";
               units milliseconds;
+              type union {
+                type uint32;
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
           }
           container detection-time {
             description "Detection-time options";
             leaf threshold {
-              type uint32;
               description "High detection-time triggering a trap";
               units milliseconds;
+              type union {
+                type uint32;
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
           }
           container authentication {
             description "Authentication options";
             leaf key-chain {
-              type string;
               description "Key chain name";
+              type string;
             }
             leaf algorithm {
+              description "Algorithm name";
               type enumeration {
                 enum simple-password {
                   description "Simple password";
@@ -14452,107 +17442,136 @@ module junos-conf-protocols {
                   description "Meticulous keyed secure hash algorithm (SHA1) ";
                 }
               }
-              description "Algorithm name";
             }
             leaf loose-check {
-              type empty;
               description "Verify authentication only if authentication is negotiated";
+              type empty;
             }
           }
           container echo {
             description "Echo mode parameters";
             leaf minimum-interval {
-              type uint32 {
-                range "100 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "100 .. 255000";
+                }
+              }
             }
           }
           container echo-lite {
             description "Echo-lite more parameters";
             leaf minimum-interval {
-              type uint32 {
-                range "100 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "100 .. 255000";
+                }
+              }
             }
           }
           leaf full-neighbors-only {
-            type empty;
             description "Setup BFD sessions only to Full neighbors";
+            type empty;
           }
           leaf holddown-interval {
-            type uint32 {
-              range "0 .. 255000";
-            }
             description "Time to hold the session-UP notification to the client";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 255000";
+              }
+            }
           }
         }
         leaf dynamic-neighbors {
-          type empty;
           description "Learn neighbors dynamically on a p2mp interface";
+          type empty;
         }
         leaf no-advertise-adjacency-segment {
-          type empty;
           description "Do not advertise an adjacency segment for this interface";
+          type empty;
         }
         list neighbor {
-          description "NBMA neighbor";
           key name;
           ordered-by user;
+          description "NBMA neighbor";
           leaf name {
-            type "jt:ipaddr";
             description "Address of neighbor";
+            type "jt:ipaddr";
           }
           leaf eligible {
-            type empty;
             description "Eligible to be DR on an NBMA network";
+            type empty;
           }
         }
         leaf poll-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Poll interval for NBMA interfaces";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf no-interface-state-traps {
-          type empty;
           description "Do not send interface state change traps";
+          type empty;
         }
         leaf strict-bfd {
-          type empty;
           description "Enable strict bfd over this interface";
+          type empty;
         }
         container post-convergence-lfa {
-          description "Protect interface using post-convergence backup path";
           presence "enable post-convergence-lfa";
+          description "Protect interface using post-convergence backup path";
           container node-protection {
-            description "Compute backup path assuming node failure";
             presence "enable node-protection";
+            description "Compute backup path assuming node failure";
             leaf cost {
-              type uint16 {
-                range "1 .. 65535";
-              }
               description "Cost for node protection";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 65535";
+                }
+              }
             }
           }
           leaf srlg-protection {
-            type empty;
             description "Compute backup path assuming SRLG failure";
+            type empty;
           }
           leaf fate-sharing-protection {
-            type empty;
             description "Compute backup path assuming fate-sharing group failure";
+            type empty;
           }
         }
         leaf te-metric {
-          type uint32 {
-            range "1 .. 4294967295";
-          }
           description "Traffic engineering metric";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 4294967295";
+            }
+          }
         }
         container ldp-synchronization {
           description "Advertise maximum metric until LDP is operational";
@@ -14568,24 +17587,34 @@ module junos-conf-protocols {
                 container index {
                   description "Adjacency SID indexed from SRGB";
                   leaf index-number {
-                    type uint32 {
-                      range "0 .. 199999";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "0 .. 199999";
+                      }
                     }
                   }
                 }
               }
               case case_2 {
                 leaf label {
-                  type uint32 {
-                    range "16 .. 1048575";
-                  }
                   description "Adjacency SID from static label pool";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "16 .. 1048575";
+                    }
+                  }
                 }
               }
               case case_3 {
                 leaf dynamic {
-                  type empty;
                   description "Dynamically allocate an adjacency segment";
+                  type empty;
                 }
               }
             }
@@ -14597,36 +17626,46 @@ module junos-conf-protocols {
                 container index {
                   description "Adjacency SID indexed from SRGB";
                   leaf index-number {
-                    type uint32 {
-                      range "0 .. 199999";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "0 .. 199999";
+                      }
                     }
                   }
                 }
               }
               case case_2 {
                 leaf label {
-                  type uint32 {
-                    range "16 .. 1048575";
-                  }
                   description "Adjacency SID from static label pool";
+                  type union {
+                    type string {
+                      pattern "<.*>|$.*";
+                    }
+                    type uint32 {
+                      range "16 .. 1048575";
+                    }
+                  }
                 }
               }
               case case_3 {
                 leaf dynamic {
-                  type empty;
                   description "Dynamically allocate an adjacency segment";
+                  type empty;
                 }
               }
             }
           }
         }
         list lan-neighbor {
-          description "Configuration specific to a LAN neighbor";
           key name;
           ordered-by user;
+          description "Configuration specific to a LAN neighbor";
           leaf name {
-            type "jt:ipaddr";
             description "Address of neighbor";
+            type "jt:ipaddr";
           }
           container ipv4-adjacency-segment {
             description "Configure ipv4 adjacency segment";
@@ -14637,24 +17676,34 @@ module junos-conf-protocols {
                   container index {
                     description "Adjacency SID indexed from SRGB";
                     leaf index-number {
-                      type uint32 {
-                        range "0 .. 199999";
+                      type union {
+                        type string {
+                          pattern "<.*>|$.*";
+                        }
+                        type uint32 {
+                          range "0 .. 199999";
+                        }
                       }
                     }
                   }
                 }
                 case case_2 {
                   leaf label {
-                    type uint32 {
-                      range "16 .. 1048575";
-                    }
                     description "Adjacency SID from static label pool";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "16 .. 1048575";
+                      }
+                    }
                   }
                 }
                 case case_3 {
                   leaf dynamic {
-                    type empty;
                     description "Dynamically allocate an adjacency segment";
+                    type empty;
                   }
                 }
               }
@@ -14666,24 +17715,34 @@ module junos-conf-protocols {
                   container index {
                     description "Adjacency SID indexed from SRGB";
                     leaf index-number {
-                      type uint32 {
-                        range "0 .. 199999";
+                      type union {
+                        type string {
+                          pattern "<.*>|$.*";
+                        }
+                        type uint32 {
+                          range "0 .. 199999";
+                        }
                       }
                     }
                   }
                 }
                 case case_2 {
                   leaf label {
-                    type uint32 {
-                      range "16 .. 1048575";
-                    }
                     description "Adjacency SID from static label pool";
+                    type union {
+                      type string {
+                        pattern "<.*>|$.*";
+                      }
+                      type uint32 {
+                        range "16 .. 1048575";
+                      }
+                    }
                   }
                 }
                 case case_3 {
                   leaf dynamic {
-                    type empty;
                     description "Dynamically allocate an adjacency segment";
+                    type empty;
                   }
                 }
               }
@@ -14691,56 +17750,86 @@ module junos-conf-protocols {
           }
         }
         leaf delay-metric {
-          type uint32 {
-            range "0 .. 16777215";
-          }
           description "Delay metric";
           units microseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 16777215";
+            }
+          }
         }
         container delay-measurement {
-          description "Enable delay measurement";
           presence "enable delay-measurement";
+          description "Enable delay measurement";
           leaf probe-interval {
-            type uint32 {
-              range "1 .. 255";
-            }
             description "Probe interval";
             units seconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf probe-count {
-            type uint32 {
-              range "1 .. 15";
-            }
             description "Probe count";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 15";
+              }
+            }
           }
           container advertisement {
             description "Delay advertisement";
             container periodic {
               description "Periodic advertisement parameters";
               leaf threshold {
-                type uint32 {
-                  range "0 .. 100";
-                }
                 description "Threshold";
                 units percentage;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 100";
+                  }
+                }
               }
               leaf interval {
-                type uint32 {
-                  range "30 .. 3600";
-                }
                 description "Interval";
                 units seconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "30 .. 3600";
+                  }
+                }
               }
             }
             container accelerated {
-              description "Accelerated advertisement parameters";
               presence "enable accelerated";
+              description "Accelerated advertisement parameters";
               leaf threshold {
-                type uint32 {
-                  range "0 .. 100";
-                }
                 description "Threshold";
                 units percentage;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 100";
+                  }
+                }
               }
             }
           }
@@ -14748,96 +17837,131 @@ module junos-conf-protocols {
         container application-specific {
           description "Advertise application-specific TE attributes";
           list attribute-group {
-            description "Link attribute group name";
             key name;
-            max-elements 1;
             ordered-by user;
+            description "Link attribute group name";
+            max-elements 1;
             leaf name {
-              type string;
               description "Link attribute group name";
+              type string;
             }
             leaf te-metric {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Traffic engineering metric for this attribute group";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
             leaf-list admin-group {
-              type string;
-              description "Administrative groups for this attribute-group";
-              max-elements 16;
               ordered-by user;
+              description "Administrative groups for this attribute-group";
+              type string;
+              max-elements 16;
             }
             leaf delay-metric {
-              type uint32 {
-                range "0 .. 16777215";
-              }
               description "Delay metric for this attribute-group";
               units microseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "0 .. 16777215";
+                }
+              }
             }
             leaf advertise-interface-delay {
-              type empty;
               description "Use interface specific static/dynamic delay values as applicable in ASLA Sub-TLVs";
+              type empty;
             }
             container application {
               description "Standard Applications part of this attribute-group";
               leaf flex-algorithm {
-                type empty;
                 description "Set X flag in standard application bit mask";
+                type empty;
               }
             }
           }
         }
       }
       leaf no-context-identifier-advertisement {
-        type empty;
         description "Disable context identifier advertisments in this area";
+        type empty;
       }
       list peer-interface {
-        description "Configuration for peer interface";
         key name;
         ordered-by user;
+        description "Configuration for peer interface";
         leaf name {
-          type string;
           description "Name of peer interface";
+          type string;
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable OSPF on this control peer";
+              type empty;
             }
           }
         }
         leaf retransmit-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Retransmission interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf transit-delay {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Transit delay (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf hello-interval {
-          type uint32 {
-            range "1 .. 255";
-          }
           description "Hello interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255";
+            }
+          }
         }
         leaf dead-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Dead interval (seconds)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf mtu {
-          type uint32 {
-            range "128 .. 65535";
-          }
           description "Maximum OSPF packet size";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "128 .. 65535";
+            }
+          }
         }
         choice auth {
           case case_1 {
@@ -14850,99 +17974,119 @@ module junos-conf-protocols {
               description "Authentication key";
               status deprecated;
               leaf keyname {
-                type "jt:unreadable";
                 description "Authentication key value";
+                type "jt:unreadable";
               }
               leaf key-id {
-                type uint32 {
-                  range "0 .. 255";
-                }
                 description "Key ID for MD5 authentication";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 255";
+                  }
+                }
               }
             }
           }
         }
         leaf demand-circuit {
-          type empty;
           description "Interface functions as a demand circuit";
+          type empty;
         }
         leaf flood-reduction {
-          type empty;
           description "Enable flood reduction";
+          type empty;
         }
         leaf no-neighbor-down-notification {
-          type empty;
           description "Don't inform other protocols about neighbor down events";
+          type empty;
         }
       }
       leaf no-source-packet-routing {
-        type empty;
         description "Disable SPRING in this area";
+        type empty;
       }
       list context-identifier {
-        description "Configure context identifier in support of edge protection";
         key name;
         ordered-by user;
+        description "Configure context identifier in support of edge protection";
         leaf name {
-          type "jt:ipv4addr";
           description "Context identifier";
+          type "jt:ipv4addr";
         }
       }
       list label-switched-path {
-        description "Configuration for advertisement of a label-switched path";
         key name;
         ordered-by user;
+        description "Configuration for advertisement of a label-switched path";
         leaf name {
+          description "Name of label-switched path to be advertised";
           type string {
             length "1 .. 64";
           }
-          description "Name of label-switched path to be advertised";
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable OSPF on this label-switched path";
+              type empty;
             }
           }
         }
         leaf metric {
-          type uint16 {
-            range "1 .. 65535";
-          }
           description "Interface metric";
-        }
-        list topology {
-          description "Topology specific attributes";
-          key name;
-          ordered-by user;
-          leaf name {
-            type string;
-            description "Topology name";
-          }
-          leaf disable {
-            type empty;
-            description "Disable this topology";
-          }
-          leaf metric {
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
             type uint16 {
               range "1 .. 65535";
             }
+          }
+        }
+        list topology {
+          key name;
+          ordered-by user;
+          description "Topology specific attributes";
+          leaf name {
+            description "Topology name";
+            type string;
+          }
+          leaf disable {
+            description "Disable this topology";
+            type empty;
+          }
+          leaf metric {
             description "Topology metric";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint16 {
+                range "1 .. 65535";
+              }
+            }
           }
           container bandwidth-based-metrics {
             description "Configure bandwidth based metrics";
             list bandwidth {
-              description "Bandwidth threshold";
               key name;
+              description "Bandwidth threshold";
               leaf name {
                 type string;
               }
               leaf metric {
-                type uint16 {
-                  range "1 .. 65535";
-                }
                 description "Metric associated with specified bandwidth";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint16 {
+                    range "1 .. 65535";
+                  }
+                }
               }
             }
           }
@@ -14952,8 +18096,8 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable OSPF";
+          type empty;
         }
       }
     }
@@ -14962,47 +18106,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum spf {
@@ -15101,110 +18250,145 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf prefix-export-limit {
-      type uint32 {
-        range "0 .. 4294967295";
-      }
       description "Maximum number of prefixes that can be exported";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 4294967295";
+        }
+      }
     }
     container rib-groups {
       description "Routing table groups for importing OSPF routes";
       leaf inet {
-        type string;
         description "Name of the IPv4/v6 routing table group";
+        type string;
       }
       leaf inet3 {
-        type string;
         description "Name of the IPv4/v6 inet.3 routing table group";
+        type string;
       }
     }
     leaf job-stats {
-      type empty;
       description "Collect job statistics";
+      type empty;
     }
     container overload {
-      description "Set the overload mode (repel transit traffic)";
       presence "enable overload";
+      description "Set the overload mode (repel transit traffic)";
       leaf timeout {
-        type uint32 {
-          range "60 .. 3600";
-        }
         description "Time after which overload mode is reset";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "60 .. 3600";
+          }
+        }
       }
       leaf allow-route-leaking {
-        type empty;
         description "Allow routes to be leaked when overload is configured";
+        type empty;
       }
       leaf stub-network {
-        type empty;
         description "Advertise Stub Network with maximum metric";
+        type empty;
       }
       leaf intra-area-prefix {
-        type empty;
         description "Advertise Intra Area Prefix with maximum metric";
+        type empty;
       }
       leaf as-external {
-        type empty;
         description "Advertise As External with maximum usable metric";
+        type empty;
       }
     }
     container database-protection {
-      description "Configure database protection attributes";
       presence "enable database-protection";
+      description "Configure database protection attributes";
       leaf maximum-lsa {
-        type uint32 {
-          range "1 .. 1000000";
-        }
         description "Maximum allowed non self-generated LSAs";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 1000000";
+          }
+        }
       }
       leaf warning-only {
-        type empty;
         description "Emit only a warning when LSA maximum limit is exceeded";
+        type empty;
       }
       leaf warning-threshold {
-        type uint8 {
-          range "30 .. 100";
-        }
         description "Percentage of LSA maximum above which to trigger warning";
         units percent;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint8 {
+            range "30 .. 100";
+          }
+        }
       }
       leaf ignore-count {
-        type uint8 {
-          range "1 .. 32";
-        }
         description "Maximum number of times to go into ignore state";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint8 {
+            range "1 .. 32";
+          }
+        }
       }
       leaf ignore-time {
-        type uint16 {
-          range "30 .. 3600";
-        }
         description "Time to stay in ignore state and ignore all neighbors";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "30 .. 3600";
+          }
+        }
       }
       leaf reset-time {
-        type uint32 {
-          range "60 .. 86400";
-        }
         description "Time after which the ignore count gets reset to zero";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "60 .. 86400";
+          }
+        }
       }
     }
     container graceful-restart {
@@ -15212,55 +18396,66 @@ module junos-conf-protocols {
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable OSPF graceful restart capability";
+            type empty;
           }
         }
       }
       leaf restart-duration {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Time for all neighbors to become full";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
       leaf notify-duration {
-        type uint32 {
-          range "1 .. 3600";
-        }
         description "Time to send all max-aged grace LSAs";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
       container helper-disable {
-        description "Disable graceful restart helper capability";
         presence "enable helper-disable";
+        description "Disable graceful restart helper capability";
         choice disable-choices {
           case case_1 {
             leaf standard {
-              type empty;
               description "Disable helper-mode for rfc3623 based GR";
+              type empty;
             }
           }
           case case_2 {
             leaf restart-signaling {
-              type empty;
               description "Disable helper mode for restart-signaling ";
+              type empty;
             }
           }
           case case_3 {
             leaf both {
-              type empty;
               description "Disable helper mode for both the types of GR";
+              type empty;
             }
           }
         }
       }
       leaf no-strict-lsa-checking {
-        type empty;
         description "Do not abort graceful helper mode upon LSA changes";
+        type empty;
       }
     }
     leaf route-type-community {
+      description "Specify BGP extended community value to encode OSPF route type";
       type enumeration {
         enum iana {
           description "BGP extended community value used is 0x0306";
@@ -15269,21 +18464,20 @@ module junos-conf-protocols {
           description "Vendor BGP extended community value used is 0x8000";
         }
       }
-      description "Specify BGP extended community value to encode OSPF route type";
     }
     container domain-id {
       description "Configure domain ID";
       choice domain_id_or_disable {
         case case_1 {
           leaf domain-id {
-            type string;
             description "Domain ID";
+            type string;
           }
         }
         case case_2 {
           leaf disable {
-            type empty;
             description "Disable domain ID";
+            type empty;
           }
         }
       }
@@ -15291,87 +18485,117 @@ module junos-conf-protocols {
     choice domain_vpn_tag_or_disable {
       case case_1 {
         leaf domain-vpn-tag {
-          type uint32 {
-            range "0 .. 4294967295";
-          }
           description "Domain VPN tag for external LSA";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 4294967295";
+            }
+          }
         }
       }
       case case_2 {
         leaf no-domain-vpn-tag {
-          type empty;
           description "Disable domain VPN tag";
+          type empty;
         }
       }
     }
     leaf preference {
-      type uint32;
       description "Preference of internal routes";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf external-preference {
-      type uint32;
       description "Preference of external routes";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf labeled-preference {
-      type uint32;
       description "Preference of labeled routes";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf-list export {
-      type "jt:policy-algebra";
-      description "Export policy";
       ordered-by user;
+      description "Export policy";
+      type "jt:policy-algebra";
     }
     leaf-list import {
-      type "jt:policy-algebra";
-      description "Import policy (for external routes or setting priority)";
       ordered-by user;
+      description "Import policy (for external routes or setting priority)";
+      type "jt:policy-algebra";
     }
     leaf reference-bandwidth {
-      type string;
       description "Bandwidth for calculating metric defaults";
+      type string;
     }
     leaf lsa-refresh-interval {
-      type uint32 {
-        range "25 .. 50";
-      }
-      default "50";
       description "LSA refresh interval (minutes)";
+      default "50";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "25 .. 50";
+        }
+      }
     }
     leaf spf-delay {
-      type uint32 {
-        range "50 .. 8000";
-      }
       description "Time to wait before running an SPF";
       status deprecated;
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "50 .. 8000";
+        }
+      }
     }
     leaf no-rfc-1583 {
-      type empty;
       description "Disable RFC1583 compatibility";
+      type empty;
     }
     leaf forwarding-address-to-broadcast {
-      type empty;
       description "Set forwarding address in Type 5 LSA in broadcast network";
+      type empty;
     }
     choice nssa-abr-option {
       case case_1 {
         leaf no-nssa-abr {
-          type empty;
           description "Disable full NSSA functionality at ABR";
+          type empty;
         }
       }
     }
     container sham-link {
-      description "Configure parameters for sham links";
       presence "enable sham-link";
+      description "Configure parameters for sham links";
       leaf local {
-        type "jt:ipaddr";
         description "Local sham link endpoint address";
+        type "jt:ipaddr";
       }
       leaf no-advertise-local {
-        type empty;
         description "Don't advertise local sham link endpoint as stub in router LSA";
         status deprecated;
+        type empty;
       }
     }
   }
@@ -15379,9 +18603,9 @@ module junos-conf-protocols {
     container traceoptions {
       description "PGM trace options";
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum init {
@@ -15408,59 +18632,59 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
   }
   grouping juniper-protocols-pim {
     leaf protocol-instance-name {
-      type string;
       description "Name of protocol instance under routing instance";
+      type string;
     }
     container family {
       description "Local address family";
       container any {
-        description "Default properties for all address families";
         presence "enable any";
+        description "Default properties for all address families";
         leaf disable {
-          type empty;
           description "Disable all families";
+          type empty;
         }
       }
       container inet {
-        description "IPv4 specific properties";
         presence "enable inet";
+        description "IPv4 specific properties";
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable PIMv4 on all interfaces";
+              type empty;
             }
           }
         }
       }
       container inet6 {
-        description "IPv6 specific properties";
         presence "enable inet6";
+        description "IPv6 specific properties";
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable PIMv6 on all interfaces";
+              type empty;
             }
           }
         }
@@ -15469,8 +18693,8 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable PIM";
+          type empty;
         }
       }
     }
@@ -15479,8 +18703,8 @@ module junos-conf-protocols {
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable non-stop routing for PIM";
+            type empty;
           }
         }
       }
@@ -15490,47 +18714,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum route {
@@ -15602,20 +18831,20 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
         container filter {
           description "Filter to apply to this flag";
@@ -15627,119 +18856,124 @@ module junos-conf-protocols {
     container dense-groups {
       description "Dense mode groups for sparse-dense mode";
       leaf dynamic-reject {
-        type empty;
         description "Reject dynamic autorp negative dense-mode prefixes learnt from network";
+        type empty;
       }
       list pim-dense-group-type {
         key name;
         ordered-by user;
         leaf name {
-          type "jt:ipprefix";
           description "Group address or range to forward in dense mode";
+          type "jt:ipprefix";
         }
         choice dense-group-flags {
           case case_1 {
             leaf reject {
-              type empty;
               description "Do not include prefix as dense mode; force sparse mode";
+              type empty;
             }
           }
           case case_2 {
             leaf announce {
-              type empty;
               description "Advertise as negative prefix in auto-RP announce messages";
+              type empty;
             }
           }
         }
       }
     }
     leaf vpn-tunnel-source {
-      type "jt:ipv4addr";
       description "Source address for the provider space mGRE tunnel";
       status deprecated;
+      type "jt:ipv4addr";
     }
     leaf vpn-group-address {
-      type "jt:ipv4addr";
       description "Group address for the VPN in provider space";
       status deprecated;
+      type "jt:ipv4addr";
     }
     leaf-list tunnel-devices {
-      type "jt:interface-device";
-      description "Tunnel devices to be used for creating mt interfaces";
       ordered-by user;
+      description "Tunnel devices to be used for creating mt interfaces";
+      type union {
+        type "jt:interface-device";
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     container rpf-selection {
       description "Select RPF neighbor";
       list group {
-        description "IP prefix of multicast group";
         key name;
         ordered-by user;
+        description "IP prefix of multicast group";
         leaf name {
-          type "jt:ipprefix";
           description "IP prefix of group";
+          type "jt:ipprefix";
         }
         container wildcard-source {
-          description "Select RPF for (*,g) and unspecified (s,g) joins";
           presence "enable wildcard-source";
+          description "Select RPF for (*,g) and unspecified (s,g) joins";
           leaf next-hop {
-            type "jt:ipaddr";
             description "Next-hop address";
+            type "jt:ipaddr";
           }
         }
         list source {
-          description "IP prefix of one or more multicast sources";
           key name;
           ordered-by user;
+          description "IP prefix of one or more multicast sources";
           leaf name {
-            type "jt:ipprefix";
             description "IP prefix of source";
+            type "jt:ipprefix";
           }
           leaf next-hop {
-            type "jt:ipaddr";
             description "Next-hop address";
+            type "jt:ipaddr";
           }
         }
       }
       list prefix-list {
-        description "Multicast group prefix list";
         key name;
         ordered-by user;
+        description "Multicast group prefix list";
         leaf name {
-          type string;
           description "Name of prefix list to match against";
+          type string;
         }
         container wildcard-source {
-          description "Select RPF for (*,g) and unspecified (s,g) joins";
           presence "enable wildcard-source";
+          description "Select RPF for (*,g) and unspecified (s,g) joins";
           leaf next-hop {
-            type "jt:ipaddr";
             description "Next-hop address";
+            type "jt:ipaddr";
           }
         }
         list source {
-          description "IP prefix of one or more multicast sources";
           key name;
           ordered-by user;
+          description "IP prefix of one or more multicast sources";
           leaf name {
-            type "jt:ipprefix";
             description "IP prefix of source";
+            type "jt:ipprefix";
           }
           leaf next-hop {
-            type "jt:ipaddr";
             description "Next-hop address";
+            type "jt:ipaddr";
           }
         }
       }
     }
     container mvpn {
-      description "PIM MVPN control-plane options";
       presence "enable mvpn";
+      description "PIM MVPN control-plane options";
       container autodiscovery {
         description "PE router autodiscovery options for SSM MDTs";
         status deprecated;
         leaf inet-mdt {
-          type empty;
           description "MDT-SAFI PE autodiscovery for SSM MDTs";
+          type empty;
         }
       }
       container family {
@@ -15747,45 +18981,45 @@ module junos-conf-protocols {
         container inet {
           description "IPv4 PIM MVPN specific properties";
           leaf rosen-mvpn {
-            type empty;
             status deprecated;
+            type empty;
           }
           leaf ngen-mvpn {
-            type empty;
             status deprecated;
+            type empty;
           }
           container autodiscovery {
             description "PE router autodiscovery options for SSM MDTs";
             leaf inet-mdt {
-              type empty;
               description "MDT-SAFI PE autodiscovery for SSM MDTs";
+              type empty;
             }
           }
           leaf disable {
-            type empty;
             description "Disable family IPv4";
+            type empty;
           }
         }
         container inet6 {
           description "IPv6 PIM MVPN specific properties";
           leaf rosen-mvpn {
-            type empty;
             status deprecated;
+            type empty;
           }
           leaf ngen-mvpn {
-            type empty;
             status deprecated;
+            type empty;
           }
           container autodiscovery {
             description "PE router autodiscovery options for SSM MDTs";
             leaf inet-mdt {
-              type empty;
               description "MDT-SAFI PE autodiscovery for SSM MDTs";
+              type empty;
             }
           }
           leaf disable {
-            type empty;
             description "Disable family IPv6";
+            type empty;
           }
         }
       }
@@ -15795,66 +19029,81 @@ module junos-conf-protocols {
       uses rib_group_type;
     }
     leaf-list import {
-      type "jt:policy-algebra";
-      description "PIM sparse import join policy";
       ordered-by user;
+      description "PIM sparse import join policy";
+      type "jt:policy-algebra";
     }
     leaf-list export {
-      type "jt:policy-algebra";
-      description "PIM sparse export join policy";
       ordered-by user;
+      description "PIM sparse export join policy";
+      type "jt:policy-algebra";
     }
     container mldp-inband-signalling {
       presence "enable mldp-inband-signalling";
       leaf-list policy {
-        type "jt:policy-algebra";
-        description "PIM MLDP join translation filter policy";
         ordered-by user;
+        description "PIM MLDP join translation filter policy";
+        type "jt:policy-algebra";
       }
     }
     container rpf-vector {
       description "RPF vector TLV";
       leaf-list policy {
-        type "jt:policy-algebra";
-        description "RPF vector TLV include policy";
         ordered-by user;
+        description "RPF vector TLV include policy";
+        type "jt:policy-algebra";
       }
     }
     leaf assert-timeout {
-      type uint32 {
-        range "5 .. 210";
-      }
-      default "180";
       description "Set assert timeout";
+      default "180";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "5 .. 210";
+        }
+      }
     }
     leaf assert-robust-count {
-      type uint32 {
-        range "1 .. 5";
-      }
-      default "2";
       description "Number of assert messages an assert winner sends in one cycle";
+      default "2";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 5";
+        }
+      }
     }
     leaf join-prune-timeout {
-      type uint32 {
-        range "210 .. 420";
-      }
-      default "210";
       description "Set join/prune timeout";
+      default "210";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "210 .. 420";
+        }
+      }
     }
     container spt-threshold {
       description "Set shortest-path-tree threshold policy";
       leaf-list infinity {
-        type "jt:policy-algebra";
-        description "Apply policy to always remain on shared tree";
         ordered-by user;
+        description "Apply policy to always remain on shared tree";
+        type "jt:policy-algebra";
       }
     }
     container sglimit {
       description "Set limit on number of (S,G) states ";
       list family {
-        description "Protocol family";
         key name;
         ordered-by user;
+        description "Protocol family";
         leaf name {
           type enumeration {
             enum inet {
@@ -15866,60 +19115,95 @@ module junos-conf-protocols {
           }
         }
         leaf maximum {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Maximum limit above which additional entries are not accepted";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf threshold {
-          type uint32 {
-            range "1 .. 100";
-          }
           description "Percentage of maximum at which to start generating warnings";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 100";
+            }
+          }
         }
         leaf log-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Time between successive log messages";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
       }
       leaf maximum {
-        type uint32 {
-          range "1 .. 65535";
-        }
         description "Maximum limit above which additional entries are not accepted";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 65535";
+          }
+        }
       }
       leaf threshold {
-        type uint32 {
-          range "1 .. 100";
-        }
         description "Percentage of maximum at which to start generating warnings";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 100";
+          }
+        }
       }
       leaf log-interval {
-        type uint32 {
-          range "1 .. 65535";
-        }
         description "Time between successive log messages";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 65535";
+          }
+        }
       }
     }
     container rp {
       description "Router's rendezvous point properties";
       leaf bootstrap-priority {
-        type uint32 {
-          range "0 .. 255";
-        }
         description "Eligibility to be the bootstrap router (IPv4 only)";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 255";
+          }
+        }
       }
       leaf-list bootstrap-import {
-        type "jt:policy-algebra";
-        description "Bootstrap import policy (IPv4 only)";
         ordered-by user;
+        description "Bootstrap import policy (IPv4 only)";
+        type "jt:policy-algebra";
       }
       leaf-list bootstrap-export {
-        type "jt:policy-algebra";
-        description "Bootstrap export policy (IPv4 only)";
         ordered-by user;
+        description "Bootstrap export policy (IPv4 only)";
+        type "jt:policy-algebra";
       }
       container bootstrap {
         description "Bootstrap properties";
@@ -15938,9 +19222,9 @@ module junos-conf-protocols {
       container register-limit {
         description "Set limit on incoming registers that create (S,G) state";
         list family {
-          description "Protocol family";
           key name;
           ordered-by user;
+          description "Protocol family";
           leaf name {
             type enumeration {
               enum inet {
@@ -15952,49 +19236,79 @@ module junos-conf-protocols {
             }
           }
           leaf maximum {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Maximum limit above which additional entries are not accepted";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf threshold {
-            type uint32 {
-              range "1 .. 100";
-            }
             description "Percentage of maximum at which to start generating warnings";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 100";
+              }
+            }
           }
           leaf log-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Time between successive log messages";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
         }
         leaf maximum {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Maximum limit above which additional entries are not accepted";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf threshold {
-          type uint32 {
-            range "1 .. 100";
-          }
           description "Percentage of maximum at which to start generating warnings";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 100";
+            }
+          }
         }
         leaf log-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Time between successive log messages";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
       }
       container group-rp-mapping {
         description "Group-rp-mapping";
         list family {
-          description "Protocol family";
           key name;
           ordered-by user;
+          description "Protocol family";
           leaf name {
             type enumeration {
               enum inet {
@@ -16006,230 +19320,295 @@ module junos-conf-protocols {
             }
           }
           leaf maximum {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Maximum limit above which additional entries are not accepted";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           leaf threshold {
-            type uint32 {
-              range "1 .. 100";
-            }
             description "Percentage of maximum at which to start generating warnings";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 100";
+              }
+            }
           }
           leaf log-interval {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "Time between successive log messages";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
         }
         leaf maximum {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Maximum limit above which additional entries are not accepted";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf threshold {
-          type uint32 {
-            range "1 .. 100";
-          }
           description "Percentage of maximum at which to start generating warnings";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 100";
+            }
+          }
         }
         leaf log-interval {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "Time between successive log messages";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
       }
       leaf-list rp-register-policy {
-        type "jt:policy-algebra";
-        description "RP policy applied to incoming register messages";
         ordered-by user;
+        description "RP policy applied to incoming register messages";
+        type "jt:policy-algebra";
       }
       leaf-list dr-register-policy {
-        type "jt:policy-algebra";
-        description "DR policy applied to outgoing register messages";
         ordered-by user;
+        description "DR policy applied to outgoing register messages";
+        type "jt:policy-algebra";
       }
       container local {
         description "Router's local RP properties";
         leaf address {
-          type "jt:ipv4addr";
           description "Local RP address (IPv4 only)";
+          type "jt:ipv4addr";
         }
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable this RP (IPv4 only)";
+              type empty;
             }
           }
         }
         leaf priority {
-          type uint32 {
-            range "0 .. 255";
-          }
           description "Router's priority for becoming an RP (IPv4 only)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 255";
+            }
+          }
         }
         leaf hold-time {
-          type uint32 {
-            range "1 .. 65535";
-          }
           description "How long neighbor considers this router to be up, in seconds (IPv4 only)";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         list group-ranges {
-          description "Group address range for which this router can be an RP (IPv4 only)";
           key name;
           ordered-by user;
+          description "Group address range for which this router can be an RP (IPv4 only)";
           leaf name {
             type "jt:ipv4prefix";
           }
         }
         leaf override {
-          type empty;
           description "Static RP mapping will take precedence over dynamic";
+          type empty;
         }
         container family {
           description "Local RP address family";
           container inet {
             description "IPv4 local RP properties";
             leaf address {
-              type "jt:ipv4addr";
               description "Local RP address";
+              type "jt:ipv4addr";
             }
             choice enable-disable {
               case case_1 {
                 leaf disable {
-                  type empty;
                   description "Disable this RP";
+                  type empty;
                 }
               }
             }
             leaf priority {
-              type uint32 {
-                range "0 .. 255";
-              }
               description "Router's priority for becoming an RP";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "0 .. 255";
+                }
+              }
             }
             leaf hold-time {
-              type uint32 {
-                range "1 .. 65535";
-              }
               description "How long neighbor considers this router to be up, in seconds";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 65535";
+                }
+              }
             }
             list group-ranges {
-              description "Group address range for which this router can be an RP";
               key name;
               ordered-by user;
+              description "Group address range for which this router can be an RP";
               leaf name {
                 type "jt:ipv4prefix";
               }
             }
             leaf override {
-              type empty;
               description "Static RP mapping will take precedence over dynamic";
+              type empty;
             }
             container anycast-pim {
               description "Attributes for IPv4 anycast PIM";
               container rp-set {
                 description "Rendezvous points belonging to anycast RP set";
                 list address {
-                  description "IPv4 address of one or more remote anycast RPs";
                   key name;
                   ordered-by user;
+                  description "IPv4 address of one or more remote anycast RPs";
                   leaf name {
-                    type "jt:ipaddr";
                     description "IPv4 address of remote anycast RP";
+                    type "jt:ipaddr";
                   }
                   leaf forward-msdp-sa {
-                    type empty;
                     description "Forward SAs learned from MSDP to this RP";
+                    type empty;
                   }
                 }
               }
               leaf local-address {
-                type "jt:ipaddr";
                 description "Local address for replicating register messages to other RPs";
+                type "jt:ipaddr";
               }
             }
           }
           container inet6 {
             description "IPv6 local RP properties";
             leaf address {
-              type "jt:ipv6addr";
               description "Local RP address";
+              type "jt:ipv6addr";
             }
             choice enable-disable {
               case case_1 {
                 leaf disable {
-                  type empty;
                   description "Disable this RP";
+                  type empty;
                 }
               }
             }
             leaf priority {
-              type uint32 {
-                range "0 .. 255";
-              }
               description "Router's priority for becoming an RP";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "0 .. 255";
+                }
+              }
             }
             leaf hold-time {
-              type uint32 {
-                range "1 .. 65535";
-              }
               description "How long neighbor considers this router to be up, in seconds";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 65535";
+                }
+              }
             }
             list group-ranges {
-              description "Group address range for which this router can be an RP";
               key name;
               ordered-by user;
+              description "Group address range for which this router can be an RP";
               leaf name {
                 type "jt:ipv6prefix";
               }
             }
             leaf override {
-              type empty;
               description "Static RP mapping will take precedence over dynamic";
+              type empty;
             }
             container anycast-pim {
               description "Attributes for IPv6 anycast PIM";
               container rp-set {
                 description "Rendezvous points belonging to anycast RP set";
                 list address {
-                  description "IPv6 address of one or more remote anycast RPs";
                   key name;
                   ordered-by user;
+                  description "IPv6 address of one or more remote anycast RPs";
                   leaf name {
-                    type "jt:ipv6addr";
                     description "IPv6 address of remote anycast RP";
+                    type "jt:ipv6addr";
                   }
                 }
               }
               leaf local-address {
-                type "jt:ipv6addr";
                 description "Local address for replicating register messages to other RPs";
+                type "jt:ipv6addr";
               }
             }
           }
         }
       }
       container embedded-rp {
-        description "Set embedded-RP mode (IPv6 only)";
         presence "enable embedded-rp";
+        description "Set embedded-RP mode (IPv6 only)";
         list group-ranges {
-          description "Group address range of RP";
           key name;
           ordered-by user;
+          description "Group address range of RP";
           uses pim_rp_group_range_type;
         }
         leaf maximum-rps {
-          type uint32 {
-            range "1 .. 500";
-          }
-          default "100";
           description "Maximum number of embedded RPs";
+          default "100";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 500";
+            }
+          }
         }
       }
       container auto-rp {
@@ -16237,123 +19616,140 @@ module junos-conf-protocols {
         choice autorp-mode {
           case case_1 {
             leaf discovery {
-              type empty;
               description "Listen for auto-RP discovery messages";
+              type empty;
             }
           }
           case case_2 {
             leaf announce {
-              type empty;
               description "Transmit auto-RP announcement messages";
+              type empty;
             }
           }
           case case_3 {
             leaf mapping {
-              type empty;
               description "Transmit auto-RP mapping messages";
+              type empty;
             }
           }
         }
         choice mapping-agent-election-choice {
           leaf mapping-agent-election {
-            type empty;
             description "Consider higher-addressed mapping agents as authoritative";
+            type empty;
           }
           leaf no-mapping-agent-election {
-            type empty;
             description "Don't consider higher-addressed mapping agents as authoritative";
+            type empty;
           }
         }
       }
       container static {
         description "Configure static PIM RPs";
         list address {
-          description "RP address";
           key name;
           ordered-by user;
+          description "RP address";
           leaf name {
-            type "jt:ipaddr";
             description "IP address of RP";
+            type "jt:ipaddr";
           }
           leaf version {
-            type uint32 {
-              range "1 .. 2";
-            }
             description "PIM version of RP";
             status deprecated;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 2";
+              }
+            }
           }
           list group-ranges {
-            description "Group address range of RP";
             key name;
             ordered-by user;
+            description "Group address range of RP";
             uses pim_rp_group_range_type;
           }
           leaf override {
-            type empty;
             description "Static RP mapping will take precedence over dynamic";
+            type empty;
           }
         }
       }
       container bidirectional {
         description "Configure PIM bidirectional-mode RPs";
         list address {
-          description "RP address";
           key name;
           ordered-by user;
+          description "RP address";
           leaf name {
-            type "jt:ipaddr";
             description "IP address of RP";
+            type "jt:ipaddr";
           }
           leaf priority {
-            type uint32 {
-              range "0 .. 255";
-            }
             description "Router's priority for becoming an RP";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 255";
+              }
+            }
           }
           leaf hold-time {
-            type uint32 {
-              range "1 .. 65535";
-            }
             description "How long neighbor considers this router to be up";
             units seconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 65535";
+              }
+            }
           }
           list group-ranges {
-            description "Group address range of RP";
             key name;
             ordered-by user;
+            description "Group address range of RP";
             uses pim_rp_group_range_type;
           }
         }
       }
     }
     leaf passive {
-      type empty;
       description "Configure PIM protocol in passive mode";
+      type empty;
     }
     list interface {
-      description "PIM interface options";
       key name;
       ordered-by user;
+      description "PIM interface options";
       leaf name {
-        type string;
         description "Interface name";
+        type string;
       }
       container family {
         description "Local address family";
         container any {
-          description "Default properties for all families";
           presence "enable any";
+          description "Default properties for all families";
           leaf disable {
-            type empty;
             description "Disable all families";
+            type empty;
           }
         }
         container inet {
-          description "IPv4 specific properties";
           presence "enable inet";
+          description "IPv4 specific properties";
           container bfd-liveness-detection {
             description "Bidirectional Forwarding Detection options";
             leaf version {
+              description "BFD protocol version number";
+              default "automatic";
               type enumeration {
                 enum 0 {
                   description "BFD version 0 (deprecated)";
@@ -16365,87 +19761,126 @@ module junos-conf-protocols {
                   description "Choose BFD version automatically";
                 }
               }
-              default "automatic";
-              description "BFD protocol version number";
             }
             leaf minimum-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf minimum-transmit-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit interval";
               status deprecated;
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf minimum-receive-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf multiplier {
-              type uint32 {
-                range "1 .. 255";
-              }
-              default "3";
               description "Detection time multiplier";
+              default "3";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255";
+                }
+              }
             }
             leaf inline-disable {
-              type empty;
               description "Disable inline mode for this BFD session";
+              type empty;
             }
             leaf pdu-size {
-              type uint32 {
-                range "24 .. 9000";
-              }
-              default "24";
               description "BFD transport protocol payload size";
+              default "24";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "24 .. 9000";
+                }
+              }
             }
             choice adaptation-choice {
               case case_1 {
                 leaf no-adaptation {
-                  type empty;
                   description "Disable adaptation";
+                  type empty;
                 }
               }
             }
             container transmit-interval {
               description "Transmit-interval options";
               leaf minimum-interval {
-                type uint32 {
-                  range "1 .. 255000";
-                }
                 description "Minimum transmit interval";
                 units milliseconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "1 .. 255000";
+                  }
+                }
               }
               leaf threshold {
-                type uint32;
                 description "High transmit interval triggering a trap";
                 units milliseconds;
+                type union {
+                  type uint32;
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                }
               }
             }
             container detection-time {
               description "Detection-time options";
               leaf threshold {
-                type uint32;
                 description "High detection-time triggering a trap";
                 units milliseconds;
+                type union {
+                  type uint32;
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                }
               }
             }
             container authentication {
               description "Authentication options";
               leaf key-chain {
-                type string;
                 description "Key chain name";
+                type string;
               }
               leaf algorithm {
+                description "Algorithm name";
                 type enumeration {
                   enum simple-password {
                     description "Simple password";
@@ -16463,33 +19898,34 @@ module junos-conf-protocols {
                     description "Meticulous keyed secure hash algorithm (SHA1) ";
                   }
                 }
-                description "Algorithm name";
               }
               leaf loose-check {
-                type empty;
                 description "Verify authentication only if authentication is negotiated";
+                type empty;
               }
             }
           }
           leaf mcae-mac-synchronize {
-            type empty;
             description "Mclag mac synchronization";
+            type empty;
           }
           choice enable-disable {
             case case_1 {
               leaf disable {
-                type empty;
                 description "Disable PIMv4 on this interface";
+                type empty;
               }
             }
           }
         }
         container inet6 {
-          description "IPv6 specific properties";
           presence "enable inet6";
+          description "IPv6 specific properties";
           container bfd-liveness-detection {
             description "Bidirectional Forwarding Detection options";
             leaf version {
+              description "BFD protocol version number";
+              default "automatic";
               type enumeration {
                 enum 0 {
                   description "BFD version 0 (deprecated)";
@@ -16501,87 +19937,126 @@ module junos-conf-protocols {
                   description "Choose BFD version automatically";
                 }
               }
-              default "automatic";
-              description "BFD protocol version number";
             }
             leaf minimum-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit and receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf minimum-transmit-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit interval";
               status deprecated;
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf minimum-receive-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum receive interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf multiplier {
-              type uint32 {
-                range "1 .. 255";
-              }
-              default "3";
               description "Detection time multiplier";
+              default "3";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255";
+                }
+              }
             }
             leaf inline-disable {
-              type empty;
               description "Disable inline mode for this BFD session";
+              type empty;
             }
             leaf pdu-size {
-              type uint32 {
-                range "24 .. 9000";
-              }
-              default "24";
               description "BFD transport protocol payload size";
+              default "24";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "24 .. 9000";
+                }
+              }
             }
             choice adaptation-choice {
               case case_1 {
                 leaf no-adaptation {
-                  type empty;
                   description "Disable adaptation";
+                  type empty;
                 }
               }
             }
             container transmit-interval {
               description "Transmit-interval options";
               leaf minimum-interval {
-                type uint32 {
-                  range "1 .. 255000";
-                }
                 description "Minimum transmit interval";
                 units milliseconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "1 .. 255000";
+                  }
+                }
               }
               leaf threshold {
-                type uint32;
                 description "High transmit interval triggering a trap";
                 units milliseconds;
+                type union {
+                  type uint32;
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                }
               }
             }
             container detection-time {
               description "Detection-time options";
               leaf threshold {
-                type uint32;
                 description "High detection-time triggering a trap";
                 units milliseconds;
+                type union {
+                  type uint32;
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                }
               }
             }
             container authentication {
               description "Authentication options";
               leaf key-chain {
-                type string;
                 description "Key chain name";
+                type string;
               }
               leaf algorithm {
+                description "Algorithm name";
                 type enumeration {
                   enum simple-password {
                     description "Simple password";
@@ -16599,19 +20074,18 @@ module junos-conf-protocols {
                     description "Meticulous keyed secure hash algorithm (SHA1) ";
                   }
                 }
-                description "Algorithm name";
               }
               leaf loose-check {
-                type empty;
                 description "Verify authentication only if authentication is negotiated";
+                type empty;
               }
             }
           }
           choice enable-disable {
             case case_1 {
               leaf disable {
-                type empty;
                 description "Disable PIMv6 on this interface";
+                type empty;
               }
             }
           }
@@ -16620,8 +20094,8 @@ module junos-conf-protocols {
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable PIM on this interface";
+            type empty;
           }
         }
       }
@@ -16630,28 +20104,44 @@ module junos-conf-protocols {
         container df-election {
           description "Bidir designated forwarder properties";
           leaf robustness-count {
-            type uint32 {
-              range "1 .. 10";
-            }
             description "Election robustness count";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 10";
+              }
+            }
           }
           leaf offer-period {
-            type uint32 {
-              range "100 .. 10000";
-            }
             description "Election offer message period";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "100 .. 10000";
+              }
+            }
           }
           leaf backoff-period {
-            type uint32 {
-              range "100 .. 65535";
-            }
             description "Election backoff period";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "100 .. 65535";
+              }
+            }
           }
         }
       }
       leaf mode {
+        description "Mode of interface";
         type enumeration {
           enum dense {
             description "Dense mode";
@@ -16669,104 +20159,140 @@ module junos-conf-protocols {
             description "Bidirectional-sparse-dense mode";
           }
         }
-        description "Mode of interface";
       }
       leaf priority {
-        type uint32 {
-          range "0 .. 4294967295";
-        }
         description "Hello option DR priority";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 4294967295";
+          }
+        }
       }
       container stickydr {
-        description "Make DR sticky";
         presence "enable stickydr";
+        description "Make DR sticky";
       }
       container multiple-triggered-joins {
-        description "Send multiple pim triggered joins in quick intervals";
         presence "enable multiple-triggered-joins";
+        description "Send multiple pim triggered joins in quick intervals";
         leaf count {
-          type uint16 {
-            range "2 .. 15";
-          }
-          default "2";
           description "Set number of triggered joins to be sent";
+          default "2";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "2 .. 15";
+            }
+          }
         }
         leaf interval {
-          type uint16 {
-            range "100 .. 1000";
-          }
-          default "100";
           description "Set interval between multiple triggered joins to be sent in milliseconds";
+          default "100";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "100 .. 1000";
+            }
+          }
         }
       }
       leaf version {
-        type uint32 {
-          range "1 .. 2";
-        }
         description "Force PIM version";
         status deprecated;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 2";
+          }
+        }
       }
       leaf hello-interval {
-        type uint32 {
-          range "0 .. 255";
-        }
         description "Hello interval";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 255";
+          }
+        }
       }
       leaf-list neighbor-policy {
-        type "jt:policy-algebra";
-        description "PIM neighbor policy applied to incoming hello messages";
         ordered-by user;
+        description "PIM neighbor policy applied to incoming hello messages";
+        type "jt:policy-algebra";
       }
       leaf-list accept-join-always-from {
-        type "jt:policy-algebra";
-        description "Accept pim join/prune messages based on the policy configured";
         ordered-by user;
+        description "Accept pim join/prune messages based on the policy configured";
+        type "jt:policy-algebra";
       }
       leaf accept-remote-source {
-        type empty;
         description "Accept traffic from remote source";
+        type empty;
       }
       container dual-dr {
-        description "Configure PIM Dual DR";
         presence "enable dual-dr";
+        description "Configure PIM Dual DR";
         leaf enhanced {
-          type empty;
           description "Enable enhanced PIM Dual DR";
+          type empty;
         }
       }
       leaf distributed-dr {
-        type empty;
         description "PIM Distributed DR";
+        type empty;
       }
       leaf reset-tracking-bit {
-        type empty;
         description "Clear tracking-bit in PIM Hello LAN Prune Delay Option";
+        type empty;
       }
       leaf propagation-delay {
-        type uint32 {
-          range "250 .. 2000";
-        }
-        default "500";
         description "Propagation delay value";
+        default "500";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "250 .. 2000";
+          }
+        }
       }
       leaf override-interval {
-        type uint32 {
-          range "500 .. 6000";
-        }
-        default "2000";
         description "Override interval value";
+        default "2000";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "500 .. 6000";
+          }
+        }
       }
       leaf disable-packet-register {
-        type empty;
         description "Disable PIM packet registers on first hop router";
+        type empty;
       }
       container bfd-liveness-detection {
         description "Bidirectional Forwarding Detection options (ipv4 only)";
         status deprecated;
         leaf version {
+          description "BFD protocol version number";
+          default "automatic";
           type enumeration {
             enum 0 {
               description "BFD version 0 (deprecated)";
@@ -16778,87 +20304,126 @@ module junos-conf-protocols {
               description "Choose BFD version automatically";
             }
           }
-          default "automatic";
-          description "BFD protocol version number";
         }
         leaf minimum-interval {
-          type uint32 {
-            range "1 .. 255000";
-          }
           description "Minimum transmit and receive interval";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255000";
+            }
+          }
         }
         leaf minimum-transmit-interval {
-          type uint32 {
-            range "1 .. 255000";
-          }
           description "Minimum transmit interval";
           status deprecated;
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255000";
+            }
+          }
         }
         leaf minimum-receive-interval {
-          type uint32 {
-            range "1 .. 255000";
-          }
           description "Minimum receive interval";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255000";
+            }
+          }
         }
         leaf multiplier {
-          type uint32 {
-            range "1 .. 255";
-          }
-          default "3";
           description "Detection time multiplier";
+          default "3";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255";
+            }
+          }
         }
         leaf inline-disable {
-          type empty;
           description "Disable inline mode for this BFD session";
+          type empty;
         }
         leaf pdu-size {
-          type uint32 {
-            range "24 .. 9000";
-          }
-          default "24";
           description "BFD transport protocol payload size";
+          default "24";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "24 .. 9000";
+            }
+          }
         }
         choice adaptation-choice {
           case case_1 {
             leaf no-adaptation {
-              type empty;
               description "Disable adaptation";
+              type empty;
             }
           }
         }
         container transmit-interval {
           description "Transmit-interval options";
           leaf minimum-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf threshold {
-            type uint32;
             description "High transmit interval triggering a trap";
             units milliseconds;
+            type union {
+              type uint32;
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
         }
         container detection-time {
           description "Detection-time options";
           leaf threshold {
-            type uint32;
             description "High detection-time triggering a trap";
             units milliseconds;
+            type union {
+              type uint32;
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
         }
         container authentication {
           description "Authentication options";
           leaf key-chain {
-            type string;
             description "Key chain name";
+            type string;
           }
           leaf algorithm {
+            description "Algorithm name";
             type enumeration {
               enum simple-password {
                 description "Simple password";
@@ -16876,11 +20441,10 @@ module junos-conf-protocols {
                 description "Meticulous keyed secure hash algorithm (SHA1) ";
               }
             }
-            description "Algorithm name";
           }
           leaf loose-check {
-            type empty;
             description "Verify authentication only if authentication is negotiated";
+            type empty;
           }
         }
       }
@@ -16891,44 +20455,54 @@ module junos-conf-protocols {
       container threshold {
         description "Threshold for creation of multicast tunnels";
         list group {
-          description "IP prefix of multicast group";
           key name;
           ordered-by user;
+          description "IP prefix of multicast group";
           leaf name {
-            type "jt:ipprefix";
             description "IP prefix of group";
+            type "jt:ipprefix";
           }
           list source {
-            description "IP prefix of one or more multicast sources ";
             key name;
             ordered-by user;
+            description "IP prefix of one or more multicast sources ";
             leaf name {
-              type "jt:ipprefix";
               description "IP prefix of source";
+              type "jt:ipprefix";
             }
             leaf rate {
-              type uint32 {
-                range "10 .. 1000000";
-              }
               description "Data threshold to create new tunnel";
               units kilobits;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "10 .. 1000000";
+                }
+              }
             }
           }
         }
       }
       leaf data-mdt-reuse {
-        type empty;
         description "Allow multiple customer streams to be transmitted over one data tunnel ";
+        type empty;
       }
       leaf tunnel-limit {
-        type uint32 {
-          range "0 .. 8192";
-        }
         description "Maximum multicast data tunnels";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 8192";
+          }
+        }
       }
       leaf group-range {
-        type "jt:ipprefix";
         description "Group address range for multicast data tunnels";
+        type "jt:ipprefix";
       }
     }
     container graceful-restart {
@@ -16936,112 +20510,152 @@ module junos-conf-protocols {
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable PIM graceful restart capability";
+            type empty;
           }
         }
       }
       leaf restart-duration {
-        type uint32 {
-          range "30 .. 300";
-        }
         description "Maximum time for graceful restart to finish (seconds)";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "30 .. 300";
+          }
+        }
       }
       leaf no-bidirectional-mode {
-        type empty;
         description "Disable PIM graceful restart for bidirectional mode";
+        type empty;
       }
       leaf restart-complete-duration {
-        type uint32 {
-          range "5 .. 300";
-        }
         description "Maximum time for graceful restart to complete (seconds)";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "5 .. 300";
+          }
+        }
       }
     }
     container join-load-balance {
-      description "Configure PIM join load balancing";
       presence "enable join-load-balance";
+      description "Configure PIM join load balancing";
       leaf automatic {
-        type empty;
         description "Enable automatic PIM join load balancing";
+        type empty;
       }
     }
     leaf standby-path-creation-delay {
-      type uint32 {
-        range "1 .. 300";
-      }
       description "Amount of time to wait before creating standby path";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 300";
+        }
+      }
     }
     leaf idle-standby-path-switchover-delay {
-      type uint32 {
-        range "1 .. 300";
-      }
       description "Amount of time to wait before switching over to idle standby path";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 300";
+        }
+      }
     }
     leaf dr-election-on-p2p {
-      type empty;
       description "Enable DR election on Point-to-Point Interfaces";
+      type empty;
     }
     leaf no-wildcard-register-stop {
-      type empty;
       description "Disable sending of wildcard register stop message";
+      type empty;
     }
     leaf nexthop-hold-time {
-      type uint32 {
-        range "1 .. 1000";
-      }
       description "Nexthop hold time in milliseconds";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 1000";
+        }
+      }
     }
     leaf mpls-internet-multicast {
-      type empty;
       description "Enable support for Internet Multicast over MPLS";
+      type empty;
     }
     container join-make-before-break {
       description "Enable PIM Join Make-Before-Break during RPF neighbor change";
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable Make-Before-Break for PIM RPF neighbor change";
+            type empty;
           }
         }
       }
     }
     leaf reset-tracking-bit {
-      type empty;
       description "Clear tracking-bit in PIM Hello LAN Prune Delay Option";
+      type empty;
     }
     leaf propagation-delay {
-      type uint32 {
-        range "250 .. 2000";
-      }
-      default "500";
       description "Propagation delay value";
+      default "500";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "250 .. 2000";
+        }
+      }
     }
     leaf override-interval {
-      type uint32 {
-        range "500 .. 6000";
-      }
-      default "2000";
       description "Override interval value";
+      default "2000";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "500 .. 6000";
+        }
+      }
     }
     leaf disable-packet-register {
-      type empty;
       description "Disable PIM packet registers on first hop router";
+      type empty;
     }
     container default-vpn-source {
-      description "Let all VRFs use master loopback address for mt interfaces";
       presence "enable default-vpn-source";
+      description "Let all VRFs use master loopback address for mt interfaces";
       leaf interface-name {
-        type "jt:interface-unit";
         description "Master loopback interface name";
+        type union {
+          type "jt:interface-unit";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
     }
   }
@@ -17055,42 +20669,57 @@ module junos-conf-protocols {
       uses erp-trace-options;
     }
     leaf restore-interval {
-      type uint32 {
-        range "1 .. 12";
-      }
-      default "5";
       description "Wait to restore interval";
+      default "5";
       units minutes;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 12";
+        }
+      }
     }
     leaf guard-interval {
-      type uint32 {
-        range "10 .. 2000";
-      }
-      default "500";
       description "Guard timer interval in 10ms steps";
+      default "500";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "10 .. 2000";
+        }
+      }
     }
     leaf hold-interval {
-      type uint32 {
-        range "0 .. 10000";
-      }
-      default "0";
       description "Hold off timer interval in 100ms steps";
+      default "0";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 10000";
+        }
+      }
     }
     list ethernet-ring {
-      description "Ethernet ring";
       key name;
       ordered-by user;
+      description "Ethernet ring";
       uses juniper-protocols-protection-group-ethernet-ring;
     }
   }
   grouping erp-trace-options {
     description "Trace options for Ethernet Ring Protocol";
     list flag {
-      description "Tracing parameters";
       key name;
       ordered-by user;
+      description "Tracing parameters";
       leaf name {
         type enumeration {
           enum events {
@@ -17126,40 +20755,45 @@ module junos-conf-protocols {
     container file {
       description "Trace file options";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf replace {
-        type empty;
         description "Replace trace file rather than appending to it";
         status deprecated;
+        type empty;
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "10";
         description "Maximum number of trace files";
+        default "10";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       leaf no-stamp {
-        type empty;
         description "Do not timestamp trace file";
         status deprecated;
+        type empty;
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
     }
@@ -17173,12 +20807,13 @@ module junos-conf-protocols {
   grouping juniper-protocols-protection-group-eaps-profile {
     description "Ethernet APS profile";
     leaf name {
+      description "Profile name";
       type string {
         length "1 .. 32";
       }
-      description "Profile name";
     }
     leaf protocol {
+      description "Protocol value";
       type enumeration {
         enum ccm {
           description "Use CCM packets for protection.";
@@ -17187,122 +20822,171 @@ module junos-conf-protocols {
           description "Use G.8031 packets for protection.";
         }
       }
-      description "Protocol value";
     }
     leaf revert-time {
-      type uint32 {
-        range "0 .. 15";
-      }
-      default "4";
       description "Reversion time in minutes, 0 would mean no reversion";
+      default "4";
       units minutes;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 15";
+        }
+      }
     }
     leaf hold-time {
-      type uint32 {
-        range "0 .. 10000";
-      }
-      default "0";
       description "Hold time in seconds";
+      default "0";
       units "milli seconds";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 10000";
+        }
+      }
     }
     leaf local-request {
+      description "Local APS request";
       type enumeration {
         enum lockout {
           description "Lockout protection";
         }
       }
-      description "Local APS request";
     }
   }
   grouping juniper-protocols-protection-group-ethernet-ring {
     description "Ethernet Ring protection group configuration";
     leaf name {
+      description "Name of Ethernet Ring protection group";
       type string {
         length "1 .. 32";
       }
-      description "Name of Ethernet Ring protection group";
     }
     leaf node-id {
-      type "jt:mac-unicast";
       description "Node ID of the protection group, by default bridge's MAC";
+      type "jt:mac-unicast";
     }
     leaf ring-protection-link-owner {
-      type empty;
       description "Ring protection link owner flag, one ring should have only one node as a ring protection link owner";
+      type empty;
     }
     leaf level {
-      type uint32 {
-        range "0 .. 7";
-      }
       description "MPG Level value for R-APS PDU";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 7";
+        }
+      }
     }
     leaf restore-interval {
-      type uint32 {
-        range "1 .. 12";
-      }
       description "Wait to restore interval";
       units minutes;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 12";
+        }
+      }
     }
     leaf guard-interval {
-      type uint32 {
-        range "10 .. 2000";
-      }
       description "Guard timer interval in 10ms";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "10 .. 2000";
+        }
+      }
     }
     leaf hold-interval {
-      type uint32 {
-        range "0 .. 10000";
-      }
       description "Hold off timer interval in 100ms steps";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 10000";
+        }
+      }
     }
     leaf non-revertive {
-      type empty;
       description "Non-revertive mode of operation";
+      type empty;
     }
     leaf wait-to-block-interval {
-      type uint32 {
-        range "5 .. 10";
-      }
-      default "5";
       description "Wait to block interval";
+      default "5";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "5 .. 10";
+        }
+      }
     }
     leaf major-ring-name {
+      description "Name of major-ring to which this sub-ring node attached";
       type string {
         length "1 .. 32";
       }
-      description "Name of major-ring to which this sub-ring node attached";
     }
     leaf propagate-tc {
-      type empty;
       description "Enable Topology Change Propagation to major-ring from the sub-ring";
+      type empty;
     }
     leaf compatibility-version {
-      type uint32 {
-        range "1 .. 2";
-      }
-      default "2";
       description "G.8032 compatibility version";
+      default "2";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 2";
+        }
+      }
     }
     leaf ring-id {
-      type uint32 {
-        range "1 .. 239";
-      }
-      default "1";
       description "Ethernet Ring ID of protection group";
+      default "1";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 239";
+        }
+      }
     }
     leaf non-vc-mode {
-      type empty;
       description "Node is operating in non virtual channel mode";
+      type empty;
     }
     leaf dot1p-priority {
-      type uint32 {
-        range "0 .. 7";
-      }
-      default "0";
       description "IEEE 802.1p priority of transmitted R-APS";
+      default "0";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 7";
+        }
+      }
     }
     container east-interface {
       description "East interface configuration";
@@ -17315,8 +20999,8 @@ module junos-conf-protocols {
       uses erp-interface;
     }
     leaf control-vlan {
-      type string;
       description "Dedicated VLAN identifier - VLAN id or VLAN name";
+      type string;
     }
     container data-channel {
       description "Ring instance data channel";
@@ -17326,32 +21010,42 @@ module junos-conf-protocols {
   }
   grouping erp-data-channel {
     leaf-list vlan {
-      type string;
-      description "VLAN ID or VLAN ID range [1..4094]";
       ordered-by user;
+      description "VLAN ID or VLAN ID range [1..4094]";
+      type string;
     }
   }
   grouping erp-interface {
     container control-channel {
-      description "Control channel of ring port";
       presence "enable control-channel";
+      description "Control channel of ring port";
       leaf vlan {
-        type uint16 {
-          range "1 .. 4094";
-        }
         description "Dedicated VLAN identifier";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "1 .. 4094";
+          }
+        }
       }
       leaf control-channel-name {
-        type "jt:interface-name";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
     }
     leaf ring-protection-link-end {
-      type empty;
       description "Port is connecting to ring protection link";
+      type empty;
     }
     leaf interface-none {
-      type empty;
       description "Port is not used";
+      type empty;
     }
   }
   grouping juniper-protocols-rip {
@@ -17360,47 +21054,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum auth {
@@ -17457,20 +21156,20 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
         container filter {
           description "Filter to apply to this flag";
@@ -17484,36 +21183,41 @@ module junos-conf-protocols {
       uses rib_group_inet_type;
     }
     leaf metric-in {
-      type uint32 {
-        range "1 .. 15";
-      }
       description "Metric value to add to incoming routes";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 15";
+        }
+      }
     }
     container send {
       description "Configure RIP send options";
       choice send-opts {
         case case_1 {
           leaf broadcast {
-            type empty;
             description "Broadcast RIPv2 packets (RIPv1 compatible)";
+            type empty;
           }
         }
         case case_2 {
           leaf multicast {
-            type empty;
             description "Multicast RIPv2 packets";
+            type empty;
           }
         }
         case case_3 {
           leaf none {
-            type empty;
             description "Do not send RIP updates";
+            type empty;
           }
         }
         case case_4 {
           leaf version-1 {
-            type empty;
             description "Broadcast RIPv1 packets";
+            type empty;
           }
         }
       }
@@ -17523,71 +21227,91 @@ module junos-conf-protocols {
       choice receive-opts {
         case case_1 {
           leaf both {
-            type empty;
             description "Accept both RIPv1 and RIPv2 packets";
+            type empty;
           }
         }
         case case_2 {
           leaf none {
-            type empty;
             description "Do not receive RIP packets";
+            type empty;
           }
         }
         case case_3 {
           leaf version-1 {
-            type empty;
             description "Accept RIPv1 packets only";
+            type empty;
           }
         }
         case case_4 {
           leaf version-2 {
-            type empty;
             description "Accept only RIPv2 packets";
+            type empty;
           }
         }
       }
     }
     choice check-zero-choice {
       leaf check-zero {
-        type empty;
         description "Check reserved fields on incoming RIPv2 packets";
+        type empty;
       }
       leaf no-check-zero {
-        type empty;
         description "Don't check reserved fields on incoming RIPv2 packets";
+        type empty;
       }
     }
     leaf message-size {
-      type uint32 {
-        range "25 .. 255";
-      }
       description "Number of route entries per update message";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "25 .. 255";
+        }
+      }
     }
     leaf-list import {
-      type "jt:policy-algebra";
-      description "Import policy";
       ordered-by user;
+      description "Import policy";
+      type "jt:policy-algebra";
     }
     leaf holddown {
-      type uint32 {
-        range "10 .. 180";
-      }
       description "Hold-down time";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "10 .. 180";
+        }
+      }
     }
     leaf route-timeout {
-      type uint32 {
-        range "30 .. 360";
-      }
       description "Delay before routes time out";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "30 .. 360";
+        }
+      }
     }
     leaf update-interval {
-      type uint32 {
-        range "10 .. 60";
-      }
       description "Interval between regular route updates";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "10 .. 60";
+        }
+      }
     }
     choice authentication {
       case case_1 {
@@ -17607,85 +21331,117 @@ module junos-conf-protocols {
       }
       case case_2 {
         list authentication-selective-md5 {
-          description "MD5 authentication with one or more keys";
           key name;
           ordered-by user;
+          description "MD5 authentication with one or more keys";
           leaf name {
-            type uint32 {
-              range "0 .. 255";
-            }
             description "Key ID for MD5 authentication";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 255";
+              }
+            }
           }
           leaf key {
-            type "jt:unreadable";
             description "MD5 authentication key value";
+            type "jt:unreadable";
           }
           leaf start-time {
-            type "jt:time";
             description "Start time for key transmission (YYYY-MM-DD.HH:MM)";
+            type "jt:time";
           }
         }
       }
     }
     leaf authentication-key {
-      type "jt:unreadable";
       description "Authentication key (password)";
+      type "jt:unreadable";
     }
     list group {
-      description "Instance configuration";
       key name;
       ordered-by user;
+      description "Instance configuration";
       leaf name {
-        type string;
         description "Group name";
+        type string;
       }
       leaf route-timeout {
-        type uint32 {
-          range "30 .. 360";
-        }
         description "Delay before routes time out";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "30 .. 360";
+          }
+        }
       }
       leaf update-interval {
-        type uint32 {
-          range "10 .. 60";
-        }
         description "Interval between regular route updates";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "10 .. 60";
+          }
+        }
       }
       leaf preference {
-        type uint32;
         description "Preference of routes learned by this group";
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf metric-out {
-        type uint32 {
-          range "1 .. 15";
-        }
         description "Default metric of exported routes";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 15";
+          }
+        }
       }
       leaf-list export {
-        type "jt:policy-algebra";
-        description "Export policy";
         ordered-by user;
+        description "Export policy";
+        type "jt:policy-algebra";
       }
       leaf-list import {
-        type "jt:policy-algebra";
-        description "Import policy";
         ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
       }
       leaf demand-circuit {
-        type empty;
         description "Enable demand circuit on this interface";
+        type empty;
       }
       leaf max-retrans-time {
-        type uint32 {
-          range "5 .. 180";
-        }
         description "Maximum time to re-transmit a message in demand-circuit";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "5 .. 180";
+          }
+        }
       }
       container bfd-liveness-detection {
         description "Bidirectional Forwarding Detection options";
         leaf version {
+          description "BFD protocol version number";
+          default "automatic";
           type enumeration {
             enum 0 {
               description "BFD version 0 (deprecated)";
@@ -17697,87 +21453,126 @@ module junos-conf-protocols {
               description "Choose BFD version automatically";
             }
           }
-          default "automatic";
-          description "BFD protocol version number";
         }
         leaf minimum-interval {
-          type uint32 {
-            range "1 .. 255000";
-          }
           description "Minimum transmit and receive interval";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255000";
+            }
+          }
         }
         leaf minimum-transmit-interval {
-          type uint32 {
-            range "1 .. 255000";
-          }
           description "Minimum transmit interval";
           status deprecated;
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255000";
+            }
+          }
         }
         leaf minimum-receive-interval {
-          type uint32 {
-            range "1 .. 255000";
-          }
           description "Minimum receive interval";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255000";
+            }
+          }
         }
         leaf multiplier {
-          type uint32 {
-            range "1 .. 255";
-          }
-          default "3";
           description "Detection time multiplier";
+          default "3";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255";
+            }
+          }
         }
         leaf inline-disable {
-          type empty;
           description "Disable inline mode for this BFD session";
+          type empty;
         }
         leaf pdu-size {
-          type uint32 {
-            range "24 .. 9000";
-          }
-          default "24";
           description "BFD transport protocol payload size";
+          default "24";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "24 .. 9000";
+            }
+          }
         }
         choice adaptation-choice {
           case case_1 {
             leaf no-adaptation {
-              type empty;
               description "Disable adaptation";
+              type empty;
             }
           }
         }
         container transmit-interval {
           description "Transmit-interval options";
           leaf minimum-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf threshold {
-            type uint32;
             description "High transmit interval triggering a trap";
             units milliseconds;
+            type union {
+              type uint32;
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
         }
         container detection-time {
           description "Detection-time options";
           leaf threshold {
-            type uint32;
             description "High detection-time triggering a trap";
             units milliseconds;
+            type union {
+              type uint32;
+              type string {
+                pattern "<.*>|$.*";
+              }
+            }
           }
         }
         container authentication {
           description "Authentication options";
           leaf key-chain {
-            type string;
             description "Key chain name";
+            type string;
           }
           leaf algorithm {
+            description "Algorithm name";
             type enumeration {
               enum simple-password {
                 description "Simple password";
@@ -17795,88 +21590,107 @@ module junos-conf-protocols {
                 description "Meticulous keyed secure hash algorithm (SHA1) ";
               }
             }
-            description "Algorithm name";
           }
           leaf loose-check {
-            type empty;
             description "Verify authentication only if authentication is negotiated";
+            type empty;
           }
         }
       }
       list neighbor {
-        description "Neighbor configuration";
         key name;
         ordered-by user;
+        description "Neighbor configuration";
         leaf name {
-          type "jt:interface-name";
           description "Interface name";
+          type union {
+            type "jt:interface-name";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
         leaf route-timeout {
-          type uint32 {
-            range "30 .. 360";
-          }
           description "Delay before routes time out";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "30 .. 360";
+            }
+          }
         }
         leaf update-interval {
-          type uint32 {
-            range "10 .. 60";
-          }
           description "Interval between regular route updates";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "10 .. 60";
+            }
+          }
         }
         leaf interface-type {
+          description "Interface type for the neighbor";
           type enumeration {
             enum p2mp {
               description "Point-to-multipoint link";
             }
           }
-          description "Interface type for the neighbor";
         }
         leaf dynamic-peers {
-          type empty;
           description "Learn peers dynamically on a p2mp interface";
+          type empty;
         }
         list peer {
-          description "P2MP peer";
           key name;
           ordered-by user;
+          description "P2MP peer";
           leaf name {
-            type "jt:ipaddr";
             description "Address of peer";
+            type "jt:ipaddr";
           }
         }
         leaf metric-in {
-          type uint32 {
-            range "1 .. 15";
-          }
           description "Metric value to add to incoming routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 15";
+            }
+          }
         }
         container send {
           description "Configure RIP send options";
           choice send-opts {
             case case_1 {
               leaf broadcast {
-                type empty;
                 description "Broadcast RIPv2 packets (RIPv1 compatible)";
+                type empty;
               }
             }
             case case_2 {
               leaf multicast {
-                type empty;
                 description "Multicast RIPv2 packets";
+                type empty;
               }
             }
             case case_3 {
               leaf none {
-                type empty;
                 description "Do not send RIP updates";
+                type empty;
               }
             }
             case case_4 {
               leaf version-1 {
-                type empty;
                 description "Broadcast RIPv1 packets";
+                type empty;
               }
             }
           }
@@ -17886,64 +21700,74 @@ module junos-conf-protocols {
           choice receive-opts {
             case case_1 {
               leaf both {
-                type empty;
                 description "Accept both RIPv1 and RIPv2 packets";
+                type empty;
               }
             }
             case case_2 {
               leaf none {
-                type empty;
                 description "Do not receive RIP packets";
+                type empty;
               }
             }
             case case_3 {
               leaf version-1 {
-                type empty;
                 description "Accept RIPv1 packets only";
+                type empty;
               }
             }
             case case_4 {
               leaf version-2 {
-                type empty;
                 description "Accept only RIPv2 packets";
+                type empty;
               }
             }
           }
         }
         leaf demand-circuit {
-          type empty;
           description "Enable demand circuit on this interface";
+          type empty;
         }
         leaf max-retrans-time {
-          type uint32 {
-            range "5 .. 180";
-          }
           description "Maximum time to re-transmit a msg in demand-circuit";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "5 .. 180";
+            }
+          }
         }
         choice check-zero-choice {
           leaf check-zero {
-            type empty;
             description "Check reserved fields on incoming RIPv1 packets";
+            type empty;
           }
           leaf no-check-zero {
-            type empty;
             description "Don't check reserved fields on incoming RIPv1 packets";
+            type empty;
           }
         }
         leaf any-sender {
-          type empty;
           description "Disable strict checks on sender address";
+          type empty;
         }
         leaf message-size {
-          type uint32 {
-            range "25 .. 255";
-          }
           description "Number of route entries per update message";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "25 .. 255";
+            }
+          }
         }
         leaf-list import {
-          type "jt:policy-algebra";
-          description "Import policy";
           ordered-by user;
+          description "Import policy";
+          type "jt:policy-algebra";
         }
         choice authentication {
           case case_1 {
@@ -17963,33 +21787,40 @@ module junos-conf-protocols {
           }
           case case_2 {
             list authentication-selective-md5 {
-              description "MD5 authentication with one or more keys";
               key name;
               ordered-by user;
+              description "MD5 authentication with one or more keys";
               leaf name {
-                type uint32 {
-                  range "0 .. 255";
-                }
                 description "Key ID for MD5 authentication";
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 255";
+                  }
+                }
               }
               leaf key {
-                type "jt:unreadable";
                 description "MD5 authentication key value";
+                type "jt:unreadable";
               }
               leaf start-time {
-                type "jt:time";
                 description "Start time for key transmission (YYYY-MM-DD.HH:MM)";
+                type "jt:time";
               }
             }
           }
         }
         leaf authentication-key {
-          type "jt:unreadable";
           description "Authentication key (password)";
+          type "jt:unreadable";
         }
         container bfd-liveness-detection {
           description "Bidirectional Forwarding Detection options";
           leaf version {
+            description "BFD protocol version number";
+            default "automatic";
             type enumeration {
               enum 0 {
                 description "BFD version 0 (deprecated)";
@@ -18001,87 +21832,126 @@ module junos-conf-protocols {
                 description "Choose BFD version automatically";
               }
             }
-            default "automatic";
-            description "BFD protocol version number";
           }
           leaf minimum-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit and receive interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf minimum-transmit-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum transmit interval";
             status deprecated;
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf minimum-receive-interval {
-            type uint32 {
-              range "1 .. 255000";
-            }
             description "Minimum receive interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255000";
+              }
+            }
           }
           leaf multiplier {
-            type uint32 {
-              range "1 .. 255";
-            }
-            default "3";
             description "Detection time multiplier";
+            default "3";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1 .. 255";
+              }
+            }
           }
           leaf inline-disable {
-            type empty;
             description "Disable inline mode for this BFD session";
+            type empty;
           }
           leaf pdu-size {
-            type uint32 {
-              range "24 .. 9000";
-            }
-            default "24";
             description "BFD transport protocol payload size";
+            default "24";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "24 .. 9000";
+              }
+            }
           }
           choice adaptation-choice {
             case case_1 {
               leaf no-adaptation {
-                type empty;
                 description "Disable adaptation";
+                type empty;
               }
             }
           }
           container transmit-interval {
             description "Transmit-interval options";
             leaf minimum-interval {
-              type uint32 {
-                range "1 .. 255000";
-              }
               description "Minimum transmit interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 255000";
+                }
+              }
             }
             leaf threshold {
-              type uint32;
               description "High transmit interval triggering a trap";
               units milliseconds;
+              type union {
+                type uint32;
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
           }
           container detection-time {
             description "Detection-time options";
             leaf threshold {
-              type uint32;
               description "High detection-time triggering a trap";
               units milliseconds;
+              type union {
+                type uint32;
+                type string {
+                  pattern "<.*>|$.*";
+                }
+              }
             }
           }
           container authentication {
             description "Authentication options";
             leaf key-chain {
-              type string;
               description "Key chain name";
+              type string;
             }
             leaf algorithm {
+              description "Algorithm name";
               type enumeration {
                 enum simple-password {
                   description "Simple password";
@@ -18099,32 +21969,36 @@ module junos-conf-protocols {
                   description "Meticulous keyed secure hash algorithm (SHA1) ";
                 }
               }
-              description "Algorithm name";
             }
             leaf loose-check {
-              type empty;
               description "Verify authentication only if authentication is negotiated";
+              type empty;
             }
           }
         }
       }
     }
     container graceful-restart {
-      description "RIP graceful restart options";
       presence "enable graceful-restart";
+      description "RIP graceful restart options";
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable graceful restart";
+            type empty;
           }
         }
       }
       leaf restart-time {
-        type uint32 {
-          range "1 .. 600";
-        }
         description "Time after which RIP is declared out of restart";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 600";
+          }
+        }
       }
     }
   }
@@ -18134,47 +22008,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum error {
@@ -18228,36 +22107,41 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf metric-in {
-      type uint32 {
-        range "1 .. 15";
-      }
       description "Metric value to add to incoming routes";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 15";
+        }
+      }
     }
     container send {
       description "Configure RIPng send options";
       choice send-opts {
         case case_1 {
           leaf none {
-            type empty;
             description "Do not send RIPng updates";
+            type empty;
           }
         }
       }
@@ -18267,115 +22151,170 @@ module junos-conf-protocols {
       choice receive-opts {
         case case_1 {
           leaf none {
-            type empty;
             description "Do not receive RIPng packets";
+            type empty;
           }
         }
       }
     }
     leaf-list import {
-      type "jt:policy-algebra";
-      description "Import policy";
       ordered-by user;
+      description "Import policy";
+      type "jt:policy-algebra";
     }
     leaf holddown {
-      type uint32 {
-        range "10 .. 180";
-      }
       description "Hold-down time";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "10 .. 180";
+        }
+      }
     }
     leaf route-timeout {
-      type uint32 {
-        range "30 .. 360";
-      }
       description "Delay before routes time out";
       units seconds;
-    }
-    leaf update-interval {
-      type uint32 {
-        range "10 .. 60";
-      }
-      description "Interval between regular route updates";
-      units seconds;
-    }
-    list group {
-      description "Instance configuration";
-      key name;
-      ordered-by user;
-      leaf name {
-        type string;
-        description "Group name";
-      }
-      leaf route-timeout {
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
         type uint32 {
           range "30 .. 360";
         }
-        description "Delay before routes time out";
-        units seconds;
       }
-      leaf update-interval {
+    }
+    leaf update-interval {
+      description "Interval between regular route updates";
+      units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
         type uint32 {
           range "10 .. 60";
         }
-        description "Interval between regular route updates";
+      }
+    }
+    list group {
+      key name;
+      ordered-by user;
+      description "Instance configuration";
+      leaf name {
+        description "Group name";
+        type string;
+      }
+      leaf route-timeout {
+        description "Delay before routes time out";
         units seconds;
-      }
-      leaf preference {
-        type uint32;
-        description "Preference of routes learned by this group";
-      }
-      leaf metric-out {
-        type uint32 {
-          range "1 .. 15";
-        }
-        description "Default metric of exported routes";
-      }
-      leaf-list export {
-        type "jt:policy-algebra";
-        description "Export policy";
-        ordered-by user;
-      }
-      leaf-list import {
-        type "jt:policy-algebra";
-        description "Import policy";
-        ordered-by user;
-      }
-      list neighbor {
-        description "Neighbor configuration";
-        key name;
-        ordered-by user;
-        leaf name {
-          type "jt:interface-name";
-          description "Interface name";
-        }
-        leaf route-timeout {
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
           type uint32 {
             range "30 .. 360";
           }
-          description "Delay before routes time out";
-          units seconds;
         }
-        leaf update-interval {
+      }
+      leaf update-interval {
+        description "Interval between regular route updates";
+        units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
           type uint32 {
             range "10 .. 60";
           }
-          description "Interval between regular route updates";
-          units seconds;
         }
-        leaf metric-in {
+      }
+      leaf preference {
+        description "Preference of routes learned by this group";
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
+      }
+      leaf metric-out {
+        description "Default metric of exported routes";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
           type uint32 {
             range "1 .. 15";
           }
+        }
+      }
+      leaf-list export {
+        ordered-by user;
+        description "Export policy";
+        type "jt:policy-algebra";
+      }
+      leaf-list import {
+        ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
+      }
+      list neighbor {
+        key name;
+        ordered-by user;
+        description "Neighbor configuration";
+        leaf name {
+          description "Interface name";
+          type union {
+            type "jt:interface-name";
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
+        }
+        leaf route-timeout {
+          description "Delay before routes time out";
+          units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "30 .. 360";
+            }
+          }
+        }
+        leaf update-interval {
+          description "Interval between regular route updates";
+          units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "10 .. 60";
+            }
+          }
+        }
+        leaf metric-in {
           description "Metric value to add to incoming routes";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 15";
+            }
+          }
         }
         container send {
           description "Configure RIPng send options";
           choice send-opts {
             case case_1 {
               leaf none {
-                type empty;
                 description "Do not send RIPng updates";
+                type empty;
               }
             }
           }
@@ -18385,35 +22324,40 @@ module junos-conf-protocols {
           choice receive-opts {
             case case_1 {
               leaf none {
-                type empty;
                 description "Do not receive RIPng packets";
+                type empty;
               }
             }
           }
         }
         leaf-list import {
-          type "jt:policy-algebra";
-          description "Import policy";
           ordered-by user;
+          description "Import policy";
+          type "jt:policy-algebra";
         }
       }
     }
     container graceful-restart {
-      description "RIPng graceful restart options";
       presence "enable graceful-restart";
+      description "RIPng graceful restart options";
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable graceful restart";
+            type empty;
           }
         }
       }
       leaf restart-time {
-        type uint32 {
-          range "1 .. 600";
-        }
         description "Time after which RIPng is declared out of restart";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 600";
+          }
+        }
       }
     }
   }
@@ -18421,8 +22365,8 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable router discovery";
+          type empty;
         }
       }
     }
@@ -18431,47 +22375,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum route {
@@ -18503,66 +22452,91 @@ module junos-conf-protocols {
       }
     }
     list interface {
-      description "Interfaces on which to configure router discovery";
       key name;
       ordered-by user;
+      description "Interfaces on which to configure router discovery";
       leaf name {
-        type "jt:interface-name";
         description "Interface name";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       leaf max-advertisement-interval {
-        type uint32 {
-          range "4 .. 1800";
-        }
         description "Maximum time before sending advertisements";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "4 .. 1800";
+          }
+        }
       }
       leaf min-advertisement-interval {
-        type uint32 {
-          range "3 .. 1800";
-        }
         description "Minimum time before sending advertisements";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "3 .. 1800";
+          }
+        }
       }
       leaf lifetime {
-        type uint32 {
-          range "3 .. 9000";
-        }
         description "How long addresses in advertisements are valid";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "3 .. 9000";
+          }
+        }
       }
     }
     list address {
-      description "IP addresses to include in advertisements";
       key name;
       ordered-by user;
+      description "IP addresses to include in advertisements";
       leaf name {
-        type "jt:ipv4addr";
         description "IP addresses to include in router advertisements";
+        type "jt:ipv4addr";
       }
       leaf advertise {
-        type empty;
         description "Advertise the IP address in advertisements";
+        type empty;
       }
       leaf ignore {
-        type empty;
         description "Do not advertise the IP address in advertisements";
+        type empty;
       }
       leaf broadcast {
-        type empty;
         description "Include IP address only in broadcast advertisements";
+        type empty;
       }
       leaf multicast {
-        type empty;
         description "Include IP address only in multicast advertisements";
+        type empty;
       }
       leaf ineligible {
-        type empty;
         description "IP address can never become a default router";
+        type empty;
       }
       leaf priority {
-        type int32;
         description "Preference of the address to become a default router";
+        type union {
+          type int32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
     }
   }
@@ -18571,8 +22545,8 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable RSVP";
+          type empty;
         }
       }
     }
@@ -18581,122 +22555,152 @@ module junos-conf-protocols {
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable RSVP graceful restart capability";
+            type empty;
           }
         }
       }
       leaf helper-disable {
-        type empty;
         description "Disable graceful restart helper capability";
+        type empty;
       }
       leaf maximum-helper-restart-time {
-        type uint32 {
-          range "1 .. 1800";
-        }
-        default "20";
         description "Maximum wait time from down event to neighbor dead";
+        default "20";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 1800";
+          }
+        }
       }
       leaf maximum-helper-recovery-time {
-        type uint32 {
-          range "1 .. 3600";
-        }
-        default "180";
         description "Maximum time restarting neighbor states are kept";
+        default "180";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 3600";
+          }
+        }
       }
     }
     container tunnel-services {
-      description "Use tunnel services for P2MP LSP ultimate-hop popping";
       presence "enable tunnel-services";
+      description "Use tunnel services for P2MP LSP ultimate-hop popping";
       leaf-list devices {
-        type "jt:interface-device";
-        description "Tunnel services devices to use for P2MP LSPs";
         ordered-by user;
+        description "Tunnel services devices to use for P2MP LSPs";
+        type union {
+          type "jt:interface-device";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
     }
     leaf no-p2mp-sublsp {
-      type empty;
       description "Disable P2MP sub-LSP object generation";
+      type empty;
     }
     leaf no-node-id-subobject {
-      type empty;
       description "Do not include the node-id sub-object in the RRO";
+      type empty;
     }
     leaf no-interface-hello {
-      type empty;
       description "Disble interface Hellos on all RSVP interfaces";
+      type empty;
     }
     container pop-and-forward {
       description "RSVP pop-and-forward specific global parameters";
       container application-label {
         description "Number of application labels under the RSVP transport";
         leaf depth {
-          type uint32 {
-            range "0 .. 3";
-          }
-          default "1";
           description "Application label depth";
+          default "1";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 3";
+            }
+          }
         }
       }
     }
     leaf hello-acknowledgements {
-      type empty;
       description "Acknowledge Hellos on RSVP interfaces not having sessions";
+      type empty;
     }
     leaf no-hello-acknowledgements {
-      type empty;
       description "Do not ack Hellos on RSVP interfaces not having sessions";
+      type empty;
     }
     container node-hello {
-      description "Enable node-ID based Hellos on all RSVP interfaces";
       presence "enable node-hello";
+      description "Enable node-ID based Hellos on all RSVP interfaces";
       leaf hello-interval {
-        type uint32 {
-          range "0 .. 60";
-        }
-        default "9";
         description "Hello interval";
+        default "9";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 60";
+          }
+        }
       }
     }
     leaf no-node-hello {
-      type empty;
       description "Disable node-ID based Hellos on the router";
+      type empty;
     }
     leaf allow-bidirectional {
-      type empty;
       description "Enable bidirectional support in RSVP";
       status deprecated;
+      type empty;
     }
     leaf local-reversion {
-      type empty;
       description "Enable local reversion at this Point of Local Repair";
+      type empty;
     }
     leaf no-local-reversion {
-      type empty;
       description "Disable local reversion at this Point of Local Repair";
+      type empty;
     }
     leaf rfc6510-lsp-attributes {
-      type empty;
       description "Use RFC6510 compliant LSP_ATTRIBUTES";
+      type empty;
     }
     container fast-reroute {
       description "One-to-one fast-reroute protection mechanism";
       leaf optimize-timer {
-        type int32 {
-          range "0 .. 65535";
-        }
         description "Frequency of reoptimization for fast-reroute detour";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "0 .. 65535";
+          }
+        }
       }
     }
     container load-balance {
       description "Per-packet load-balancing algorithm";
       leaf bandwidth {
-        type empty;
         description "Per-packet load balancing proportional to LSP bandwidth";
+        type empty;
       }
     }
     container traceoptions {
@@ -18704,47 +22708,52 @@ module junos-conf-protocols {
       container file {
         description "Trace file options";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf replace {
-          type empty;
           description "Replace trace file rather than appending to it";
           status deprecated;
+          type empty;
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "10";
           description "Maximum number of trace files";
+          default "10";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         leaf no-stamp {
-          type empty;
           description "Do not timestamp trace file";
           status deprecated;
+          type empty;
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum io-event {
@@ -18798,244 +22807,279 @@ module junos-conf-protocols {
           }
         }
         leaf send {
-          type empty;
           description "Trace transmitted packets";
+          type empty;
         }
         leaf receive {
-          type empty;
           description "Trace received packets";
+          type empty;
         }
         leaf detail {
-          type empty;
           description "Trace detailed information";
+          type empty;
         }
         leaf disable {
-          type empty;
           description "Disable this trace flag";
+          type empty;
         }
       }
     }
     leaf refresh-time {
-      type uint32 {
-        range "1 .. 65535";
-      }
-      default "1200";
       description "Refresh time in seconds";
+      default "1200";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 65535";
+        }
+      }
     }
     leaf keep-multiplier {
-      type uint32 {
-        range "1 .. 255";
-      }
-      default "3";
       description "Keep multiplier";
+      default "3";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 255";
+        }
+      }
     }
     leaf graceful-deletion-timeout {
-      type uint32 {
-        range "1 .. 300";
-      }
-      default "30";
       description "Time to complete graceful deletion signaling";
+      default "30";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 300";
+        }
+      }
     }
     leaf setup-protection {
-      type empty;
       description "Enable setup protection";
+      type empty;
     }
     leaf no-p2mp-re-merge {
-      type empty;
       description "Enable p2mp remerge";
+      type empty;
     }
     leaf cross-credibility-cspf {
-      type empty;
       description "Compute CSPF paths spanning protocols for bypass LSP, detour LSP and loose hop expansion";
+      type empty;
     }
     container preemption {
       description "Set RSVP session preemption attributes";
       choice preemption-type {
         case case_1 {
           leaf disabled {
-            type empty;
             description "No RSVP session preemption";
+            type empty;
           }
         }
         case case_2 {
           leaf normal {
-            type empty;
             description "Run RSVP session preemption to accommodate new sessions";
+            type empty;
           }
         }
         case case_3 {
           leaf aggressive {
-            type empty;
             description "Run RSVP session preemption whenever necessary";
+            type empty;
           }
         }
       }
       container soft-preemption {
         description "Options for establishing new path before tearing down a preempted LSP";
         leaf cleanup-timer {
-          type int32 {
-            range "0 .. 10800";
-          }
           description "Time a soft-preempted LSP will be maintained";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type int32 {
+              range "0 .. 10800";
+            }
+          }
         }
       }
     }
     leaf authentication-key {
-      type "jt:unreadable";
       description "Authentication password";
+      type "jt:unreadable";
     }
     leaf no-authentication-check {
-      type empty;
       description "Skip authentication check for received messages";
+      type empty;
     }
     container associated-bidirectional-lsp {
       description "Set associated bidirectional LSP attributes";
       leaf single-sided-provisioning {
-        type empty;
         description "Enable unidirectional reverse LSP setup for single sided provisioned forward LSP";
+        type empty;
       }
     }
     leaf no-enhanced-frr-bypass {
-      type empty;
       description "Disable enhanced facility backup FRR";
+      type empty;
     }
     leaf no-node-hello-on-bypass {
-      type empty;
       description "Do not send NodeID hello over bypass LSP";
+      type empty;
     }
     container expand-flood-reflector-hop {
-      description "Control expansion of flood reflector ERO strict hops";
       presence "enable expand-flood-reflector-hop";
+      description "Control expansion of flood reflector ERO strict hops";
     }
     list interface {
-      description "RSVP interface options";
       key name;
       ordered-by user;
+      description "RSVP interface options";
       leaf name {
-        type "jt:interface-name";
         description "Interface name";
+        type union {
+          type "jt:interface-name";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable RSVP on this interface";
+            type empty;
           }
         }
       }
       leaf authentication-key {
-        type "jt:unreadable";
         description "Authentication password";
+        type "jt:unreadable";
       }
       choice aggregate-choice {
         leaf aggregate {
-          type empty;
           description "Permit refresh reduction extensions on the interface";
           status deprecated;
+          type empty;
         }
         leaf no-aggregate {
-          type empty;
           description "Don't permit refresh reduction extensions on the interface";
           status deprecated;
+          type empty;
         }
       }
       choice reliable-choice {
         leaf reliable {
-          type empty;
           description "Permit reliable message delivery on the interface";
+          type empty;
         }
         leaf no-reliable {
-          type empty;
           description "Don't permit reliable message delivery on the interface";
+          type empty;
         }
       }
       leaf hello-interval {
-        type uint32 {
-          range "0 .. 60";
-        }
-        default "9";
         description "Hello interval";
+        default "9";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 60";
+          }
+        }
       }
       container subscription {
         description "Link bandwidth percentage for RSVP reservation";
         uses subscription-type;
       }
       leaf bandwidth {
-        type string;
         description "Available bandwidth for the interface units bps";
+        type string;
       }
       container update-threshold {
         description "Change in reserved bandwidth to trigger IGP update";
         container adaptive {
           description "Tune update-threshold dynamically";
           list limit {
-            description "Available Bandwidth threshold limit";
             key name;
+            description "Available Bandwidth threshold limit";
             leaf name {
-              type string;
               description "Upper limit of Available bandwidth for this range";
+              type string;
             }
             leaf threshold-percent {
+              description "Percentage change in reserved bandwidth to trigger IGP update";
+              default "10.0";
+              units percent;
               type decimal64 {
                 fraction-digits 9;
                 range "0.001 .. 20";
               }
-              default "10.0";
-              description "Percentage change in reserved bandwidth to trigger IGP update";
-              units percent;
             }
             leaf threshold-value {
-              type string;
               description "Change in reserved bandwidth to trigger IGP update (will be capped at 20% of link BW)";
+              type string;
             }
           }
         }
         leaf threshold-percent {
+          description "Percentage change in reserved bandwidth to trigger IGP update";
+          default "10.0";
+          units percent;
           type decimal64 {
             fraction-digits 9;
             range "0.001 .. 20";
           }
-          default "10.0";
-          description "Percentage change in reserved bandwidth to trigger IGP update";
-          units percent;
         }
         leaf threshold-value {
-          type string;
           description "Change in reserved bandwidth to trigger IGP update (will be capped at 20% of link BW)";
+          type string;
         }
       }
       container update-threshold-max-reservable {
         description "Change in non-rsvp bandwidth to trigger IGP update ";
         leaf bandwidth {
-          type string;
           description "Change in non-rsvp bandwidth to trigger IGP update units bps";
+          type string;
         }
         leaf percent {
-          type uint32 {
-            range "1 .. 100";
-          }
           description "Percentage change in max-reservable bandwidth to trigger IGP update";
           units percent;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 100";
+            }
+          }
         }
       }
       container non-rsvp-bandwdith {
         description "Config knobs relating to non-rsvp bandwidth";
         leaf local-bw-override-threshold {
-          type empty;
           description "Overide threshold and update local bandwidth with non-rsvp bandwidth usage";
+          type empty;
         }
       }
       container link-protection {
-        description "Protect traffic with a label-stacked LSP";
         presence "enable link-protection";
+        description "Protect traffic with a label-stacked LSP";
         choice enable-disable {
           case case_1 {
             leaf disable {
-              type empty;
               description "Disable link protection on this interface";
+              type empty;
             }
           }
         }
@@ -19044,86 +23088,121 @@ module junos-conf-protocols {
           uses bandwidth-type;
         }
         leaf max-bypasses {
-          type uint32 {
-            range "0 .. 99";
-          }
-          default "1";
           description "Max number of bypasses permitted for protecting this interface";
+          default "1";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 99";
+            }
+          }
         }
         leaf subscription {
-          type uint32 {
-            range "1 .. 65535";
-          }
-          default "100";
           description "Percent of bandwidth guaranteed when admitting protected LSPs into bypasses";
+          default "100";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 65535";
+            }
+          }
         }
         leaf no-node-protection {
-          type empty;
           description "Disallow node protection on this interface";
+          type empty;
         }
         leaf optimize-timer {
-          type uint32 {
-            range "0 .. 65535";
-          }
-          default "0";
           description "Interval between bypass reoptimizations";
+          default "0";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 65535";
+            }
+          }
         }
         leaf class-of-service {
-          type int32 {
-            range "0 .. 7";
-          }
           description "Class of service for the bypass LSP";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type int32 {
+              range "0 .. 7";
+            }
+          }
         }
         leaf hop-limit {
-          type uint32 {
-            range "2 .. 255";
-          }
           description "Maximum allowed router hops for bypass";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 255";
+            }
+          }
         }
         leaf no-cspf {
-          type empty;
           description "Disable automatic path computation";
+          type empty;
         }
         leaf exclude-srlg {
-          type empty;
           description "Exclude SRLG links";
+          type empty;
         }
         container priority {
-          description "Preemption priorities for the bypass LSP";
           presence "enable priority";
+          description "Preemption priorities for the bypass LSP";
         }
         leaf setup-priority {
-          type uint32 {
-            range "0 .. 7";
-          }
           description "Set-up priority";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 7";
+            }
+          }
         }
         leaf reservation-priority {
-          type uint32 {
-            range "0 .. 7";
-          }
           description "Reservation priority";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "0 .. 7";
+            }
+          }
         }
         list path {
-          description "Explicit route of bypass path";
           key name;
           ordered-by user;
+          description "Explicit route of bypass path";
           leaf name {
-            type "jt:ipv4addr";
             description "Address of next system in path";
+            type "jt:ipv4addr";
           }
           choice loose_strict_none {
             case case_1 {
               leaf loose {
-                type empty;
                 description "Next hop might not be adjacent";
+                type empty;
               }
             }
             case case_2 {
               leaf strict {
-                type empty;
                 description "Next hop must be adjacent";
+                type empty;
               }
             }
           }
@@ -19133,18 +23212,18 @@ module junos-conf-protocols {
           uses admin_group_include_exclude;
         }
         list bypass {
-          description "Bypass with specific constraints";
           key name;
           ordered-by user;
+          description "Bypass with specific constraints";
           leaf name {
+            description "Name of bypass";
             type string {
               length "1 .. 64";
             }
-            description "Name of bypass";
           }
           leaf to {
-            type "jt:ipv4addr";
             description "Address of egress router";
+            type "jt:ipv4addr";
           }
           container bandwidth {
             description "Bandwidth for each bypass";
@@ -19156,66 +23235,86 @@ module junos-conf-protocols {
             uses bypass-subscription-type;
           }
           leaf description {
+            description "Text description of bypass";
             type string {
               length "1 .. 80";
             }
-            description "Text description of bypass";
           }
           container priority {
-            description "Preemption priorities for bypass";
             presence "enable priority";
+            description "Preemption priorities for bypass";
           }
           leaf setup-priority {
-            type uint32 {
-              range "0 .. 7";
-            }
             description "Set-up priority";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 7";
+              }
+            }
           }
           leaf reservation-priority {
-            type uint32 {
-              range "0 .. 7";
-            }
             description "Reservation priority";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "0 .. 7";
+              }
+            }
           }
           leaf class-of-service {
-            type int32 {
-              range "0 .. 7";
-            }
             description "Class of service for the bypass LSP";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type int32 {
+                range "0 .. 7";
+              }
+            }
           }
           leaf hop-limit {
-            type uint32 {
-              range "2 .. 255";
-            }
             description "Maximum allowed router hops for bypass";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 255";
+              }
+            }
           }
           leaf no-cspf {
-            type empty;
             description "Disable automatic path computation";
+            type empty;
           }
           leaf exclude-srlg {
-            type empty;
             description "Exclude SRLG links";
+            type empty;
           }
           list path {
-            description "Explicit route of bypass path";
             key name;
             ordered-by user;
+            description "Explicit route of bypass path";
             leaf name {
-              type "jt:ipv4addr";
               description "Address of next system in path";
+              type "jt:ipv4addr";
             }
             choice loose_strict_none {
               case case_1 {
                 leaf loose {
-                  type empty;
                   description "Next hop might not be adjacent";
+                  type empty;
                 }
               }
               case case_2 {
                 leaf strict {
-                  type empty;
                   description "Next hop must be adjacent";
+                  type empty;
                 }
               }
             }
@@ -19230,8 +23329,8 @@ module junos-conf-protocols {
           choice compute-algo {
             case case_1 {
               leaf bandwidth {
-                type empty;
                 description "Compute path optimized for available bandwidth";
+                type empty;
               }
             }
           }
@@ -19239,77 +23338,82 @@ module junos-conf-protocols {
       }
     }
     list peer-interface {
-      description "Configuration for peer interface";
       key name;
       ordered-by user;
+      description "Configuration for peer interface";
       leaf name {
-        type string;
         description "Name of peer interface";
+        type string;
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable RSVP on this control peer";
+            type empty;
           }
         }
       }
       leaf authentication-key {
-        type "jt:unreadable";
         description "Authentication password";
+        type "jt:unreadable";
       }
       choice aggregate-choice {
         leaf aggregate {
-          type empty;
           description "Permit refresh reduction extensions on the interface";
           status deprecated;
+          type empty;
         }
         leaf no-aggregate {
-          type empty;
           description "Don't permit refresh reduction extensions on the interface";
           status deprecated;
+          type empty;
         }
       }
       choice reliable-choice {
         leaf reliable {
-          type empty;
           description "Permit reliable message delivery on the interface";
+          type empty;
         }
         leaf no-reliable {
-          type empty;
           description "Don't permit reliable message delivery on the interface";
+          type empty;
         }
       }
       leaf hello-interval {
-        type uint32 {
-          range "0 .. 60";
-        }
-        default "9";
         description "Hello interval";
+        default "9";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 60";
+          }
+        }
       }
       container dynamic-bidirectional-transport {
-        description "Enable dynamic setup of bidirectional packet LSP for transporting non-packet GMPLS LSP";
         presence "enable dynamic-bidirectional-transport";
+        description "Enable dynamic setup of bidirectional packet LSP for transporting non-packet GMPLS LSP";
         leaf template {
-          type string;
           description "Template for the dynamic bidirectional packet LSP";
+          type string;
         }
       }
     }
     list lsp-set {
-      description "Configuration for lsp set";
       key name;
       ordered-by user;
+      description "Configuration for lsp set";
       leaf name {
-        type string;
         description "Name of lsp set";
+        type string;
       }
       choice enable-disable {
         case case_1 {
           leaf disable {
-            type empty;
             description "Disable this lsp set";
+            type empty;
           }
         }
       }
@@ -19322,47 +23426,52 @@ module junos-conf-protocols {
         container file {
           description "Trace file options";
           leaf filename {
+            description "Name of file in which to write trace information";
             type string {
               length "1 .. 1024";
             }
-            description "Name of file in which to write trace information";
           }
           leaf replace {
-            type empty;
             description "Replace trace file rather than appending to it";
             status deprecated;
+            type empty;
           }
           leaf size {
-            type string;
             description "Maximum trace file size";
+            type string;
           }
           leaf files {
-            type uint32 {
-              range "2 .. 1000";
-            }
-            default "10";
             description "Maximum number of trace files";
+            default "10";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 1000";
+              }
+            }
           }
           leaf no-stamp {
-            type empty;
             description "Do not timestamp trace file";
             status deprecated;
+            type empty;
           }
           choice world-readable-choice {
             leaf world-readable {
-              type empty;
               description "Allow any user to read the log file";
+              type empty;
             }
             leaf no-world-readable {
-              type empty;
               description "Don't allow any user to read the log file";
+              type empty;
             }
           }
         }
         list flag {
-          description "Tracing parameters";
           key name;
           ordered-by user;
+          description "Tracing parameters";
           leaf name {
             type enumeration {
               enum io-event {
@@ -19416,20 +23525,20 @@ module junos-conf-protocols {
             }
           }
           leaf send {
-            type empty;
             description "Trace transmitted packets";
+            type empty;
           }
           leaf receive {
-            type empty;
             description "Trace received packets";
+            type empty;
           }
           leaf detail {
-            type empty;
             description "Trace detailed information";
+            type empty;
           }
           leaf disable {
-            type empty;
             description "Disable this trace flag";
+            type empty;
           }
         }
       }
@@ -19437,155 +23546,185 @@ module junos-conf-protocols {
   }
   grouping bypass-subscription-type {
     leaf subscription {
-      type string;
-      default "100";
       description "Subscription percentage for bandwidth protection";
+      default "100";
+      type string;
     }
   }
   grouping juniper-protocols-stp {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable STP";
+          type empty;
         }
       }
     }
     leaf bpdu-destination-mac-address {
+      description "Destination MAC address in the spanning tree BPDUs";
       type enumeration {
         enum provider-bridge-group {
           description "802.1ad provider bridge group address";
         }
       }
-      description "Destination MAC address in the spanning tree BPDUs";
     }
     leaf bridge-priority {
-      type string;
       description "Priority of the bridge (in increments of 4k - 0,4k,8k,..60k)";
+      type string;
     }
     leaf backup-bridge-priority {
-      type string;
       description "Priority of the bridge (in increments of 4k - 4k,8k,..60k)";
+      type string;
     }
     leaf max-age {
-      type uint16 {
-        range "6 .. 40";
-      }
       description "Maximum age of received protocol bpdu";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "6 .. 40";
+        }
+      }
     }
     leaf hello-time {
-      type uint16 {
-        range "1 .. 10";
-      }
       description "Time interval between configuration BPDUs";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "1 .. 10";
+        }
+      }
     }
     leaf forward-delay {
-      type uint16 {
-        range "4 .. 30";
-      }
       description "Time spent in listening or learning state";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "4 .. 30";
+        }
+      }
     }
     leaf system-identifier {
-      type "jt:mac-unicast";
       description "Sytem identifier to represent this node";
+      type "jt:mac-unicast";
     }
     container traceoptions {
       description "Tracing options for debugging protocol operation";
       uses stp-trace-options;
     }
     leaf vpls-flush-on-topology-change {
-      type empty;
       description "Enable VPLS MAC flush on root protected CE interface receving topology change";
+      type empty;
     }
     leaf priority-hold-time {
-      type uint16 {
-        range "1 .. 255";
-      }
       description "Hold time before switching to primary priority when core domain becomes up";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "1 .. 255";
+        }
+      }
     }
     list system-id {
-      description "System ID to IP mapping";
       key name;
       ordered-by user;
+      description "System ID to IP mapping";
       uses system-id-ip-map;
     }
     list interface {
-      description "Interface options";
       key name;
+      description "Interface options";
       uses stp-interface;
     }
     leaf extended-system-id {
-      type uint16 {
-        range "0 .. 4095";
-      }
       description "Extended system identifier";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "0 .. 4095";
+        }
+      }
     }
     leaf force-version {
+      description "Force protocol version";
       type enumeration {
         enum stp {
           description "Spanning tree protocol";
         }
       }
-      description "Force protocol version";
     }
     leaf bpdu-block-on-edge {
-      type empty;
       description "Block BPDU on all interfaces configured as edge (BPDU Protect)";
+      type empty;
     }
   }
   grouping juniper-protocols-vgd {
     container traceoptions {
       description "OVSDB trace options";
       leaf no-remote-trace {
-        type empty;
         description "Disable remote tracing";
+        type empty;
       }
       container file {
         description "Trace file information";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "3";
           description "Maximum number of trace files";
+          default "3";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
         leaf match {
-          type "jt:regular-expression";
           description "Regular expression for lines to be logged";
+          type "jt:regular-expression";
         }
         leaf microsecond-stamp {
-          type empty;
           description "Timestamp with microsecond granularity";
+          type empty;
         }
       }
       list flag {
-        description "Tracing flag parameters";
         key name;
         ordered-by user;
+        description "Tracing flag parameters";
         leaf name {
           type enumeration {
             enum interface {
@@ -19617,76 +23756,106 @@ module junos-conf-protocols {
       }
     }
     list interfaces {
-      description "Interfaces configured to be controlled by OVSDB";
       key name;
       ordered-by user;
+      description "Interfaces configured to be controlled by OVSDB";
       leaf name {
-        type "jt:interface-unit";
         description "Interface name";
+        type union {
+          type "jt:interface-unit";
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
     }
     list controller {
-      description "Controller's IP address and port";
       key name;
       ordered-by user;
+      description "Controller's IP address and port";
       leaf name {
-        type "jt:ipaddr";
         description "Controller's IPv4 address";
+        type "jt:ipaddr";
       }
       container protocol {
         description "Protocol type for controller connection";
         container tcp {
           description "Set protocol type to 'TCP'";
           leaf port {
-            type int32 {
-              range "1024 .. 65535";
-            }
             description "Controller's port number";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type int32 {
+                range "1024 .. 65535";
+              }
+            }
           }
         }
         container ssl {
           description "Set protocol type to 'SSL' (default)";
           leaf port {
-            type int32 {
-              range "1024 .. 65535";
-            }
             description "Controller's port number";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type int32 {
+                range "1024 .. 65535";
+              }
+            }
           }
         }
       }
       leaf maximum-backoff-duration {
-        type uint32 {
-          range "1000 .. 4294967295";
-        }
         description "Maximum duration to wait between connection attempts";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1000 .. 4294967295";
+          }
+        }
       }
       leaf inactivity-probe-duration {
-        type uint32;
         description "Maximum idle duration before sending inactivity probe";
         units milliseconds;
+        type union {
+          type uint32;
+          type string {
+            pattern "<.*>|$.*";
+          }
+        }
       }
     }
   }
   grouping juniper-protocols-vni-options {
     list vni {
-      description "Per-vni options";
       key name;
+      description "Per-vni options";
       leaf name {
-        type int32 {
-          range "1 .. 16777214";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type int32 {
+            range "1 .. 16777214";
+          }
         }
       }
       container vrf-target {
         description "VRF target community configuration";
         leaf export {
-          type string;
           description "Target community to use when marking routes on export";
           status deprecated;
+          type string;
         }
         leaf community {
-          type string;
           description "Target community";
+          type string;
         }
       }
     }
@@ -19695,153 +23864,188 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable VSTP";
+          type empty;
         }
       }
     }
     leaf force-version {
+      description "Force protocol version";
       type enumeration {
         enum stp {
           description "Spanning tree protocol";
         }
       }
-      description "Force protocol version";
     }
     leaf bpdu-block-on-edge {
-      type empty;
       description "Block BPDU on all interfaces configured as edge (BPDU Protect)";
+      type empty;
     }
     leaf vpls-flush-on-topology-change {
-      type empty;
       description "Enable VPLS MAC flush on root protected CE interface receving topology change";
+      type empty;
     }
     leaf priority-hold-time {
-      type uint16 {
-        range "1 .. 255";
-      }
       description "Hold time before switching to primary priority when core domain becomes up";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "1 .. 255";
+        }
+      }
     }
     list system-id {
-      description "System ID to IP mapping";
       key name;
       ordered-by user;
+      description "System ID to IP mapping";
       uses system-id-ip-map;
     }
     list interface {
-      description "Interface options";
       key name;
+      description "Interface options";
       uses stp-interface;
     }
     list vlan {
-      description "VLAN spanning tree options";
       key name;
+      description "VLAN spanning tree options";
       leaf name {
-        type string;
         description "VLAN id or all";
+        type string;
       }
       leaf bridge-priority {
-        type string;
         description "Priority of the bridge (in increments of 4k - 0,4k,8k,..60k)";
+        type string;
       }
       leaf backup-bridge-priority {
-        type string;
         description "Priority of the bridge (in increments of 4k - 4k,8k,..60k)";
+        type string;
       }
       leaf max-age {
-        type uint16 {
-          range "6 .. 40";
-        }
         description "Maximum age of received protocol bpdu";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "6 .. 40";
+          }
+        }
       }
       leaf hello-time {
-        type uint16 {
-          range "1 .. 10";
-        }
         description "Time interval between configuration BPDUs";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "1 .. 10";
+          }
+        }
       }
       leaf forward-delay {
-        type uint16 {
-          range "4 .. 30";
-        }
         description "Time spent in listening or learning state";
         units seconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint16 {
+            range "4 .. 30";
+          }
+        }
       }
       leaf system-identifier {
-        type "jt:mac-unicast";
         description "Sytem identifier to represent this node";
+        type "jt:mac-unicast";
       }
       container traceoptions {
         description "Tracing options for debugging protocol operation";
         uses stp-trace-options;
       }
       list interface {
-        description "Interface options";
         key name;
+        description "Interface options";
         uses stp-interface;
       }
     }
     container vlan-group {
-      description "Spanning tree options for group of VLANs";
       presence "enable vlan-group";
+      description "Spanning tree options for group of VLANs";
       list group {
-        description "Name if VLAN group";
         key name;
         ordered-by user;
+        description "Name if VLAN group";
         leaf name {
+          description "VLAN group name";
           type string {
             length "1 .. 63";
           }
-          description "VLAN group name";
         }
         leaf-list vlan {
-          type string;
-          description "VLAN ID or VLAN ID range [1..4094]";
           ordered-by user;
+          description "VLAN ID or VLAN ID range [1..4094]";
+          type string;
         }
         leaf bridge-priority {
-          type string;
           description "Priority of the bridge (in increments of 4k - 0,4k,8k,..60k)";
+          type string;
         }
         leaf backup-bridge-priority {
-          type string;
           description "Priority of the bridge (in increments of 4k - 4k,8k,..60k)";
+          type string;
         }
         leaf max-age {
-          type uint16 {
-            range "6 .. 40";
-          }
           description "Maximum age of received protocol bpdu";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "6 .. 40";
+            }
+          }
         }
         leaf hello-time {
-          type uint16 {
-            range "1 .. 10";
-          }
           description "Time interval between configuration BPDUs";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "1 .. 10";
+            }
+          }
         }
         leaf forward-delay {
-          type uint16 {
-            range "4 .. 30";
-          }
           description "Time spent in listening or learning state";
           units seconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint16 {
+              range "4 .. 30";
+            }
+          }
         }
         leaf system-identifier {
-          type "jt:mac-unicast";
           description "Sytem identifier to represent this node";
+          type "jt:mac-unicast";
         }
         container traceoptions {
           description "Tracing options for debugging protocol operation";
           uses stp-trace-options;
         }
         list interface {
-          description "Interface options";
           key name;
+          description "Interface options";
           uses stp-interface;
         }
       }
@@ -19851,21 +24055,27 @@ module junos-conf-protocols {
     choice enable-disable {
       case case_1 {
         leaf disable {
-          type empty;
           description "Disable LDP synchronization";
+          type empty;
         }
       }
     }
     leaf hold-time {
-      type uint32 {
-        range "1 .. 65535";
-      }
       description "Time during which maximum metric is advertised";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 65535";
+        }
+      }
     }
   }
   grouping ldp_filter_obj {
     description "Filter to apply to tracing";
     leaf match-on {
+      description "Argument on which to match";
       type enumeration {
         enum fec {
           description "Filter based on FEC associated to the traced object.";
@@ -19874,70 +24084,74 @@ module junos-conf-protocols {
           description "Filter based on packet source and destination addresses.";
         }
       }
-      description "Argument on which to match";
     }
     leaf-list policy {
-      type "jt:policy-algebra";
-      description "Filter policy";
       ordered-by user;
+      description "Filter policy";
+      type "jt:policy-algebra";
     }
   }
   grouping lmp_control_channel_type {
     leaf name {
-      type "jt:interface-name";
       description "Control channel interface";
+      type union {
+        type "jt:interface-name";
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     leaf remote-address {
-      type "jt:ipaddr";
       description "Control channel remote address";
+      type "jt:ipaddr";
     }
   }
   grouping lsp-set-match-type {
     leaf lsp-name {
-      type string;
       description "LSP name that matches this string";
+      type string;
     }
     leaf lsp-regex {
-      type string;
       description "All LSPs that match this regular expression pattern";
+      type string;
     }
     leaf p2mp-name {
-      type string;
       description "P2MP names that match this string";
+      type string;
     }
     leaf p2mp-regex {
-      type string;
       description "P2MP names that match this regular expression pattern";
+      type string;
     }
     choice router-type {
       case case_1 {
         leaf egress {
-          type empty;
           description "All LSPs for which this router is egress";
+          type empty;
         }
       }
       case case_2 {
         leaf ingress {
-          type empty;
           description "All LSPs for which this router is ingress";
+          type empty;
         }
       }
       case case_3 {
         leaf transit {
-          type empty;
           description "All LSPs for which this router is transit";
+          type empty;
         }
       }
     }
   }
   grouping macro-data-type {
     leaf name {
-      type string;
       description "Keyword part of the keyword-value pair";
+      type string;
     }
     leaf value {
-      type string;
       description "Value part of the keyword-value pair";
+      type string;
     }
   }
   grouping mrp-trace-options {
@@ -19945,47 +24159,52 @@ module junos-conf-protocols {
     container file {
       description "Trace file options";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf replace {
-        type empty;
         description "Replace trace file rather than appending to it";
         status deprecated;
+        type empty;
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "10";
         description "Maximum number of trace files";
+        default "10";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       leaf no-stamp {
-        type empty;
         description "Do not timestamp trace file";
         status deprecated;
+        type empty;
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
     }
     list flag {
-      description "Tracing parameters";
       key name;
       ordered-by user;
+      description "Tracing parameters";
       leaf name {
         type enumeration {
           enum events {
@@ -20012,8 +24231,8 @@ module junos-conf-protocols {
         }
       }
       leaf disable {
-        type empty;
         description "Disable this trace flag";
+        type empty;
       }
     }
   }
@@ -20022,18 +24241,29 @@ module junos-conf-protocols {
       type string;
     }
     leaf priority {
-      type uint16 {
-        range "0 .. 255";
-      }
       description "Interface priority (in increments of 16 - 0,16,..240)";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "0 .. 255";
+        }
+      }
     }
     leaf cost {
-      type uint32 {
-        range "1 .. 200000000";
-      }
       description "Cost of the interface";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 200000000";
+        }
+      }
     }
     leaf mode {
+      description "Interface mode (P2P or shared)";
       type enumeration {
         enum point-to-point {
           description "Interface mode is point-to-point";
@@ -20042,81 +24272,85 @@ module junos-conf-protocols {
           description "Interface mode is shared";
         }
       }
-      description "Interface mode (P2P or shared)";
     }
     leaf edge {
-      type empty;
       description "Port is an edge port";
+      type empty;
     }
     leaf access-trunk {
-      type empty;
       description "Send/Receive untagged RSTP BPDUs on this interface";
+      type empty;
     }
     container bpdu-timeout-action {
-      description "Define action on BPDU expiry (Loop Protect)";
       presence "enable bpdu-timeout-action";
+      description "Define action on BPDU expiry (Loop Protect)";
       leaf block {
-        type empty;
         description "Block the interface";
+        type empty;
       }
       leaf alarm {
-        type empty;
         description "Generate an alarm";
+        type empty;
       }
     }
     leaf no-root-port {
-      type empty;
       description "Do not allow the interface to become root (Root Protect)";
+      type empty;
     }
     leaf disable {
-      type empty;
       description "Disable Spanning Tree on port";
+      type empty;
     }
   }
   grouping pccd-traceoptions-type {
     description "Trace options for PCCD";
     leaf no-remote-trace {
-      type empty;
       description "Disable remote tracing";
+      type empty;
     }
     container file {
       description "Trace file information";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "3";
         description "Maximum number of trace files";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
       leaf match {
-        type "jt:regular-expression";
         description "Regular expression for lines to be logged";
+        type "jt:regular-expression";
       }
     }
     list flag {
-      description "Area of PCCD to enable debugging output";
       key name;
       ordered-by user;
+      description "Area of PCCD to enable debugging output";
       leaf name {
         type enumeration {
           enum pccd-main {
@@ -20149,37 +24383,49 @@ module junos-conf-protocols {
   }
   grouping peer-group {
     leaf name {
-      type "jt:ipv4addr";
       description "IP address for this peer";
+      type "jt:ipv4addr";
     }
     leaf local-ip-addr {
-      type "jt:ipv4addr";
       description "Local IP address to use for this peer alone.";
+      type "jt:ipv4addr";
     }
     leaf session-establishment-hold-time {
-      type uint32 {
-        range "45 .. 600";
-      }
       description "Time within which connection must succeed with this peer";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "45 .. 600";
+        }
+      }
     }
     leaf-list redundancy-group-id-list {
-      type uint32;
-      description "List of redundacy groups this peer is part of";
       ordered-by user;
+      description "List of redundacy groups this peer is part of";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|$.*";
+        }
+      }
     }
     container backup-liveness-detection {
-      description "Backup liveness detection";
       presence "enable backup-liveness-detection";
+      description "Backup liveness detection";
       leaf backup-peer-ip {
-        type "jt:ipv4addr";
         description "Backup livelness detection peer's IP address";
+        type "jt:ipv4addr";
       }
     }
     container liveness-detection {
-      description "Bidirectional Forwarding Detection options for the peer";
       presence "enable liveness-detection";
+      description "Bidirectional Forwarding Detection options for the peer";
       leaf version {
+        description "BFD protocol version number";
+        default "automatic";
         type enumeration {
           enum 0 {
             description "BFD version 0 (deprecated)";
@@ -20191,105 +24437,143 @@ module junos-conf-protocols {
             description "Choose BFD version automatically";
           }
         }
-        default "automatic";
-        description "BFD protocol version number";
       }
       leaf minimum-interval {
-        type uint32 {
-          range "1 .. 255000";
-        }
         description "Minimum transmit and receive interval";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 255000";
+          }
+        }
       }
       leaf minimum-transmit-interval {
-        type uint32 {
-          range "1 .. 255000";
-        }
         description "Minimum transmit interval";
         status deprecated;
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 255000";
+          }
+        }
       }
       leaf minimum-receive-interval {
-        type uint32 {
-          range "1 .. 255000";
-        }
         description "Minimum receive interval";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 255000";
+          }
+        }
       }
       leaf multiplier {
-        type uint32 {
-          range "1 .. 255";
-        }
-        default "3";
         description "Detection time multiplier";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 255";
+          }
+        }
       }
       leaf inline-disable {
-        type empty;
         description "Disable inline mode for this BFD session";
+        type empty;
       }
       leaf pdu-size {
-        type uint32 {
-          range "24 .. 9000";
-        }
-        default "24";
         description "BFD transport protocol payload size";
+        default "24";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "24 .. 9000";
+          }
+        }
       }
       choice adaptation-choice {
         case case_1 {
           leaf no-adaptation {
-            type empty;
             description "Disable adaptation";
+            type empty;
           }
         }
       }
       container transmit-interval {
         description "Transmit-interval options";
         leaf minimum-interval {
-          type uint32 {
-            range "1 .. 255000";
-          }
           description "Minimum transmit interval";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255000";
+            }
+          }
         }
         leaf threshold {
-          type uint32;
           description "High transmit interval triggering a trap";
           units milliseconds;
+          type union {
+            type uint32;
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
       }
       container detection-time {
         description "Detection-time options";
         leaf threshold {
-          type uint32;
           description "High detection-time triggering a trap";
           units milliseconds;
+          type union {
+            type uint32;
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
       }
     }
     leaf authentication-key {
+      description "MD5 authentication key";
       type string {
         length "1 .. 126";
       }
-      description "MD5 authentication key";
     }
   }
   grouping periodic_oam {
     container mpls-tp-mode {
-      description "MPLS-TP Mode, Do not use IP addressing for OAM";
       presence "enable mpls-tp-mode";
+      description "MPLS-TP Mode, Do not use IP addressing for OAM";
       container lsping-channel-type {
         description "Supported Control-channel types for MPLS-TP mode....";
         choice action-choice {
           case case_1 {
             leaf ipv4 {
-              type empty;
               description "Use channel-type IPv4(0x0021), With IP-UDP encapsulation";
+              type empty;
             }
           }
           case case_2 {
             leaf on-demand-cv {
-              type empty;
               description "Use channel-type On-Demand-CV(0x0025), Without IP-UDP encapsulation";
+              type empty;
             }
           }
         }
@@ -20298,14 +24582,16 @@ module junos-conf-protocols {
     container bfd-port {
       description "Egress knob to select MHOP-BFD port for MPLS BFD";
       leaf-list import {
-        type "jt:policy-algebra";
-        description "Import policy";
         ordered-by user;
+        description "Import policy";
+        type "jt:policy-algebra";
       }
     }
     container bfd-liveness-detection {
       description "Bidirectional Forwarding Detection options";
       leaf version {
+        description "BFD protocol version number";
+        default "automatic";
         type enumeration {
           enum 0 {
             description "BFD version 0 (deprecated)";
@@ -20317,78 +24603,116 @@ module junos-conf-protocols {
             description "Choose BFD version automatically";
           }
         }
-        default "automatic";
-        description "BFD protocol version number";
       }
       leaf minimum-interval {
-        type uint32 {
-          range "1 .. 255000";
-        }
         description "Minimum transmit and receive interval";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 255000";
+          }
+        }
       }
       leaf minimum-transmit-interval {
-        type uint32 {
-          range "1 .. 255000";
-        }
         description "Minimum transmit interval";
         status deprecated;
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 255000";
+          }
+        }
       }
       leaf minimum-receive-interval {
-        type uint32 {
-          range "1 .. 255000";
-        }
         description "Minimum receive interval";
         units milliseconds;
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 255000";
+          }
+        }
       }
       leaf multiplier {
-        type uint32 {
-          range "1 .. 255";
-        }
-        default "3";
         description "Detection time multiplier";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "1 .. 255";
+          }
+        }
       }
       leaf inline-disable {
-        type empty;
         description "Disable inline mode for this BFD session";
+        type empty;
       }
       leaf pdu-size {
-        type uint32 {
-          range "24 .. 9000";
-        }
-        default "24";
         description "BFD transport protocol payload size";
+        default "24";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "24 .. 9000";
+          }
+        }
       }
       choice adaptation-choice {
         case case_1 {
           leaf no-adaptation {
-            type empty;
             description "Disable adaptation";
+            type empty;
           }
         }
       }
       container transmit-interval {
         description "Transmit-interval options";
         leaf minimum-interval {
-          type uint32 {
-            range "1 .. 255000";
-          }
           description "Minimum transmit interval";
           units milliseconds;
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "1 .. 255000";
+            }
+          }
         }
         leaf threshold {
-          type uint32;
           description "High transmit interval triggering a trap";
           units milliseconds;
+          type union {
+            type uint32;
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
       }
       container detection-time {
         description "Detection-time options";
         leaf threshold {
-          type uint32;
           description "High detection-time triggering a trap";
           units milliseconds;
+          type union {
+            type uint32;
+            type string {
+              pattern "<.*>|$.*";
+            }
+          }
         }
       }
       container failure-action {
@@ -20396,32 +24720,37 @@ module junos-conf-protocols {
         choice action-choice {
           case case_1 {
             leaf teardown {
-              type empty;
               description "Teardown label switched path and resignal";
+              type empty;
             }
           }
           case case_2 {
             container make-before-break {
-              description "Resignal the label switched path before teardown";
               presence "enable make-before-break";
+              description "Resignal the label switched path before teardown";
               leaf teardown-timeout {
-                type uint32 {
-                  range "0 .. 30";
-                }
                 description "Time to wait before teardown";
                 units seconds;
+                type union {
+                  type string {
+                    pattern "<.*>|$.*";
+                  }
+                  type uint32 {
+                    range "0 .. 30";
+                  }
+                }
               }
             }
           }
         }
       }
       leaf no-router-alert-option {
-        type empty;
         description "Do not set Router-Alert options in IP header for MPLS-BFD";
+        type empty;
       }
       leaf use-ip-ttl-1 {
-        type empty;
         description "Set TTL value to 1 in IP header for MPLS-BFD";
+        type empty;
       }
     }
     container performance-monitoring {
@@ -20431,47 +24760,52 @@ module junos-conf-protocols {
         container file {
           description "Trace file options";
           leaf filename {
+            description "Name of file in which to write trace information";
             type string {
               length "1 .. 1024";
             }
-            description "Name of file in which to write trace information";
           }
           leaf replace {
-            type empty;
             description "Replace trace file rather than appending to it";
             status deprecated;
+            type empty;
           }
           leaf size {
-            type string;
             description "Maximum trace file size";
+            type string;
           }
           leaf files {
-            type uint32 {
-              range "2 .. 1000";
-            }
-            default "10";
             description "Maximum number of trace files";
+            default "10";
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "2 .. 1000";
+              }
+            }
           }
           leaf no-stamp {
-            type empty;
             description "Do not timestamp trace file";
             status deprecated;
+            type empty;
           }
           choice world-readable-choice {
             leaf world-readable {
-              type empty;
               description "Allow any user to read the log file";
+              type empty;
             }
             leaf no-world-readable {
-              type empty;
               description "Don't allow any user to read the log file";
+              type empty;
             }
           }
         }
         list flag {
-          description "Tracing parameters";
           key name;
           ordered-by user;
+          description "Tracing parameters";
           leaf name {
             type enumeration {
               enum init {
@@ -20504,9 +24838,10 @@ module junos-conf-protocols {
         container loss {
           description "Loss measurement options";
           list traffic-class {
-            description "Traffic class specific options";
             key name;
+            description "Traffic class specific options";
             leaf name {
+              description "Traffic class value";
               type enumeration {
                 enum tc-0 {
                   description "Traffic class 0";
@@ -20539,16 +24874,22 @@ module junos-conf-protocols {
                   description "No Traffic class";
                 }
               }
-              description "Traffic class value";
             }
             leaf query-interval {
-              type uint32 {
-                range "1000 .. 4294967295";
-              }
               description "Minimum transmit interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1000 .. 4294967295";
+                }
+              }
             }
             leaf measurement-quantity {
+              description "Loss measurement quantity";
+              default "packets";
               type enumeration {
                 enum bytes {
                   description "Byte loss measurement";
@@ -20557,35 +24898,49 @@ module junos-conf-protocols {
                   description "Packet loss measurement";
                 }
               }
-              default "packets";
-              description "Loss measurement quantity";
             }
             leaf average-sample-size {
-              type uint16 {
-                range "1 .. 30";
-              }
               description "Number of samples used in average calculation";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 30";
+                }
+              }
             }
             leaf loss-threshold {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Loss threshold value";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
             leaf loss-threshold-window {
-              type uint32 {
-                range "1 .. 30";
-              }
               description "Number of samples for loss threshold calculation";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 30";
+                }
+              }
             }
           }
         }
         container delay {
           description "Delay measurement options";
           list traffic-class {
-            description "Traffic class specific options";
             key name;
+            description "Traffic class specific options";
             leaf name {
+              description "Traffic class value";
               type enumeration {
                 enum tc-0 {
                   description "Traffic class 0";
@@ -20615,49 +24970,74 @@ module junos-conf-protocols {
                   description "All Traffic classes";
                 }
               }
-              description "Traffic class value";
             }
             leaf query-interval {
-              type uint32 {
-                range "1000 .. 4294967295";
-              }
               description "Minimum transmit interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1000 .. 4294967295";
+                }
+              }
             }
             leaf padding-size {
-              type uint16 {
-                range "1 .. 1500";
-              }
               description "Size of padding";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 1500";
+                }
+              }
             }
             leaf average-sample-size {
-              type uint16 {
-                range "1 .. 30";
-              }
               description "Number of samples used in average calculation";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 30";
+                }
+              }
             }
             leaf twcd-delay-threshold {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Two way channel delay threshold value";
               units microseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
             leaf rtt-delay-threshold {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Round trip delay threshold value";
               units microseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
           }
         }
         container loss-delay {
           description "Combined loss-delay measurement options";
           list traffic-class {
-            description "Traffic class specific options";
             key name;
+            description "Traffic class specific options";
             leaf name {
+              description "Traffic class value";
               type enumeration {
                 enum tc-0 {
                   description "Traffic class 0";
@@ -20690,16 +25070,22 @@ module junos-conf-protocols {
                   description "No Traffic class";
                 }
               }
-              description "Traffic class value";
             }
             leaf query-interval {
-              type uint32 {
-                range "1000 .. 4294967295";
-              }
               description "Minimum transmit interval";
               units milliseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1000 .. 4294967295";
+                }
+              }
             }
             leaf measurement-quantity {
+              description "Loss measurement quantity";
+              default "packets";
               type enumeration {
                 enum bytes {
                   description "Byte loss measurement";
@@ -20708,46 +25094,74 @@ module junos-conf-protocols {
                   description "Packet loss measurement";
                 }
               }
-              default "packets";
-              description "Loss measurement quantity";
             }
             leaf padding-size {
-              type uint16 {
-                range "1 .. 1500";
-              }
               description "Size of padding";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 1500";
+                }
+              }
             }
             leaf average-sample-size {
-              type uint16 {
-                range "1 .. 30";
-              }
               description "Number of samples used in average calculation";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint16 {
+                  range "1 .. 30";
+                }
+              }
             }
             leaf loss-threshold {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Loss threshold value";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
             leaf loss-threshold-window {
-              type uint32 {
-                range "1 .. 30";
-              }
               description "Number of samples for loss threshold calculation";
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 30";
+                }
+              }
             }
             leaf twcd-delay-threshold {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Two way channel delay threshold value";
               units microseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
             leaf rtt-delay-threshold {
-              type uint32 {
-                range "1 .. 4294967295";
-              }
               description "Round trip delay threshold value";
               units microseconds;
+              type union {
+                type string {
+                  pattern "<.*>|$.*";
+                }
+                type uint32 {
+                  range "1 .. 4294967295";
+                }
+              }
             }
           }
         }
@@ -20757,82 +25171,107 @@ module junos-conf-protocols {
         container loss {
           description "Loss measurement options";
           leaf min-query-interval {
-            type uint32 {
-              range "1000 .. 4294967295";
-            }
             description "Minimum query interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1000 .. 4294967295";
+              }
+            }
           }
         }
         container delay {
           description "Delay measurement options";
           leaf min-query-interval {
-            type uint32 {
-              range "1000 .. 4294967295";
-            }
             description "Minimum query interval";
             units milliseconds;
+            type union {
+              type string {
+                pattern "<.*>|$.*";
+              }
+              type uint32 {
+                range "1000 .. 4294967295";
+              }
+            }
           }
         }
       }
     }
     leaf lsp-ping-interval {
-      type uint16 {
-        range "30 .. 3600";
-      }
       description "Time interval between LSP ping messages";
       units seconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "30 .. 3600";
+        }
+      }
     }
     leaf lsp-ping-multiplier {
-      type uint8 {
-        range "1 .. 5";
-      }
       description "Number of ping reply missed before declaring BFD down";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint8 {
+          range "1 .. 5";
+        }
+      }
     }
     container traceoptions {
       description "Trace options for MPLSOAM process";
       leaf no-remote-trace {
-        type empty;
         description "Disable remote tracing";
+        type empty;
       }
       container file {
         description "Trace file information";
         leaf filename {
+          description "Name of file in which to write trace information";
           type string {
             length "1 .. 1024";
           }
-          description "Name of file in which to write trace information";
         }
         leaf size {
-          type string;
           description "Maximum trace file size";
+          type string;
         }
         leaf files {
-          type uint32 {
-            range "2 .. 1000";
-          }
-          default "3";
           description "Maximum number of trace files";
+          default "3";
+          type union {
+            type string {
+              pattern "<.*>|$.*";
+            }
+            type uint32 {
+              range "2 .. 1000";
+            }
+          }
         }
         choice world-readable-choice {
           leaf world-readable {
-            type empty;
             description "Allow any user to read the log file";
+            type empty;
           }
           leaf no-world-readable {
-            type empty;
             description "Don't allow any user to read the log file";
+            type empty;
           }
         }
         leaf match {
-          type "jt:regular-expression";
           description "Regular expression for lines to be logged";
+          type "jt:regular-expression";
         }
       }
       list flag {
-        description "Tracing parameters";
         key name;
         ordered-by user;
+        description "Tracing parameters";
         leaf name {
           type enumeration {
             enum configuration {
@@ -20863,36 +25302,41 @@ module junos-conf-protocols {
   }
   grouping pim_bootstrap_options_type {
     leaf priority {
-      type uint32 {
-        range "0 .. 255";
-      }
       description "Eligibility to be the bootstrap router";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 255";
+        }
+      }
     }
     leaf-list import {
-      type "jt:policy-algebra";
-      description "Bootstrap import policy";
       ordered-by user;
+      description "Bootstrap import policy";
+      type "jt:policy-algebra";
     }
     leaf-list export {
-      type "jt:policy-algebra";
-      description "Bootstrap export policy";
       ordered-by user;
+      description "Bootstrap export policy";
+      type "jt:policy-algebra";
     }
   }
   grouping pim_filter_obj {
     description "Filter to apply to tracing";
     leaf match-on {
+      description "Argument on which to match";
       type enumeration {
         enum prefix {
           description "Filter based on prefix";
         }
       }
-      description "Argument on which to match";
     }
     leaf-list policy {
-      type "jt:policy-algebra";
-      description "Filter policy";
       ordered-by user;
+      description "Filter policy";
+      type "jt:policy-algebra";
     }
   }
   grouping pim_rp_group_range_type {
@@ -20900,54 +25344,66 @@ module junos-conf-protocols {
       type "jt:ipprefix";
     }
     leaf nexthop-hold-time {
-      type uint32 {
-        range "1 .. 1000";
-      }
       description "Nexthop hold time in milliseconds";
       units milliseconds;
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 1000";
+        }
+      }
     }
   }
   grouping ppp-traceoptions-type {
     description "Trace options for PPP process";
     leaf no-remote-trace {
-      type empty;
       description "Disable remote tracing";
+      type empty;
     }
     container file {
       description "Trace file information";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "3";
         description "Maximum number of trace files";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
       leaf match {
-        type "jt:regular-expression";
         description "Regular expression for lines to be logged";
+        type "jt:regular-expression";
       }
     }
     leaf level {
+      description "Level of debugging output";
+      default "error";
       type enumeration {
         enum error {
           description "Match error conditions";
@@ -20968,13 +25424,11 @@ module junos-conf-protocols {
           description "Match all levels";
         }
       }
-      default "error";
-      description "Level of debugging output";
     }
     list flag {
-      description "Area of PPP process to enable debugging output";
       key name;
       ordered-by user;
+      description "Area of PPP process to enable debugging output";
       leaf name {
         type enumeration {
           enum access {
@@ -21050,44 +25504,51 @@ module junos-conf-protocols {
   grouping pppoe-traceoptions-type {
     description "Trace options for PPPoE process";
     leaf no-remote-trace {
-      type empty;
       description "Disable remote tracing";
+      type empty;
     }
     container file {
       description "Trace file information";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "3";
         description "Maximum number of trace files";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
       leaf match {
-        type "jt:regular-expression";
         description "Regular expression for lines to be logged";
+        type "jt:regular-expression";
       }
     }
     leaf level {
+      description "Level of debugging output";
+      default "error";
       type enumeration {
         enum error {
           description "Match error conditions";
@@ -21108,13 +25569,11 @@ module junos-conf-protocols {
           description "Match all levels";
         }
       }
-      default "error";
-      description "Level of debugging output";
     }
     list flag {
-      description "Area of PPPoE process to enable debugging output";
       key name;
       ordered-by user;
+      description "Area of PPPoE process to enable debugging output";
       leaf name {
         type enumeration {
           enum config {
@@ -21166,38 +25625,38 @@ module junos-conf-protocols {
       }
     }
     container filter {
-      description "Trace filtering";
       presence "enable filter";
+      description "Trace filtering";
       leaf aci {
+        description "Regular expression to match ACI";
         type string {
           length "1 .. 64";
         }
-        description "Regular expression to match ACI";
       }
       leaf ari {
+        description "Regular expression to match ARI";
         type string {
           length "1 .. 64";
         }
-        description "Regular expression to match ARI";
       }
       leaf service-name {
+        description "Service name";
         type string {
           length "1 .. 64";
         }
-        description "Service name";
       }
       leaf underlying-interface {
-        type string;
         description "Underlying interface name";
+        type string;
       }
       container user {
-        description "Filter by user name";
         presence "enable user";
+        description "Filter by user name";
         leaf username {
+          description "Name of the user to be filtered";
           type string {
             length "1 .. 64";
           }
-          description "Name of the user to be filtered";
         }
       }
     }
@@ -21205,44 +25664,51 @@ module junos-conf-protocols {
   grouping r2cp-traceoptions-type {
     description "Trace options for R2CP process";
     leaf no-remote-trace {
-      type empty;
       description "Disable remote tracing";
+      type empty;
     }
     container file {
       description "Trace file information";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "3";
         description "Maximum number of trace files";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
       leaf match {
-        type "jt:regular-expression";
         description "Regular expression for lines to be logged";
+        type "jt:regular-expression";
       }
     }
     leaf level {
+      description "Level of debugging output";
+      default "error";
       type enumeration {
         enum error {
           description "Match error conditions";
@@ -21263,13 +25729,11 @@ module junos-conf-protocols {
           description "Match all levels";
         }
       }
-      default "error";
-      description "Level of debugging output";
     }
     list flag {
-      description "Area of R2CP process to enable debugging output";
       key name;
       ordered-by user;
+      description "Area of R2CP process to enable debugging output";
       leaf name {
         type enumeration {
           enum configuration {
@@ -21311,54 +25775,54 @@ module junos-conf-protocols {
   }
   grouping rib-inet3 {
     container "inet.3" {
-      description "Use inet.3 to exchange labeled unicast routes";
       presence "enable inet.3";
+      description "Use inet.3 to exchange labeled unicast routes";
     }
   }
   grouping rib_group_inet_type {
     description "Routing table group";
     leaf ribgroup-name {
-      type string;
       description "Name of the routing table group";
+      type string;
     }
   }
   grouping rib_group_type {
     leaf inet-old-style {
-      type string;
       description "Name of the IPv4 routing table group";
       status deprecated;
+      type string;
     }
     leaf inet {
-      type string;
       description "Name of the IPv4 routing table group";
+      type string;
     }
     leaf inet3 {
-      type string;
       description "Name of the IPv4 inet.3 routing table group";
+      type string;
     }
     leaf inet6 {
-      type string;
       description "Name of the IPv6 routing table group";
+      type string;
     }
     leaf inet63 {
-      type string;
       description "Name of the IPv6 inet6.3 routing table group";
+      type string;
     }
   }
   grouping rip_filter_obj {
     description "Filter to apply to tracing";
     leaf match-on {
+      description "Argument on which to match";
       type enumeration {
         enum prefix {
           description "Filter based on prefix";
         }
       }
-      description "Argument on which to match";
     }
     leaf-list policy {
-      type "jt:policy-algebra";
-      description "Filter policy";
       ordered-by user;
+      description "Filter policy";
+      type "jt:policy-algebra";
     }
   }
   grouping stp-interface {
@@ -21366,18 +25830,29 @@ module junos-conf-protocols {
       type string;
     }
     leaf priority {
-      type uint16 {
-        range "0 .. 255";
-      }
       description "Interface priority (in increments of 16 - 0,16,..240)";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint16 {
+          range "0 .. 255";
+        }
+      }
     }
     leaf cost {
-      type uint32 {
-        range "1 .. 200000000";
-      }
       description "Cost of the interface";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "1 .. 200000000";
+        }
+      }
     }
     leaf mode {
+      description "Interface mode (P2P or shared)";
       type enumeration {
         enum point-to-point {
           description "Interface mode is point-to-point";
@@ -21386,35 +25861,34 @@ module junos-conf-protocols {
           description "Interface mode is shared";
         }
       }
-      description "Interface mode (P2P or shared)";
     }
     leaf edge {
-      type empty;
       description "Port is an edge port";
+      type empty;
     }
     leaf access-trunk {
-      type empty;
       description "Send/Receive untagged RSTP BPDUs on this interface";
+      type empty;
     }
     container bpdu-timeout-action {
-      description "Define action on BPDU expiry (Loop Protect)";
       presence "enable bpdu-timeout-action";
+      description "Define action on BPDU expiry (Loop Protect)";
       leaf block {
-        type empty;
         description "Block the interface";
+        type empty;
       }
       leaf alarm {
-        type empty;
         description "Generate an alarm";
+        type empty;
       }
     }
     leaf no-root-port {
-      type empty;
       description "Do not allow the interface to become root (Root Protect)";
+      type empty;
     }
     leaf disable {
-      type empty;
       description "Disable Spanning Tree on port";
+      type empty;
     }
   }
   grouping stp-trace-options {
@@ -21422,47 +25896,52 @@ module junos-conf-protocols {
     container file {
       description "Trace file options";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf replace {
-        type empty;
         description "Replace trace file rather than appending to it";
         status deprecated;
+        type empty;
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "10";
         description "Maximum number of trace files";
+        default "10";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       leaf no-stamp {
-        type empty;
         description "Do not timestamp trace file";
         status deprecated;
+        type empty;
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
     }
     list flag {
-      description "Tracing parameters";
       key name;
       ordered-by user;
+      description "Tracing parameters";
       leaf name {
         type enumeration {
           enum events {
@@ -21516,50 +25995,55 @@ module junos-conf-protocols {
         }
       }
       leaf disable {
-        type empty;
         description "Disable this trace flag";
+        type empty;
       }
     }
   }
   grouping subscription-type {
     leaf link-subscription {
-      type string;
-      default "100";
       description "Link bandwidth percentage for RSVP reservation";
+      default "100";
+      type string;
     }
     leaf ct0 {
-      type string;
-      default "100";
       description "Subscription percentage for traffic class 0";
+      default "100";
+      type string;
     }
     leaf ct1 {
-      type string;
-      default "100";
       description "Subscription percentage for traffic class 1";
+      default "100";
+      type string;
     }
     leaf ct2 {
-      type string;
-      default "100";
       description "Subscription percentage for traffic class 2";
+      default "100";
+      type string;
     }
     leaf ct3 {
-      type string;
-      default "100";
       description "Subscription percentage for traffic class 3";
+      default "100";
+      type string;
     }
     list priority {
-      description "Subscription percentage for a specific priority";
       key priority-value;
       ordered-by user;
+      description "Subscription percentage for a specific priority";
       leaf priority-value {
-        type uint32 {
-          range "0 .. 7";
-        }
         description "Priority for which subscription percent is being configured";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "0 .. 7";
+          }
+        }
       }
       leaf percent {
-        type string;
         description "Subscription percent for the specific priority";
+        type string;
       }
     }
   }
@@ -21568,12 +26052,13 @@ module junos-conf-protocols {
       type "jt:mac-unicast";
     }
     leaf ip-address {
-      type "jt:ipv4prefix";
       description "Peer ID (IP Address)";
+      type "jt:ipv4prefix";
     }
   }
   grouping te-class-object {
     leaf traffic-class {
+      description "Traffic class";
       type enumeration {
         enum ct0 {
           description "Traffic class 0";
@@ -21588,56 +26073,67 @@ module junos-conf-protocols {
           description "Traffic class 3";
         }
       }
-      description "Traffic class";
     }
     leaf priority {
-      type uint32 {
-        range "0 .. 7";
-      }
       description "Preemption priority for this class";
+      type union {
+        type string {
+          pattern "<.*>|$.*";
+        }
+        type uint32 {
+          range "0 .. 7";
+        }
+      }
     }
   }
   grouping timingd-traceoptions {
     description "Trace options for PTP stack and Servo";
     leaf no-remote-trace {
-      type empty;
       description "Disable remote tracing";
+      type empty;
     }
     container file {
       description "Trace file information";
       leaf filename {
+        description "Name of file in which to write trace information";
         type string {
           length "1 .. 1024";
         }
-        description "Name of file in which to write trace information";
       }
       leaf size {
-        type string;
         description "Maximum trace file size";
+        type string;
       }
       leaf files {
-        type uint32 {
-          range "2 .. 1000";
-        }
-        default "3";
         description "Maximum number of trace files";
+        default "3";
+        type union {
+          type string {
+            pattern "<.*>|$.*";
+          }
+          type uint32 {
+            range "2 .. 1000";
+          }
+        }
       }
       choice world-readable-choice {
         leaf world-readable {
-          type empty;
           description "Allow any user to read the log file";
+          type empty;
         }
         leaf no-world-readable {
-          type empty;
           description "Don't allow any user to read the log file";
+          type empty;
         }
       }
       leaf match {
-        type "jt:regular-expression";
         description "Regular expression for lines to be logged";
+        type "jt:regular-expression";
       }
     }
     leaf level {
+      description "Level of debugging output";
+      default "error";
       type enumeration {
         enum error {
           description "Match error conditions";
@@ -21658,13 +26154,11 @@ module junos-conf-protocols {
           description "Match all levels";
         }
       }
-      default "error";
-      description "Level of debugging output";
     }
     list flag {
-      description "Tracing parameters";
       key name;
       ordered-by user;
+      description "Tracing parameters";
       leaf name {
         type enumeration {
           enum init {

--- a/src/respnet/devices/JuniperCRPD_23_4R1_9.act
+++ b/src/respnet/devices/JuniperCRPD_23_4R1_9.act
@@ -3492,16 +3492,16 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__path_selection
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp__med_multiplier(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint16", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp__igp_multiplier(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint16", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(yang.adata.MNode):
-    med_multiplier: int
-    igp_multiplier: int
+    med_multiplier: value
+    igp_multiplier: value
 
-    mut def __init__(self, med_multiplier: ?int=None, igp_multiplier: ?int=None):
+    mut def __init__(self, med_multiplier: ?value=None, igp_multiplier: ?value=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         if med_multiplier != None:
             self.med_multiplier = med_multiplier
@@ -3517,21 +3517,21 @@ class junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_i
         _med_multiplier = self.med_multiplier
         _igp_multiplier = self.igp_multiplier
         if _med_multiplier is not None:
-            children['med-multiplier'] = yang.gdata.Leaf('uint16', _med_multiplier)
+            children['med-multiplier'] = yang.gdata.Leaf('union', _med_multiplier)
         if _igp_multiplier is not None:
-            children['igp-multiplier'] = yang.gdata.Leaf('uint16', _igp_multiplier)
+            children['igp-multiplier'] = yang.gdata.Leaf('union', _igp_multiplier)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(med_multiplier=n.get_opt_int("med-multiplier"), igp_multiplier=n.get_opt_int("igp-multiplier"))
+            return junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(med_multiplier=n.get_opt_value("med-multiplier"), igp_multiplier=n.get_opt_value("igp-multiplier"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(med_multiplier=yang.gdata.from_xml_opt_int(n, "med-multiplier"), igp_multiplier=yang.gdata.from_xml_opt_int(n, "igp-multiplier"))
+            return junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(med_multiplier=yang.gdata.from_xml_opt_value(n, "med-multiplier"), igp_multiplier=yang.gdata.from_xml_opt_value(n, "igp-multiplier"))
         return None
 
 
@@ -3616,25 +3616,25 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__local_a
     return yang.gdata.Leaf("string", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__hold_time(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__maximum(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout__forever(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout__timeout(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(yang.adata.MNode):
     forever: ?bool
-    timeout: ?int
+    timeout: ?value
 
-    mut def __init__(self, forever: ?bool, timeout: ?int):
+    mut def __init__(self, forever: ?bool, timeout: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.forever = forever
         self.timeout = timeout
@@ -3646,28 +3646,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if _forever is not None:
             children['forever'] = yang.gdata.Leaf('empty', _forever)
         if _timeout is not None:
-            children['timeout'] = yang.gdata.Leaf('uint32', _timeout)
+            children['timeout'] = yang.gdata.Leaf('union', _timeout)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool("forever"), timeout=n.get_opt_int("timeout"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool("forever"), timeout=n.get_opt_value("timeout"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, "forever"), timeout=yang.gdata.from_xml_opt_int(n, "timeout"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, "forever"), timeout=yang.gdata.from_xml_opt_value(n, "timeout"))
         return None
 
 
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
     idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout
 
-    mut def __init__(self, limit_threshold: ?int, idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout=None):
+    mut def __init__(self, limit_threshold: ?value, idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
         self.idle_timeout = idle_timeout
@@ -3685,7 +3685,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _limit_threshold = self.limit_threshold
         _idle_timeout = self.idle_timeout
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         if _idle_timeout is not None:
             children['idle-timeout'] = _idle_timeout.to_gdata()
         return yang.gdata.Container(children, presence=True)
@@ -3693,24 +3693,24 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_int("limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container("idle-timeout")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_value("limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container("idle-timeout")))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, "idle-timeout")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, "idle-timeout")))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
 
-    mut def __init__(self, limit_threshold: ?int):
+    mut def __init__(self, limit_threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
 
@@ -3718,30 +3718,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         children = {}
         _limit_threshold = self.limit_threshold
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_int("limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_value("limit-threshold"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
 
-    mut def __init__(self, limit_threshold: ?int):
+    mut def __init__(self, limit_threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
 
@@ -3749,30 +3749,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         children = {}
         _limit_threshold = self.limit_threshold
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_int("limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_value("limit-threshold"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"))
         return None
 
 
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(yang.adata.MNode):
-    maximum: ?int
+    maximum: ?value
     teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown
     drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess
     hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess
 
-    mut def __init__(self, maximum: ?int, teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown=None, drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess=None, hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess=None):
+    mut def __init__(self, maximum: ?value, teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown=None, drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess=None, hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.maximum = maximum
         self.teardown = teardown
@@ -3810,7 +3810,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _drop_excess = self.drop_excess
         _hide_excess = self.hide_excess
         if _maximum is not None:
-            children['maximum'] = yang.gdata.Leaf('uint32', _maximum)
+            children['maximum'] = yang.gdata.Leaf('union', _maximum)
         if _teardown is not None:
             children['teardown'] = _teardown.to_gdata()
         if _drop_excess is not None:
@@ -3822,34 +3822,34 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(maximum=n.get_opt_int("maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_container("teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_container("drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_container("hide-excess")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(maximum=n.get_opt_value("maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_container("teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_container("drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_container("hide-excess")))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(maximum=yang.gdata.from_xml_opt_int(n, "maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, "teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, "drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, "hide-excess")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(maximum=yang.gdata.from_xml_opt_value(n, "maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, "teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, "drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, "hide-excess")))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__maximum(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__forever(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__timeout(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(yang.adata.MNode):
     forever: ?bool
-    timeout: ?int
+    timeout: ?value
 
-    mut def __init__(self, forever: ?bool, timeout: ?int):
+    mut def __init__(self, forever: ?bool, timeout: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.forever = forever
         self.timeout = timeout
@@ -3861,28 +3861,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         if _forever is not None:
             children['forever'] = yang.gdata.Leaf('empty', _forever)
         if _timeout is not None:
-            children['timeout'] = yang.gdata.Leaf('uint32', _timeout)
+            children['timeout'] = yang.gdata.Leaf('union', _timeout)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool("forever"), timeout=n.get_opt_int("timeout"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool("forever"), timeout=n.get_opt_value("timeout"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, "forever"), timeout=yang.gdata.from_xml_opt_int(n, "timeout"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, "forever"), timeout=yang.gdata.from_xml_opt_value(n, "timeout"))
         return None
 
 
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
     idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout
 
-    mut def __init__(self, limit_threshold: ?int, idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout=None):
+    mut def __init__(self, limit_threshold: ?value, idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
         self.idle_timeout = idle_timeout
@@ -3900,7 +3900,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _limit_threshold = self.limit_threshold
         _idle_timeout = self.idle_timeout
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         if _idle_timeout is not None:
             children['idle-timeout'] = _idle_timeout.to_gdata()
         return yang.gdata.Container(children, presence=True)
@@ -3908,24 +3908,24 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_int("limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container("idle-timeout")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_value("limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container("idle-timeout")))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, "idle-timeout")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, "idle-timeout")))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
 
-    mut def __init__(self, limit_threshold: ?int):
+    mut def __init__(self, limit_threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
 
@@ -3933,30 +3933,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         children = {}
         _limit_threshold = self.limit_threshold
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_int("limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_value("limit-threshold"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
 
-    mut def __init__(self, limit_threshold: ?int):
+    mut def __init__(self, limit_threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
 
@@ -3964,30 +3964,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         children = {}
         _limit_threshold = self.limit_threshold
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_int("limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_value("limit-threshold"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"))
         return None
 
 
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(yang.adata.MNode):
-    maximum: ?int
+    maximum: ?value
     teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown
     drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess
     hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess
 
-    mut def __init__(self, maximum: ?int, teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown=None, drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess=None, hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess=None):
+    mut def __init__(self, maximum: ?value, teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown=None, drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess=None, hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.maximum = maximum
         self.teardown = teardown
@@ -4025,7 +4025,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _drop_excess = self.drop_excess
         _hide_excess = self.hide_excess
         if _maximum is not None:
-            children['maximum'] = yang.gdata.Leaf('uint32', _maximum)
+            children['maximum'] = yang.gdata.Leaf('union', _maximum)
         if _teardown is not None:
             children['teardown'] = _teardown.to_gdata()
         if _drop_excess is not None:
@@ -4037,13 +4037,13 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_int("maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_container("teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_container("drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_container("hide-excess")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_value("maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_container("teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_container("drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_container("hide-excess")))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(maximum=yang.gdata.from_xml_opt_int(n, "maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, "teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, "drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, "hide-excess")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(maximum=yang.gdata.from_xml_opt_value(n, "maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, "teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, "drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, "hide-excess")))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit()
 
 
@@ -4125,10 +4125,10 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
     return yang.gdata.LeafList(val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_count(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("int32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__include_backup_path(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("int32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__multipath(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -4136,11 +4136,11 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(yang.adata.MNode):
     path_selection_mode: junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode
     prefix_policy: list[str]
-    path_count: ?int
-    include_backup_path: ?int
+    path_count: ?value
+    include_backup_path: ?value
     multipath: ?bool
 
-    mut def __init__(self, path_selection_mode: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode=None, prefix_policy: ?list[str]=None, path_count: ?int, include_backup_path: ?int, multipath: ?bool):
+    mut def __init__(self, path_selection_mode: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode=None, prefix_policy: ?list[str]=None, path_count: ?value, include_backup_path: ?value, multipath: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         if path_selection_mode is not None:
             self.path_selection_mode = path_selection_mode
@@ -4167,9 +4167,9 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             children['path-selection-mode'] = _path_selection_mode.to_gdata()
         children['prefix-policy'] = yang.gdata.LeafList(self.prefix_policy)
         if _path_count is not None:
-            children['path-count'] = yang.gdata.Leaf('int32', _path_count)
+            children['path-count'] = yang.gdata.Leaf('union', _path_count)
         if _include_backup_path is not None:
-            children['include-backup-path'] = yang.gdata.Leaf('int32', _include_backup_path)
+            children['include-backup-path'] = yang.gdata.Leaf('union', _include_backup_path)
         if _multipath is not None:
             children['multipath'] = yang.gdata.Leaf('empty', _multipath)
         return yang.gdata.Container(children, presence=True)
@@ -4177,13 +4177,13 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_container("path-selection-mode")), prefix_policy=n.get_opt_strs("prefix-policy"), path_count=n.get_opt_int("path-count"), include_backup_path=n.get_opt_int("include-backup-path"), multipath=n.get_opt_bool("multipath"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_container("path-selection-mode")), prefix_policy=n.get_opt_strs("prefix-policy"), path_count=n.get_opt_value("path-count"), include_backup_path=n.get_opt_value("include-backup-path"), multipath=n.get_opt_bool("multipath"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode.from_xml(yang.gdata.get_xml_opt_child(n, "path-selection-mode")), prefix_policy=yang.gdata.from_xml_opt_strs(n, "prefix-policy"), path_count=yang.gdata.from_xml_opt_int(n, "path-count"), include_backup_path=yang.gdata.from_xml_opt_int(n, "include-backup-path"), multipath=yang.gdata.from_xml_opt_bool(n, "multipath"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode.from_xml(yang.gdata.get_xml_opt_child(n, "path-selection-mode")), prefix_policy=yang.gdata.from_xml_opt_strs(n, "prefix-policy"), path_count=yang.gdata.from_xml_opt_value(n, "path-count"), include_backup_path=yang.gdata.from_xml_opt_value(n, "include-backup-path"), multipath=yang.gdata.from_xml_opt_bool(n, "multipath"))
         return None
 
 
@@ -4267,12 +4267,12 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
     return yang.gdata.Leaf("string", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops__loops(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("int32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(yang.adata.MNode):
-    loops: ?int
+    loops: ?value
 
-    mut def __init__(self, loops: ?int):
+    mut def __init__(self, loops: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.loops = loops
 
@@ -4280,19 +4280,19 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         children = {}
         _loops = self.loops
         if _loops is not None:
-            children['loops'] = yang.gdata.Leaf('int32', _loops)
+            children['loops'] = yang.gdata.Leaf('union', _loops)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(loops=n.get_opt_int("loops"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(loops=n.get_opt_value("loops"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(loops=yang.gdata.from_xml_opt_int(n, "loops"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(loops=yang.gdata.from_xml_opt_value(n, "loops"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops()
 
 
@@ -4301,16 +4301,16 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay__routing_uptime(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay__inbound_convergence(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(yang.adata.MNode):
-    routing_uptime: ?int
-    inbound_convergence: ?int
+    routing_uptime: ?value
+    inbound_convergence: ?value
 
-    mut def __init__(self, routing_uptime: ?int, inbound_convergence: ?int):
+    mut def __init__(self, routing_uptime: ?value, inbound_convergence: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.routing_uptime = routing_uptime
         self.inbound_convergence = inbound_convergence
@@ -4320,36 +4320,36 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _routing_uptime = self.routing_uptime
         _inbound_convergence = self.inbound_convergence
         if _routing_uptime is not None:
-            children['routing-uptime'] = yang.gdata.Leaf('uint32', _routing_uptime)
+            children['routing-uptime'] = yang.gdata.Leaf('union', _routing_uptime)
         if _inbound_convergence is not None:
-            children['inbound-convergence'] = yang.gdata.Leaf('uint32', _inbound_convergence)
+            children['inbound-convergence'] = yang.gdata.Leaf('union', _inbound_convergence)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_int("routing-uptime"), inbound_convergence=n.get_opt_int("inbound-convergence"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_value("routing-uptime"), inbound_convergence=n.get_opt_value("inbound-convergence"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=yang.gdata.from_xml_opt_int(n, "routing-uptime"), inbound_convergence=yang.gdata.from_xml_opt_int(n, "inbound-convergence"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=yang.gdata.from_xml_opt_value(n, "routing-uptime"), inbound_convergence=yang.gdata.from_xml_opt_value(n, "inbound-convergence"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay__route_age(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay__routing_uptime(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(yang.adata.MNode):
-    route_age: ?int
-    routing_uptime: ?int
+    route_age: ?value
+    routing_uptime: ?value
 
-    mut def __init__(self, route_age: ?int, routing_uptime: ?int):
+    mut def __init__(self, route_age: ?value, routing_uptime: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.route_age = route_age
         self.routing_uptime = routing_uptime
@@ -4359,21 +4359,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _route_age = self.route_age
         _routing_uptime = self.routing_uptime
         if _route_age is not None:
-            children['route-age'] = yang.gdata.Leaf('uint32', _route_age)
+            children['route-age'] = yang.gdata.Leaf('union', _route_age)
         if _routing_uptime is not None:
-            children['routing-uptime'] = yang.gdata.Leaf('uint32', _routing_uptime)
+            children['routing-uptime'] = yang.gdata.Leaf('union', _routing_uptime)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_int("route-age"), routing_uptime=n.get_opt_int("routing-uptime"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_value("route-age"), routing_uptime=n.get_opt_value("routing-uptime"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=yang.gdata.from_xml_opt_int(n, "route-age"), routing_uptime=yang.gdata.from_xml_opt_int(n, "routing-uptime"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=yang.gdata.from_xml_opt_value(n, "route-age"), routing_uptime=yang.gdata.from_xml_opt_value(n, "routing-uptime"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay()
 
 
@@ -4468,12 +4468,12 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build__maximum_delay(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(yang.adata.MNode):
-    maximum_delay: ?int
+    maximum_delay: ?value
 
-    mut def __init__(self, maximum_delay: ?int):
+    mut def __init__(self, maximum_delay: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.maximum_delay = maximum_delay
 
@@ -4481,19 +4481,19 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         children = {}
         _maximum_delay = self.maximum_delay
         if _maximum_delay is not None:
-            children['maximum-delay'] = yang.gdata.Leaf('uint32', _maximum_delay)
+            children['maximum-delay'] = yang.gdata.Leaf('union', _maximum_delay)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_int("maximum-delay"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_value("maximum-delay"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(maximum_delay=yang.gdata.from_xml_opt_int(n, "maximum-delay"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(maximum_delay=yang.gdata.from_xml_opt_value(n, "maximum-delay"))
         return None
 
 
@@ -4688,16 +4688,16 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority__priority(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority__expedited(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(yang.adata.MNode):
-    priority: ?int
+    priority: ?value
     expedited: ?bool
 
-    mut def __init__(self, priority: ?int, expedited: ?bool):
+    mut def __init__(self, priority: ?value, expedited: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.priority = priority
         self.expedited = expedited
@@ -4707,7 +4707,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _priority = self.priority
         _expedited = self.expedited
         if _priority is not None:
-            children['priority'] = yang.gdata.Leaf('uint32', _priority)
+            children['priority'] = yang.gdata.Leaf('union', _priority)
         if _expedited is not None:
             children['expedited'] = yang.gdata.Leaf('empty', _expedited)
         return yang.gdata.Container(children)
@@ -4715,28 +4715,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(priority=n.get_opt_int("priority"), expedited=n.get_opt_bool("expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(priority=n.get_opt_value("priority"), expedited=n.get_opt_bool("expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(priority=yang.gdata.from_xml_opt_int(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(priority=yang.gdata.from_xml_opt_value(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority__priority(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority__expedited(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(yang.adata.MNode):
-    priority: ?int
+    priority: ?value
     expedited: ?bool
 
-    mut def __init__(self, priority: ?int, expedited: ?bool):
+    mut def __init__(self, priority: ?value, expedited: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.priority = priority
         self.expedited = expedited
@@ -4746,7 +4746,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _priority = self.priority
         _expedited = self.expedited
         if _priority is not None:
-            children['priority'] = yang.gdata.Leaf('uint32', _priority)
+            children['priority'] = yang.gdata.Leaf('union', _priority)
         if _expedited is not None:
             children['expedited'] = yang.gdata.Leaf('empty', _expedited)
         return yang.gdata.Container(children)
@@ -4754,28 +4754,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(priority=n.get_opt_int("priority"), expedited=n.get_opt_bool("expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(priority=n.get_opt_value("priority"), expedited=n.get_opt_bool("expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(priority=yang.gdata.from_xml_opt_int(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(priority=yang.gdata.from_xml_opt_value(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority__priority(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority__expedited(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(yang.adata.MNode):
-    priority: ?int
+    priority: ?value
     expedited: ?bool
 
-    mut def __init__(self, priority: ?int, expedited: ?bool):
+    mut def __init__(self, priority: ?value, expedited: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.priority = priority
         self.expedited = expedited
@@ -4785,7 +4785,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
         _priority = self.priority
         _expedited = self.expedited
         if _priority is not None:
-            children['priority'] = yang.gdata.Leaf('uint32', _priority)
+            children['priority'] = yang.gdata.Leaf('union', _priority)
         if _expedited is not None:
             children['expedited'] = yang.gdata.Leaf('empty', _expedited)
         return yang.gdata.Container(children)
@@ -4793,13 +4793,13 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(priority=n.get_opt_int("priority"), expedited=n.get_opt_bool("expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(priority=n.get_opt_value("priority"), expedited=n.get_opt_bool("expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(priority=yang.gdata.from_xml_opt_int(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(priority=yang.gdata.from_xml_opt_value(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority()
 
 
@@ -5211,22 +5211,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(ya
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__maximum(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout__forever(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout__timeout(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(yang.adata.MNode):
     forever: ?bool
-    timeout: ?int
+    timeout: ?value
 
-    mut def __init__(self, forever: ?bool, timeout: ?int):
+    mut def __init__(self, forever: ?bool, timeout: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.forever = forever
         self.timeout = timeout
@@ -5238,28 +5238,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if _forever is not None:
             children['forever'] = yang.gdata.Leaf('empty', _forever)
         if _timeout is not None:
-            children['timeout'] = yang.gdata.Leaf('uint32', _timeout)
+            children['timeout'] = yang.gdata.Leaf('union', _timeout)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool("forever"), timeout=n.get_opt_int("timeout"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool("forever"), timeout=n.get_opt_value("timeout"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, "forever"), timeout=yang.gdata.from_xml_opt_int(n, "timeout"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, "forever"), timeout=yang.gdata.from_xml_opt_value(n, "timeout"))
         return None
 
 
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
     idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout
 
-    mut def __init__(self, limit_threshold: ?int, idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout=None):
+    mut def __init__(self, limit_threshold: ?value, idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
         self.idle_timeout = idle_timeout
@@ -5277,7 +5277,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _limit_threshold = self.limit_threshold
         _idle_timeout = self.idle_timeout
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         if _idle_timeout is not None:
             children['idle-timeout'] = _idle_timeout.to_gdata()
         return yang.gdata.Container(children, presence=True)
@@ -5285,24 +5285,24 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_int("limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container("idle-timeout")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_value("limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container("idle-timeout")))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, "idle-timeout")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, "idle-timeout")))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
 
-    mut def __init__(self, limit_threshold: ?int):
+    mut def __init__(self, limit_threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
 
@@ -5310,30 +5310,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         children = {}
         _limit_threshold = self.limit_threshold
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_int("limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_value("limit-threshold"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
 
-    mut def __init__(self, limit_threshold: ?int):
+    mut def __init__(self, limit_threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
 
@@ -5341,30 +5341,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         children = {}
         _limit_threshold = self.limit_threshold
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_int("limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_value("limit-threshold"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"))
         return None
 
 
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(yang.adata.MNode):
-    maximum: ?int
+    maximum: ?value
     teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown
     drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess
     hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess
 
-    mut def __init__(self, maximum: ?int, teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown=None, drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess=None, hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess=None):
+    mut def __init__(self, maximum: ?value, teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown=None, drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess=None, hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.maximum = maximum
         self.teardown = teardown
@@ -5402,7 +5402,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _drop_excess = self.drop_excess
         _hide_excess = self.hide_excess
         if _maximum is not None:
-            children['maximum'] = yang.gdata.Leaf('uint32', _maximum)
+            children['maximum'] = yang.gdata.Leaf('union', _maximum)
         if _teardown is not None:
             children['teardown'] = _teardown.to_gdata()
         if _drop_excess is not None:
@@ -5414,34 +5414,34 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(maximum=n.get_opt_int("maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_container("teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_container("drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_container("hide-excess")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(maximum=n.get_opt_value("maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_container("teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_container("drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_container("hide-excess")))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(maximum=yang.gdata.from_xml_opt_int(n, "maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, "teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, "drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, "hide-excess")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(maximum=yang.gdata.from_xml_opt_value(n, "maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, "teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, "drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, "hide-excess")))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__maximum(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__forever(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__timeout(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(yang.adata.MNode):
     forever: ?bool
-    timeout: ?int
+    timeout: ?value
 
-    mut def __init__(self, forever: ?bool, timeout: ?int):
+    mut def __init__(self, forever: ?bool, timeout: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.forever = forever
         self.timeout = timeout
@@ -5453,28 +5453,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         if _forever is not None:
             children['forever'] = yang.gdata.Leaf('empty', _forever)
         if _timeout is not None:
-            children['timeout'] = yang.gdata.Leaf('uint32', _timeout)
+            children['timeout'] = yang.gdata.Leaf('union', _timeout)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool("forever"), timeout=n.get_opt_int("timeout"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool("forever"), timeout=n.get_opt_value("timeout"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, "forever"), timeout=yang.gdata.from_xml_opt_int(n, "timeout"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, "forever"), timeout=yang.gdata.from_xml_opt_value(n, "timeout"))
         return None
 
 
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
     idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout
 
-    mut def __init__(self, limit_threshold: ?int, idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout=None):
+    mut def __init__(self, limit_threshold: ?value, idle_timeout: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
         self.idle_timeout = idle_timeout
@@ -5492,7 +5492,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _limit_threshold = self.limit_threshold
         _idle_timeout = self.idle_timeout
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         if _idle_timeout is not None:
             children['idle-timeout'] = _idle_timeout.to_gdata()
         return yang.gdata.Container(children, presence=True)
@@ -5500,24 +5500,24 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_int("limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container("idle-timeout")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_value("limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container("idle-timeout")))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, "idle-timeout")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, "idle-timeout")))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
 
-    mut def __init__(self, limit_threshold: ?int):
+    mut def __init__(self, limit_threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
 
@@ -5525,30 +5525,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         children = {}
         _limit_threshold = self.limit_threshold
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_int("limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_value("limit-threshold"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(yang.adata.MNode):
-    limit_threshold: ?int
+    limit_threshold: ?value
 
-    mut def __init__(self, limit_threshold: ?int):
+    mut def __init__(self, limit_threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.limit_threshold = limit_threshold
 
@@ -5556,30 +5556,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         children = {}
         _limit_threshold = self.limit_threshold
         if _limit_threshold is not None:
-            children['limit-threshold'] = yang.gdata.Leaf('uint32', _limit_threshold)
+            children['limit-threshold'] = yang.gdata.Leaf('union', _limit_threshold)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_int("limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_value("limit-threshold"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_int(n, "limit-threshold"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, "limit-threshold"))
         return None
 
 
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(yang.adata.MNode):
-    maximum: ?int
+    maximum: ?value
     teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown
     drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess
     hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess
 
-    mut def __init__(self, maximum: ?int, teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown=None, drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess=None, hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess=None):
+    mut def __init__(self, maximum: ?value, teardown: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown=None, drop_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess=None, hide_excess: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.maximum = maximum
         self.teardown = teardown
@@ -5617,7 +5617,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _drop_excess = self.drop_excess
         _hide_excess = self.hide_excess
         if _maximum is not None:
-            children['maximum'] = yang.gdata.Leaf('uint32', _maximum)
+            children['maximum'] = yang.gdata.Leaf('union', _maximum)
         if _teardown is not None:
             children['teardown'] = _teardown.to_gdata()
         if _drop_excess is not None:
@@ -5629,13 +5629,13 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_int("maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_container("teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_container("drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_container("hide-excess")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_value("maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_container("teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_container("drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_container("hide-excess")))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(maximum=yang.gdata.from_xml_opt_int(n, "maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, "teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, "drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, "hide-excess")))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(maximum=yang.gdata.from_xml_opt_value(n, "maximum"), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, "teardown")), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, "drop-excess")), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, "hide-excess")))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit()
 
 
@@ -5717,10 +5717,10 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
     return yang.gdata.LeafList(val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_count(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("int32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__include_backup_path(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("int32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__multipath(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -5728,11 +5728,11 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(yang.adata.MNode):
     path_selection_mode: junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode
     prefix_policy: list[str]
-    path_count: ?int
-    include_backup_path: ?int
+    path_count: ?value
+    include_backup_path: ?value
     multipath: ?bool
 
-    mut def __init__(self, path_selection_mode: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode=None, prefix_policy: ?list[str]=None, path_count: ?int, include_backup_path: ?int, multipath: ?bool):
+    mut def __init__(self, path_selection_mode: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode=None, prefix_policy: ?list[str]=None, path_count: ?value, include_backup_path: ?value, multipath: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         if path_selection_mode is not None:
             self.path_selection_mode = path_selection_mode
@@ -5759,9 +5759,9 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             children['path-selection-mode'] = _path_selection_mode.to_gdata()
         children['prefix-policy'] = yang.gdata.LeafList(self.prefix_policy)
         if _path_count is not None:
-            children['path-count'] = yang.gdata.Leaf('int32', _path_count)
+            children['path-count'] = yang.gdata.Leaf('union', _path_count)
         if _include_backup_path is not None:
-            children['include-backup-path'] = yang.gdata.Leaf('int32', _include_backup_path)
+            children['include-backup-path'] = yang.gdata.Leaf('union', _include_backup_path)
         if _multipath is not None:
             children['multipath'] = yang.gdata.Leaf('empty', _multipath)
         return yang.gdata.Container(children, presence=True)
@@ -5769,13 +5769,13 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_container("path-selection-mode")), prefix_policy=n.get_opt_strs("prefix-policy"), path_count=n.get_opt_int("path-count"), include_backup_path=n.get_opt_int("include-backup-path"), multipath=n.get_opt_bool("multipath"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_container("path-selection-mode")), prefix_policy=n.get_opt_strs("prefix-policy"), path_count=n.get_opt_value("path-count"), include_backup_path=n.get_opt_value("include-backup-path"), multipath=n.get_opt_bool("multipath"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode.from_xml(yang.gdata.get_xml_opt_child(n, "path-selection-mode")), prefix_policy=yang.gdata.from_xml_opt_strs(n, "prefix-policy"), path_count=yang.gdata.from_xml_opt_int(n, "path-count"), include_backup_path=yang.gdata.from_xml_opt_int(n, "include-backup-path"), multipath=yang.gdata.from_xml_opt_bool(n, "multipath"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode.from_xml(yang.gdata.get_xml_opt_child(n, "path-selection-mode")), prefix_policy=yang.gdata.from_xml_opt_strs(n, "prefix-policy"), path_count=yang.gdata.from_xml_opt_value(n, "path-count"), include_backup_path=yang.gdata.from_xml_opt_value(n, "include-backup-path"), multipath=yang.gdata.from_xml_opt_bool(n, "multipath"))
         return None
 
 
@@ -5859,12 +5859,12 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
     return yang.gdata.Leaf("string", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops__loops(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("int32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(yang.adata.MNode):
-    loops: ?int
+    loops: ?value
 
-    mut def __init__(self, loops: ?int):
+    mut def __init__(self, loops: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.loops = loops
 
@@ -5872,19 +5872,19 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         children = {}
         _loops = self.loops
         if _loops is not None:
-            children['loops'] = yang.gdata.Leaf('int32', _loops)
+            children['loops'] = yang.gdata.Leaf('union', _loops)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(loops=n.get_opt_int("loops"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(loops=n.get_opt_value("loops"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(loops=yang.gdata.from_xml_opt_int(n, "loops"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(loops=yang.gdata.from_xml_opt_value(n, "loops"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops()
 
 
@@ -5893,16 +5893,16 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay__routing_uptime(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay__inbound_convergence(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(yang.adata.MNode):
-    routing_uptime: ?int
-    inbound_convergence: ?int
+    routing_uptime: ?value
+    inbound_convergence: ?value
 
-    mut def __init__(self, routing_uptime: ?int, inbound_convergence: ?int):
+    mut def __init__(self, routing_uptime: ?value, inbound_convergence: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.routing_uptime = routing_uptime
         self.inbound_convergence = inbound_convergence
@@ -5912,36 +5912,36 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _routing_uptime = self.routing_uptime
         _inbound_convergence = self.inbound_convergence
         if _routing_uptime is not None:
-            children['routing-uptime'] = yang.gdata.Leaf('uint32', _routing_uptime)
+            children['routing-uptime'] = yang.gdata.Leaf('union', _routing_uptime)
         if _inbound_convergence is not None:
-            children['inbound-convergence'] = yang.gdata.Leaf('uint32', _inbound_convergence)
+            children['inbound-convergence'] = yang.gdata.Leaf('union', _inbound_convergence)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_int("routing-uptime"), inbound_convergence=n.get_opt_int("inbound-convergence"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_value("routing-uptime"), inbound_convergence=n.get_opt_value("inbound-convergence"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=yang.gdata.from_xml_opt_int(n, "routing-uptime"), inbound_convergence=yang.gdata.from_xml_opt_int(n, "inbound-convergence"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=yang.gdata.from_xml_opt_value(n, "routing-uptime"), inbound_convergence=yang.gdata.from_xml_opt_value(n, "inbound-convergence"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay__route_age(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay__routing_uptime(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(yang.adata.MNode):
-    route_age: ?int
-    routing_uptime: ?int
+    route_age: ?value
+    routing_uptime: ?value
 
-    mut def __init__(self, route_age: ?int, routing_uptime: ?int):
+    mut def __init__(self, route_age: ?value, routing_uptime: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.route_age = route_age
         self.routing_uptime = routing_uptime
@@ -5951,21 +5951,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _route_age = self.route_age
         _routing_uptime = self.routing_uptime
         if _route_age is not None:
-            children['route-age'] = yang.gdata.Leaf('uint32', _route_age)
+            children['route-age'] = yang.gdata.Leaf('union', _route_age)
         if _routing_uptime is not None:
-            children['routing-uptime'] = yang.gdata.Leaf('uint32', _routing_uptime)
+            children['routing-uptime'] = yang.gdata.Leaf('union', _routing_uptime)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_int("route-age"), routing_uptime=n.get_opt_int("routing-uptime"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_value("route-age"), routing_uptime=n.get_opt_value("routing-uptime"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=yang.gdata.from_xml_opt_int(n, "route-age"), routing_uptime=yang.gdata.from_xml_opt_int(n, "routing-uptime"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=yang.gdata.from_xml_opt_value(n, "route-age"), routing_uptime=yang.gdata.from_xml_opt_value(n, "routing-uptime"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay()
 
 
@@ -6060,12 +6060,12 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build__maximum_delay(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(yang.adata.MNode):
-    maximum_delay: ?int
+    maximum_delay: ?value
 
-    mut def __init__(self, maximum_delay: ?int):
+    mut def __init__(self, maximum_delay: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.maximum_delay = maximum_delay
 
@@ -6073,19 +6073,19 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         children = {}
         _maximum_delay = self.maximum_delay
         if _maximum_delay is not None:
-            children['maximum-delay'] = yang.gdata.Leaf('uint32', _maximum_delay)
+            children['maximum-delay'] = yang.gdata.Leaf('union', _maximum_delay)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_int("maximum-delay"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_value("maximum-delay"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(maximum_delay=yang.gdata.from_xml_opt_int(n, "maximum-delay"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(maximum_delay=yang.gdata.from_xml_opt_value(n, "maximum-delay"))
         return None
 
 
@@ -6280,16 +6280,16 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family_
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority__priority(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority__expedited(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(yang.adata.MNode):
-    priority: ?int
+    priority: ?value
     expedited: ?bool
 
-    mut def __init__(self, priority: ?int, expedited: ?bool):
+    mut def __init__(self, priority: ?value, expedited: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.priority = priority
         self.expedited = expedited
@@ -6299,7 +6299,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _priority = self.priority
         _expedited = self.expedited
         if _priority is not None:
-            children['priority'] = yang.gdata.Leaf('uint32', _priority)
+            children['priority'] = yang.gdata.Leaf('union', _priority)
         if _expedited is not None:
             children['expedited'] = yang.gdata.Leaf('empty', _expedited)
         return yang.gdata.Container(children)
@@ -6307,28 +6307,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(priority=n.get_opt_int("priority"), expedited=n.get_opt_bool("expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(priority=n.get_opt_value("priority"), expedited=n.get_opt_bool("expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(priority=yang.gdata.from_xml_opt_int(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(priority=yang.gdata.from_xml_opt_value(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority__priority(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority__expedited(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(yang.adata.MNode):
-    priority: ?int
+    priority: ?value
     expedited: ?bool
 
-    mut def __init__(self, priority: ?int, expedited: ?bool):
+    mut def __init__(self, priority: ?value, expedited: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.priority = priority
         self.expedited = expedited
@@ -6338,7 +6338,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _priority = self.priority
         _expedited = self.expedited
         if _priority is not None:
-            children['priority'] = yang.gdata.Leaf('uint32', _priority)
+            children['priority'] = yang.gdata.Leaf('union', _priority)
         if _expedited is not None:
             children['expedited'] = yang.gdata.Leaf('empty', _expedited)
         return yang.gdata.Container(children)
@@ -6346,28 +6346,28 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(priority=n.get_opt_int("priority"), expedited=n.get_opt_bool("expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(priority=n.get_opt_value("priority"), expedited=n.get_opt_bool("expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(priority=yang.gdata.from_xml_opt_int(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(priority=yang.gdata.from_xml_opt_value(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority__priority(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority__expedited(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(yang.adata.MNode):
-    priority: ?int
+    priority: ?value
     expedited: ?bool
 
-    mut def __init__(self, priority: ?int, expedited: ?bool):
+    mut def __init__(self, priority: ?value, expedited: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.priority = priority
         self.expedited = expedited
@@ -6377,7 +6377,7 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
         _priority = self.priority
         _expedited = self.expedited
         if _priority is not None:
-            children['priority'] = yang.gdata.Leaf('uint32', _priority)
+            children['priority'] = yang.gdata.Leaf('union', _priority)
         if _expedited is not None:
             children['expedited'] = yang.gdata.Leaf('empty', _expedited)
         return yang.gdata.Container(children)
@@ -6385,13 +6385,13 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(priority=n.get_opt_int("priority"), expedited=n.get_opt_bool("expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(priority=n.get_opt_value("priority"), expedited=n.get_opt_bool("expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority:
         if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(priority=yang.gdata.from_xml_opt_int(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
+            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(priority=yang.gdata.from_xml_opt_value(n, "priority"), expedited=yang.gdata.from_xml_opt_bool(n, "expedited"))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority()
 
 
@@ -6971,7 +6971,7 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__group__export(
     return yang.gdata.LeafList(val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__tcp_mss(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__bgp__group__neighbor__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -7064,17 +7064,17 @@ class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNo
     type: ?str
     description: ?str
     local_address: ?str
-    hold_time: ?int
+    hold_time: ?value
     family: junos_conf_root__configuration__protocols__bgp__group__family
     authentication_key: ?str
     authentication_algorithm: ?str
     tcpao_auth_mismatch: ?str
     authentication_key_chain: ?str
     export: list[str]
-    tcp_mss: ?int
+    tcp_mss: ?value
     neighbor: junos_conf_root__configuration__protocols__bgp__group__neighbor
 
-    mut def __init__(self, name: str, type: ?str, description: ?str, local_address: ?str, hold_time: ?int, family: ?junos_conf_root__configuration__protocols__bgp__group__family=None, authentication_key: ?str, authentication_algorithm: ?str, tcpao_auth_mismatch: ?str, authentication_key_chain: ?str, export: ?list[str]=None, tcp_mss: ?int, neighbor: list[junos_conf_root__configuration__protocols__bgp__group__neighbor_entry]=[]):
+    mut def __init__(self, name: str, type: ?str, description: ?str, local_address: ?str, hold_time: ?value, family: ?junos_conf_root__configuration__protocols__bgp__group__family=None, authentication_key: ?str, authentication_algorithm: ?str, tcpao_auth_mismatch: ?str, authentication_key_chain: ?str, export: ?list[str]=None, tcp_mss: ?value, neighbor: list[junos_conf_root__configuration__protocols__bgp__group__neighbor_entry]=[]):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.name = name
         self.type = type
@@ -7123,7 +7123,7 @@ class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNo
         if _local_address is not None:
             children['local-address'] = yang.gdata.Leaf('string', _local_address)
         if _hold_time is not None:
-            children['hold-time'] = yang.gdata.Leaf('uint32', _hold_time)
+            children['hold-time'] = yang.gdata.Leaf('union', _hold_time)
         if _family is not None:
             children['family'] = _family.to_gdata()
         if _authentication_key is not None:
@@ -7136,18 +7136,18 @@ class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNo
             children['authentication-key-chain'] = yang.gdata.Leaf('string', _authentication_key_chain)
         children['export'] = yang.gdata.LeafList(self.export)
         if _tcp_mss is not None:
-            children['tcp-mss'] = yang.gdata.Leaf('uint32', _tcp_mss)
+            children['tcp-mss'] = yang.gdata.Leaf('union', _tcp_mss)
         if _neighbor is not None:
             children['neighbor'] = _neighbor.to_gdata()
         return yang.gdata.ListElement([yang.gdata.yang_str(self.name)], children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group_entry:
-        return junos_conf_root__configuration__protocols__bgp__group_entry(name=n.get_str("name"), type=n.get_opt_str("type"), description=n.get_opt_str("description"), local_address=n.get_opt_str("local-address"), hold_time=n.get_opt_int("hold-time"), family=junos_conf_root__configuration__protocols__bgp__group__family.from_gdata(n.get_opt_container("family")), authentication_key=n.get_opt_str("authentication-key"), authentication_algorithm=n.get_opt_str("authentication-algorithm"), tcpao_auth_mismatch=n.get_opt_str("tcpao-auth-mismatch"), authentication_key_chain=n.get_opt_str("authentication-key-chain"), export=n.get_opt_strs("export"), tcp_mss=n.get_opt_int("tcp-mss"), neighbor=junos_conf_root__configuration__protocols__bgp__group__neighbor.from_gdata(n.get_opt_list("neighbor")))
+        return junos_conf_root__configuration__protocols__bgp__group_entry(name=n.get_str("name"), type=n.get_opt_str("type"), description=n.get_opt_str("description"), local_address=n.get_opt_str("local-address"), hold_time=n.get_opt_value("hold-time"), family=junos_conf_root__configuration__protocols__bgp__group__family.from_gdata(n.get_opt_container("family")), authentication_key=n.get_opt_str("authentication-key"), authentication_algorithm=n.get_opt_str("authentication-algorithm"), tcpao_auth_mismatch=n.get_opt_str("tcpao-auth-mismatch"), authentication_key_chain=n.get_opt_str("authentication-key-chain"), export=n.get_opt_strs("export"), tcp_mss=n.get_opt_value("tcp-mss"), neighbor=junos_conf_root__configuration__protocols__bgp__group__neighbor.from_gdata(n.get_opt_list("neighbor")))
 
     @staticmethod
     mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__bgp__group_entry:
-        return junos_conf_root__configuration__protocols__bgp__group_entry(name=yang.gdata.from_xml_str(n, "name"), type=yang.gdata.from_xml_opt_str(n, "type"), description=yang.gdata.from_xml_opt_str(n, "description"), local_address=yang.gdata.from_xml_opt_str(n, "local-address"), hold_time=yang.gdata.from_xml_opt_int(n, "hold-time"), family=junos_conf_root__configuration__protocols__bgp__group__family.from_xml(yang.gdata.get_xml_opt_child(n, "family")), authentication_key=yang.gdata.from_xml_opt_str(n, "authentication-key"), authentication_algorithm=yang.gdata.from_xml_opt_str(n, "authentication-algorithm"), tcpao_auth_mismatch=yang.gdata.from_xml_opt_str(n, "tcpao-auth-mismatch"), authentication_key_chain=yang.gdata.from_xml_opt_str(n, "authentication-key-chain"), export=yang.gdata.from_xml_opt_strs(n, "export"), tcp_mss=yang.gdata.from_xml_opt_int(n, "tcp-mss"), neighbor=junos_conf_root__configuration__protocols__bgp__group__neighbor.from_xml(yang.gdata.get_xml_children(n, "neighbor")))
+        return junos_conf_root__configuration__protocols__bgp__group_entry(name=yang.gdata.from_xml_str(n, "name"), type=yang.gdata.from_xml_opt_str(n, "type"), description=yang.gdata.from_xml_opt_str(n, "description"), local_address=yang.gdata.from_xml_opt_str(n, "local-address"), hold_time=yang.gdata.from_xml_opt_value(n, "hold-time"), family=junos_conf_root__configuration__protocols__bgp__group__family.from_xml(yang.gdata.get_xml_opt_child(n, "family")), authentication_key=yang.gdata.from_xml_opt_str(n, "authentication-key"), authentication_algorithm=yang.gdata.from_xml_opt_str(n, "authentication-algorithm"), tcpao_auth_mismatch=yang.gdata.from_xml_opt_str(n, "tcpao-auth-mismatch"), authentication_key_chain=yang.gdata.from_xml_opt_str(n, "authentication-key-chain"), export=yang.gdata.from_xml_opt_strs(n, "export"), tcp_mss=yang.gdata.from_xml_opt_value(n, "tcp-mss"), neighbor=junos_conf_root__configuration__protocols__bgp__group__neighbor.from_xml(yang.gdata.get_xml_children(n, "neighbor")))
 
 class junos_conf_root__configuration__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__bgp__group_entry]
@@ -7243,19 +7243,19 @@ class junos_conf_root__configuration__protocols__bgp(yang.adata.MNode):
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__name(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("string", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization__disable(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization__hold_time(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(yang.adata.MNode):
     disable: ?bool
-    hold_time: ?int
+    hold_time: ?value
 
-    mut def __init__(self, disable: ?bool, hold_time: ?int):
+    mut def __init__(self, disable: ?bool, hold_time: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.disable = disable
         self.hold_time = hold_time
@@ -7267,38 +7267,38 @@ class junos_conf_root__configuration__protocols__isis__interface__ldp_synchroniz
         if _disable is not None:
             children['disable'] = yang.gdata.Leaf('empty', _disable)
         if _hold_time is not None:
-            children['hold-time'] = yang.gdata.Leaf('uint32', _hold_time)
+            children['hold-time'] = yang.gdata.Leaf('union', _hold_time)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(disable=n.get_opt_bool("disable"), hold_time=n.get_opt_int("hold-time"))
+            return junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(disable=n.get_opt_bool("disable"), hold_time=n.get_opt_value("hold-time"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(disable=yang.gdata.from_xml_opt_bool(n, "disable"), hold_time=yang.gdata.from_xml_opt_int(n, "hold-time"))
+            return junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(disable=yang.gdata.from_xml_opt_bool(n, "disable"), hold_time=yang.gdata.from_xml_opt_value(n, "hold-time"))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__level__name(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__level__disable(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__level__metric(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__interface__level_entry(yang.adata.MNode):
-    name: int
+    name: value
     disable: ?bool
-    metric: ?int
+    metric: ?value
 
-    mut def __init__(self, name: int, disable: ?bool, metric: ?int):
+    mut def __init__(self, name: value, disable: ?bool, metric: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.name = name
         self.disable = disable
@@ -7310,20 +7310,20 @@ class junos_conf_root__configuration__protocols__isis__interface__level_entry(ya
         _disable = self.disable
         _metric = self.metric
         if _name is not None:
-            children['name'] = yang.gdata.Leaf('uint32', _name)
+            children['name'] = yang.gdata.Leaf('union', _name)
         if _disable is not None:
             children['disable'] = yang.gdata.Leaf('empty', _disable)
         if _metric is not None:
-            children['metric'] = yang.gdata.Leaf('uint32', _metric)
+            children['metric'] = yang.gdata.Leaf('union', _metric)
         return yang.gdata.ListElement([yang.gdata.yang_str(self.name)], children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__level_entry:
-        return junos_conf_root__configuration__protocols__isis__interface__level_entry(name=n.get_int("name"), disable=n.get_opt_bool("disable"), metric=n.get_opt_int("metric"))
+        return junos_conf_root__configuration__protocols__isis__interface__level_entry(name=n.get_value("name"), disable=n.get_opt_bool("disable"), metric=n.get_opt_value("metric"))
 
     @staticmethod
     mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__level_entry:
-        return junos_conf_root__configuration__protocols__isis__interface__level_entry(name=yang.gdata.from_xml_int(n, "name"), disable=yang.gdata.from_xml_opt_bool(n, "disable"), metric=yang.gdata.from_xml_opt_int(n, "metric"))
+        return junos_conf_root__configuration__protocols__isis__interface__level_entry(name=yang.gdata.from_xml_value(n, "name"), disable=yang.gdata.from_xml_opt_bool(n, "disable"), metric=yang.gdata.from_xml_opt_value(n, "metric"))
 
 class junos_conf_root__configuration__protocols__isis__interface__level(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface__level_entry]
@@ -7335,9 +7335,16 @@ class junos_conf_root__configuration__protocols__isis__interface__level(yang.ada
     mut def create(self, name):
         for e in self.elements:
             match = True
-            if e.name != name:
-                match = False
-                continue
+            e_name = e.name
+            if isinstance(e_name, str) and isinstance(name, str):
+                if e_name != name:
+                    match = False
+                    continue
+            e_name = e.name
+            if isinstance(e_name, int) and isinstance(name, int):
+                if e_name != name:
+                    match = False
+                    continue
             if match:
                 return e
 
@@ -7371,7 +7378,7 @@ class junos_conf_root__configuration__protocols__isis__interface__level(yang.ada
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__lsp_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__point_to_point(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -7422,37 +7429,37 @@ mut def from_json_junos_conf_root__configuration__protocols__isis__interface__fa
     return yang.gdata.Leaf("enumeration", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_transmit_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_receive_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__multiplier(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__inline_disable(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__pdu_size(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__no_adaptation(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval__minimum_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval__threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(yang.adata.MNode):
-    minimum_interval: ?int
-    threshold: ?int
+    minimum_interval: ?value
+    threshold: ?value
 
-    mut def __init__(self, minimum_interval: ?int, threshold: ?int):
+    mut def __init__(self, minimum_interval: ?value, threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.minimum_interval = minimum_interval
         self.threshold = threshold
@@ -7462,32 +7469,32 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
         _minimum_interval = self.minimum_interval
         _threshold = self.threshold
         if _minimum_interval is not None:
-            children['minimum-interval'] = yang.gdata.Leaf('uint32', _minimum_interval)
+            children['minimum-interval'] = yang.gdata.Leaf('union', _minimum_interval)
         if _threshold is not None:
-            children['threshold'] = yang.gdata.Leaf('uint32', _threshold)
+            children['threshold'] = yang.gdata.Leaf('union', _threshold)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(minimum_interval=n.get_opt_int("minimum-interval"), threshold=n.get_opt_int("threshold"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(minimum_interval=n.get_opt_value("minimum-interval"), threshold=n.get_opt_value("threshold"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(minimum_interval=yang.gdata.from_xml_opt_int(n, "minimum-interval"), threshold=yang.gdata.from_xml_opt_int(n, "threshold"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(minimum_interval=yang.gdata.from_xml_opt_value(n, "minimum-interval"), threshold=yang.gdata.from_xml_opt_value(n, "threshold"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time__threshold(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(yang.adata.MNode):
-    threshold: ?int
+    threshold: ?value
 
-    mut def __init__(self, threshold: ?int):
+    mut def __init__(self, threshold: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.threshold = threshold
 
@@ -7495,19 +7502,19 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
         children = {}
         _threshold = self.threshold
         if _threshold is not None:
-            children['threshold'] = yang.gdata.Leaf('uint32', _threshold)
+            children['threshold'] = yang.gdata.Leaf('union', _threshold)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(threshold=n.get_opt_int("threshold"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(threshold=n.get_opt_value("threshold"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(threshold=yang.gdata.from_xml_opt_int(n, "threshold"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(threshold=yang.gdata.from_xml_opt_value(n, "threshold"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time()
 
 
@@ -7560,12 +7567,12 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo__minimum_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(yang.adata.MNode):
-    minimum_interval: ?int
+    minimum_interval: ?value
 
-    mut def __init__(self, minimum_interval: ?int):
+    mut def __init__(self, minimum_interval: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.minimum_interval = minimum_interval
 
@@ -7573,30 +7580,30 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
         children = {}
         _minimum_interval = self.minimum_interval
         if _minimum_interval is not None:
-            children['minimum-interval'] = yang.gdata.Leaf('uint32', _minimum_interval)
+            children['minimum-interval'] = yang.gdata.Leaf('union', _minimum_interval)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(minimum_interval=n.get_opt_int("minimum-interval"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(minimum_interval=n.get_opt_value("minimum-interval"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(minimum_interval=yang.gdata.from_xml_opt_int(n, "minimum-interval"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(minimum_interval=yang.gdata.from_xml_opt_value(n, "minimum-interval"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite__minimum_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(yang.adata.MNode):
-    minimum_interval: ?int
+    minimum_interval: ?value
 
-    mut def __init__(self, minimum_interval: ?int):
+    mut def __init__(self, minimum_interval: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.minimum_interval = minimum_interval
 
@@ -7604,43 +7611,43 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
         children = {}
         _minimum_interval = self.minimum_interval
         if _minimum_interval is not None:
-            children['minimum-interval'] = yang.gdata.Leaf('uint32', _minimum_interval)
+            children['minimum-interval'] = yang.gdata.Leaf('union', _minimum_interval)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(minimum_interval=n.get_opt_int("minimum-interval"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(minimum_interval=n.get_opt_value("minimum-interval"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(minimum_interval=yang.gdata.from_xml_opt_int(n, "minimum-interval"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(minimum_interval=yang.gdata.from_xml_opt_value(n, "minimum-interval"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__holddown_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(yang.adata.MNode):
     version: str
-    minimum_interval: ?int
-    minimum_transmit_interval: ?int
-    minimum_receive_interval: ?int
-    multiplier: int
+    minimum_interval: ?value
+    minimum_transmit_interval: ?value
+    minimum_receive_interval: ?value
+    multiplier: value
     inline_disable: ?bool
-    pdu_size: int
+    pdu_size: value
     no_adaptation: ?bool
     transmit_interval: junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval
     detection_time: junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time
     authentication: junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication
     echo: junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo
     echo_lite: junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite
-    holddown_interval: ?int
+    holddown_interval: ?value
 
-    mut def __init__(self, version: ?str=None, minimum_interval: ?int, minimum_transmit_interval: ?int, minimum_receive_interval: ?int, multiplier: ?int=None, inline_disable: ?bool, pdu_size: ?int=None, no_adaptation: ?bool, transmit_interval: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval=None, detection_time: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time=None, authentication: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication=None, echo: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo=None, echo_lite: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite=None, holddown_interval: ?int):
+    mut def __init__(self, version: ?str=None, minimum_interval: ?value, minimum_transmit_interval: ?value, minimum_receive_interval: ?value, multiplier: ?value=None, inline_disable: ?bool, pdu_size: ?value=None, no_adaptation: ?bool, transmit_interval: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval=None, detection_time: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time=None, authentication: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication=None, echo: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo=None, echo_lite: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite=None, holddown_interval: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         if version != None:
             self.version = version
@@ -7715,17 +7722,17 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
         if _version is not None:
             children['version'] = yang.gdata.Leaf('enumeration', _version)
         if _minimum_interval is not None:
-            children['minimum-interval'] = yang.gdata.Leaf('uint32', _minimum_interval)
+            children['minimum-interval'] = yang.gdata.Leaf('union', _minimum_interval)
         if _minimum_transmit_interval is not None:
-            children['minimum-transmit-interval'] = yang.gdata.Leaf('uint32', _minimum_transmit_interval)
+            children['minimum-transmit-interval'] = yang.gdata.Leaf('union', _minimum_transmit_interval)
         if _minimum_receive_interval is not None:
-            children['minimum-receive-interval'] = yang.gdata.Leaf('uint32', _minimum_receive_interval)
+            children['minimum-receive-interval'] = yang.gdata.Leaf('union', _minimum_receive_interval)
         if _multiplier is not None:
-            children['multiplier'] = yang.gdata.Leaf('uint32', _multiplier)
+            children['multiplier'] = yang.gdata.Leaf('union', _multiplier)
         if _inline_disable is not None:
             children['inline-disable'] = yang.gdata.Leaf('empty', _inline_disable)
         if _pdu_size is not None:
-            children['pdu-size'] = yang.gdata.Leaf('uint32', _pdu_size)
+            children['pdu-size'] = yang.gdata.Leaf('union', _pdu_size)
         if _no_adaptation is not None:
             children['no-adaptation'] = yang.gdata.Leaf('empty', _no_adaptation)
         if _transmit_interval is not None:
@@ -7739,19 +7746,19 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
         if _echo_lite is not None:
             children['echo-lite'] = _echo_lite.to_gdata()
         if _holddown_interval is not None:
-            children['holddown-interval'] = yang.gdata.Leaf('uint32', _holddown_interval)
+            children['holddown-interval'] = yang.gdata.Leaf('union', _holddown_interval)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(version=n.get_opt_str("version"), minimum_interval=n.get_opt_int("minimum-interval"), minimum_transmit_interval=n.get_opt_int("minimum-transmit-interval"), minimum_receive_interval=n.get_opt_int("minimum-receive-interval"), multiplier=n.get_opt_int("multiplier"), inline_disable=n.get_opt_bool("inline-disable"), pdu_size=n.get_opt_int("pdu-size"), no_adaptation=n.get_opt_bool("no-adaptation"), transmit_interval=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval.from_gdata(n.get_opt_container("transmit-interval")), detection_time=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time.from_gdata(n.get_opt_container("detection-time")), authentication=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication.from_gdata(n.get_opt_container("authentication")), echo=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo.from_gdata(n.get_opt_container("echo")), echo_lite=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite.from_gdata(n.get_opt_container("echo-lite")), holddown_interval=n.get_opt_int("holddown-interval"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(version=n.get_opt_str("version"), minimum_interval=n.get_opt_value("minimum-interval"), minimum_transmit_interval=n.get_opt_value("minimum-transmit-interval"), minimum_receive_interval=n.get_opt_value("minimum-receive-interval"), multiplier=n.get_opt_value("multiplier"), inline_disable=n.get_opt_bool("inline-disable"), pdu_size=n.get_opt_value("pdu-size"), no_adaptation=n.get_opt_bool("no-adaptation"), transmit_interval=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval.from_gdata(n.get_opt_container("transmit-interval")), detection_time=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time.from_gdata(n.get_opt_container("detection-time")), authentication=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication.from_gdata(n.get_opt_container("authentication")), echo=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo.from_gdata(n.get_opt_container("echo")), echo_lite=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite.from_gdata(n.get_opt_container("echo-lite")), holddown_interval=n.get_opt_value("holddown-interval"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(version=yang.gdata.from_xml_opt_str(n, "version"), minimum_interval=yang.gdata.from_xml_opt_int(n, "minimum-interval"), minimum_transmit_interval=yang.gdata.from_xml_opt_int(n, "minimum-transmit-interval"), minimum_receive_interval=yang.gdata.from_xml_opt_int(n, "minimum-receive-interval"), multiplier=yang.gdata.from_xml_opt_int(n, "multiplier"), inline_disable=yang.gdata.from_xml_opt_bool(n, "inline-disable"), pdu_size=yang.gdata.from_xml_opt_int(n, "pdu-size"), no_adaptation=yang.gdata.from_xml_opt_bool(n, "no-adaptation"), transmit_interval=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval.from_xml(yang.gdata.get_xml_opt_child(n, "transmit-interval")), detection_time=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time.from_xml(yang.gdata.get_xml_opt_child(n, "detection-time")), authentication=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication.from_xml(yang.gdata.get_xml_opt_child(n, "authentication")), echo=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo.from_xml(yang.gdata.get_xml_opt_child(n, "echo")), echo_lite=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite.from_xml(yang.gdata.get_xml_opt_child(n, "echo-lite")), holddown_interval=yang.gdata.from_xml_opt_int(n, "holddown-interval"))
+            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(version=yang.gdata.from_xml_opt_str(n, "version"), minimum_interval=yang.gdata.from_xml_opt_value(n, "minimum-interval"), minimum_transmit_interval=yang.gdata.from_xml_opt_value(n, "minimum-transmit-interval"), minimum_receive_interval=yang.gdata.from_xml_opt_value(n, "minimum-receive-interval"), multiplier=yang.gdata.from_xml_opt_value(n, "multiplier"), inline_disable=yang.gdata.from_xml_opt_bool(n, "inline-disable"), pdu_size=yang.gdata.from_xml_opt_value(n, "pdu-size"), no_adaptation=yang.gdata.from_xml_opt_bool(n, "no-adaptation"), transmit_interval=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval.from_xml(yang.gdata.get_xml_opt_child(n, "transmit-interval")), detection_time=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time.from_xml(yang.gdata.get_xml_opt_child(n, "detection-time")), authentication=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication.from_xml(yang.gdata.get_xml_opt_child(n, "authentication")), echo=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo.from_xml(yang.gdata.get_xml_opt_child(n, "echo")), echo_lite=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite.from_xml(yang.gdata.get_xml_opt_child(n, "echo-lite")), holddown_interval=yang.gdata.from_xml_opt_value(n, "holddown-interval"))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection()
 
 
@@ -7838,12 +7845,12 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
     name: str
     ldp_synchronization: ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization
     level: junos_conf_root__configuration__protocols__isis__interface__level
-    lsp_interval: int
+    lsp_interval: value
     point_to_point: ?bool
     passive: ?junos_conf_root__configuration__protocols__isis__interface__passive
     family: junos_conf_root__configuration__protocols__isis__interface__family
 
-    mut def __init__(self, name: str, ldp_synchronization: ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization=None, level: list[junos_conf_root__configuration__protocols__isis__interface__level_entry]=[], lsp_interval: ?int=None, point_to_point: ?bool, passive: ?junos_conf_root__configuration__protocols__isis__interface__passive=None, family: list[junos_conf_root__configuration__protocols__isis__interface__family_entry]=[]):
+    mut def __init__(self, name: str, ldp_synchronization: ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization=None, level: list[junos_conf_root__configuration__protocols__isis__interface__level_entry]=[], lsp_interval: ?value=None, point_to_point: ?bool, passive: ?junos_conf_root__configuration__protocols__isis__interface__passive=None, family: list[junos_conf_root__configuration__protocols__isis__interface__family_entry]=[]):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.name = name
         self.ldp_synchronization = ldp_synchronization
@@ -7884,13 +7891,13 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
         _passive = self.passive
         _family = self.family
         if _name is not None:
-            children['name'] = yang.gdata.Leaf('string', _name)
+            children['name'] = yang.gdata.Leaf('union', _name)
         if _ldp_synchronization is not None:
             children['ldp-synchronization'] = _ldp_synchronization.to_gdata()
         if _level is not None:
             children['level'] = _level.to_gdata()
         if _lsp_interval is not None:
-            children['lsp-interval'] = yang.gdata.Leaf('uint32', _lsp_interval)
+            children['lsp-interval'] = yang.gdata.Leaf('union', _lsp_interval)
         if _point_to_point is not None:
             children['point-to-point'] = yang.gdata.Leaf('empty', _point_to_point)
         if _passive is not None:
@@ -7901,11 +7908,11 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface_entry:
-        return junos_conf_root__configuration__protocols__isis__interface_entry(name=n.get_str("name"), ldp_synchronization=junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization.from_gdata(n.get_opt_container("ldp-synchronization")), level=junos_conf_root__configuration__protocols__isis__interface__level.from_gdata(n.get_opt_list("level")), lsp_interval=n.get_opt_int("lsp-interval"), point_to_point=n.get_opt_bool("point-to-point"), passive=junos_conf_root__configuration__protocols__isis__interface__passive.from_gdata(n.get_opt_container("passive")), family=junos_conf_root__configuration__protocols__isis__interface__family.from_gdata(n.get_opt_list("family")))
+        return junos_conf_root__configuration__protocols__isis__interface_entry(name=n.get_str("name"), ldp_synchronization=junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization.from_gdata(n.get_opt_container("ldp-synchronization")), level=junos_conf_root__configuration__protocols__isis__interface__level.from_gdata(n.get_opt_list("level")), lsp_interval=n.get_opt_value("lsp-interval"), point_to_point=n.get_opt_bool("point-to-point"), passive=junos_conf_root__configuration__protocols__isis__interface__passive.from_gdata(n.get_opt_container("passive")), family=junos_conf_root__configuration__protocols__isis__interface__family.from_gdata(n.get_opt_list("family")))
 
     @staticmethod
     mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__interface_entry:
-        return junos_conf_root__configuration__protocols__isis__interface_entry(name=yang.gdata.from_xml_str(n, "name"), ldp_synchronization=junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization.from_xml(yang.gdata.get_xml_opt_child(n, "ldp-synchronization")), level=junos_conf_root__configuration__protocols__isis__interface__level.from_xml(yang.gdata.get_xml_children(n, "level")), lsp_interval=yang.gdata.from_xml_opt_int(n, "lsp-interval"), point_to_point=yang.gdata.from_xml_opt_bool(n, "point-to-point"), passive=junos_conf_root__configuration__protocols__isis__interface__passive.from_xml(yang.gdata.get_xml_opt_child(n, "passive")), family=junos_conf_root__configuration__protocols__isis__interface__family.from_xml(yang.gdata.get_xml_children(n, "family")))
+        return junos_conf_root__configuration__protocols__isis__interface_entry(name=yang.gdata.from_xml_str(n, "name"), ldp_synchronization=junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization.from_xml(yang.gdata.get_xml_opt_child(n, "ldp-synchronization")), level=junos_conf_root__configuration__protocols__isis__interface__level.from_xml(yang.gdata.get_xml_children(n, "level")), lsp_interval=yang.gdata.from_xml_opt_value(n, "lsp-interval"), point_to_point=yang.gdata.from_xml_opt_bool(n, "point-to-point"), passive=junos_conf_root__configuration__protocols__isis__interface__passive.from_xml(yang.gdata.get_xml_opt_child(n, "passive")), family=junos_conf_root__configuration__protocols__isis__interface__family.from_xml(yang.gdata.get_xml_children(n, "family")))
 
 class junos_conf_root__configuration__protocols__isis__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface_entry]
@@ -7953,12 +7960,12 @@ class junos_conf_root__configuration__protocols__isis__interface(yang.adata.MNod
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment__hold_time(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(yang.adata.MNode):
-    hold_time: ?int
+    hold_time: ?value
 
-    mut def __init__(self, hold_time: ?int):
+    mut def __init__(self, hold_time: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.hold_time = hold_time
 
@@ -7966,19 +7973,19 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__ad
         children = {}
         _hold_time = self.hold_time
         if _hold_time is not None:
-            children['hold-time'] = yang.gdata.Leaf('uint32', _hold_time)
+            children['hold-time'] = yang.gdata.Leaf('union', _hold_time)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(hold_time=n.get_opt_int("hold-time"))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(hold_time=n.get_opt_value("hold-time"))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(hold_time=yang.gdata.from_xml_opt_int(n, "hold-time"))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(hold_time=yang.gdata.from_xml_opt_value(n, "hold-time"))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment()
 
 
@@ -8023,16 +8030,16 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__ud
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb__start_label(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb__index_range(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(yang.adata.MNode):
-    start_label: ?int
-    index_range: ?int
+    start_label: ?value
+    index_range: ?value
 
-    mut def __init__(self, start_label: ?int, index_range: ?int):
+    mut def __init__(self, start_label: ?value, index_range: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.start_label = start_label
         self.index_range = index_range
@@ -8042,40 +8049,40 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
         _start_label = self.start_label
         _index_range = self.index_range
         if _start_label is not None:
-            children['start-label'] = yang.gdata.Leaf('uint32', _start_label)
+            children['start-label'] = yang.gdata.Leaf('union', _start_label)
         if _index_range is not None:
-            children['index-range'] = yang.gdata.Leaf('uint32', _index_range)
+            children['index-range'] = yang.gdata.Leaf('union', _index_range)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(start_label=n.get_opt_int("start-label"), index_range=n.get_opt_int("index-range"))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(start_label=n.get_opt_value("start-label"), index_range=n.get_opt_value("index-range"))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(start_label=yang.gdata.from_xml_opt_int(n, "start-label"), index_range=yang.gdata.from_xml_opt_int(n, "index-range"))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(start_label=yang.gdata.from_xml_opt_value(n, "start-label"), index_range=yang.gdata.from_xml_opt_value(n, "index-range"))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__ipv4_index(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__ipv6_index(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__index_range(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(yang.adata.MNode):
-    ipv4_index: ?int
-    ipv6_index: ?int
-    index_range: ?int
+    ipv4_index: ?value
+    ipv6_index: ?value
+    index_range: ?value
 
-    mut def __init__(self, ipv4_index: ?int, ipv6_index: ?int, index_range: ?int):
+    mut def __init__(self, ipv4_index: ?value, ipv6_index: ?value, index_range: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.ipv4_index = ipv4_index
         self.ipv6_index = ipv6_index
@@ -8087,23 +8094,23 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__no
         _ipv6_index = self.ipv6_index
         _index_range = self.index_range
         if _ipv4_index is not None:
-            children['ipv4-index'] = yang.gdata.Leaf('uint32', _ipv4_index)
+            children['ipv4-index'] = yang.gdata.Leaf('union', _ipv4_index)
         if _ipv6_index is not None:
-            children['ipv6-index'] = yang.gdata.Leaf('uint32', _ipv6_index)
+            children['ipv6-index'] = yang.gdata.Leaf('union', _ipv6_index)
         if _index_range is not None:
-            children['index-range'] = yang.gdata.Leaf('uint32', _index_range)
+            children['index-range'] = yang.gdata.Leaf('union', _index_range)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(ipv4_index=n.get_opt_int("ipv4-index"), ipv6_index=n.get_opt_int("ipv6-index"), index_range=n.get_opt_int("index-range"))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(ipv4_index=n.get_opt_value("ipv4-index"), ipv6_index=n.get_opt_value("ipv6-index"), index_range=n.get_opt_value("index-range"))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(ipv4_index=yang.gdata.from_xml_opt_int(n, "ipv4-index"), ipv6_index=yang.gdata.from_xml_opt_int(n, "ipv6-index"), index_range=yang.gdata.from_xml_opt_int(n, "index-range"))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(ipv4_index=yang.gdata.from_xml_opt_value(n, "ipv4-index"), ipv6_index=yang.gdata.from_xml_opt_value(n, "ipv6-index"), index_range=yang.gdata.from_xml_opt_value(n, "index-range"))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment()
 
 
@@ -8561,12 +8568,12 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe__interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(yang.adata.MNode):
-    interval: ?int
+    interval: ?value
 
-    mut def __init__(self, interval: ?int):
+    mut def __init__(self, interval: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.interval = interval
 
@@ -8574,19 +8581,19 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
         children = {}
         _interval = self.interval
         if _interval is not None:
-            children['interval'] = yang.gdata.Leaf('uint32', _interval)
+            children['interval'] = yang.gdata.Leaf('union', _interval)
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(interval=n.get_opt_int("interval"))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(interval=n.get_opt_value("interval"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(interval=yang.gdata.from_xml_opt_int(n, "interval"))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(interval=yang.gdata.from_xml_opt_value(n, "interval"))
         return None
 
 
@@ -8735,7 +8742,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing(yan
     udp_tunneling: junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling
     srgb: junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb
     node_segment: junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment
-    flex_algorithm: list[int]
+    flex_algorithm: list[value]
     use_flex_algorithm_metric_always: ?bool
     strict_asla_based_flex_algorithm: ?bool
     new_capability_subtlv: ?bool
@@ -8748,7 +8755,7 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing(yan
     sensor_based_stats: junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats
     traffic_statistics: junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics
 
-    mut def __init__(self, adjacency_segment: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment=None, udp_tunneling: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling=None, srgb: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb=None, node_segment: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment=None, flex_algorithm: ?list[int]=None, use_flex_algorithm_metric_always: ?bool, strict_asla_based_flex_algorithm: ?bool, new_capability_subtlv: ?bool, explicit_null: ?bool, mapping_server: ?str, no_strict_spf: ?bool, no_binding_sid_leaking: ?bool, ldp_stitching: ?bool, srv6: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6=None, sensor_based_stats: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats=None, traffic_statistics: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics=None):
+    mut def __init__(self, adjacency_segment: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment=None, udp_tunneling: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling=None, srgb: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb=None, node_segment: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment=None, flex_algorithm: ?list[value]=None, use_flex_algorithm_metric_always: ?bool, strict_asla_based_flex_algorithm: ?bool, new_capability_subtlv: ?bool, explicit_null: ?bool, mapping_server: ?str, no_strict_spf: ?bool, no_binding_sid_leaking: ?bool, ldp_stitching: ?bool, srv6: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6=None, sensor_based_stats: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats=None, traffic_statistics: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics=None):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         if adjacency_segment is not None:
             self.adjacency_segment = adjacency_segment
@@ -8867,19 +8874,19 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing(yan
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing(adjacency_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment.from_gdata(n.get_opt_container("adjacency-segment")), udp_tunneling=junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling.from_gdata(n.get_opt_container("udp-tunneling")), srgb=junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb.from_gdata(n.get_opt_container("srgb")), node_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment.from_gdata(n.get_opt_container("node-segment")), flex_algorithm=n.get_opt_ints("flex-algorithm"), use_flex_algorithm_metric_always=n.get_opt_bool("use-flex-algorithm-metric-always"), strict_asla_based_flex_algorithm=n.get_opt_bool("strict-asla-based-flex-algorithm"), new_capability_subtlv=n.get_opt_bool("new-capability-subtlv"), explicit_null=n.get_opt_bool("explicit-null"), mapping_server=n.get_opt_str("mapping-server"), no_strict_spf=n.get_opt_bool("no-strict-spf"), no_binding_sid_leaking=n.get_opt_bool("no-binding-sid-leaking"), ldp_stitching=n.get_opt_bool("ldp-stitching"), srv6=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6.from_gdata(n.get_opt_container("srv6")), sensor_based_stats=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats.from_gdata(n.get_opt_container("sensor-based-stats")), traffic_statistics=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics.from_gdata(n.get_opt_container("traffic-statistics")))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing(adjacency_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment.from_gdata(n.get_opt_container("adjacency-segment")), udp_tunneling=junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling.from_gdata(n.get_opt_container("udp-tunneling")), srgb=junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb.from_gdata(n.get_opt_container("srgb")), node_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment.from_gdata(n.get_opt_container("node-segment")), flex_algorithm=n.get_opt_values("flex-algorithm"), use_flex_algorithm_metric_always=n.get_opt_bool("use-flex-algorithm-metric-always"), strict_asla_based_flex_algorithm=n.get_opt_bool("strict-asla-based-flex-algorithm"), new_capability_subtlv=n.get_opt_bool("new-capability-subtlv"), explicit_null=n.get_opt_bool("explicit-null"), mapping_server=n.get_opt_str("mapping-server"), no_strict_spf=n.get_opt_bool("no-strict-spf"), no_binding_sid_leaking=n.get_opt_bool("no-binding-sid-leaking"), ldp_stitching=n.get_opt_bool("ldp-stitching"), srv6=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6.from_gdata(n.get_opt_container("srv6")), sensor_based_stats=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats.from_gdata(n.get_opt_container("sensor-based-stats")), traffic_statistics=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics.from_gdata(n.get_opt_container("traffic-statistics")))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing(adjacency_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment.from_xml(yang.gdata.get_xml_opt_child(n, "adjacency-segment")), udp_tunneling=junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling.from_xml(yang.gdata.get_xml_opt_child(n, "udp-tunneling")), srgb=junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb.from_xml(yang.gdata.get_xml_opt_child(n, "srgb")), node_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment.from_xml(yang.gdata.get_xml_opt_child(n, "node-segment")), flex_algorithm=yang.gdata.from_xml_opt_ints(n, "flex-algorithm"), use_flex_algorithm_metric_always=yang.gdata.from_xml_opt_bool(n, "use-flex-algorithm-metric-always"), strict_asla_based_flex_algorithm=yang.gdata.from_xml_opt_bool(n, "strict-asla-based-flex-algorithm"), new_capability_subtlv=yang.gdata.from_xml_opt_bool(n, "new-capability-subtlv"), explicit_null=yang.gdata.from_xml_opt_bool(n, "explicit-null"), mapping_server=yang.gdata.from_xml_opt_str(n, "mapping-server"), no_strict_spf=yang.gdata.from_xml_opt_bool(n, "no-strict-spf"), no_binding_sid_leaking=yang.gdata.from_xml_opt_bool(n, "no-binding-sid-leaking"), ldp_stitching=yang.gdata.from_xml_opt_bool(n, "ldp-stitching"), srv6=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6.from_xml(yang.gdata.get_xml_opt_child(n, "srv6")), sensor_based_stats=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats.from_xml(yang.gdata.get_xml_opt_child(n, "sensor-based-stats")), traffic_statistics=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics.from_xml(yang.gdata.get_xml_opt_child(n, "traffic-statistics")))
+            return junos_conf_root__configuration__protocols__isis__source_packet_routing(adjacency_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment.from_xml(yang.gdata.get_xml_opt_child(n, "adjacency-segment")), udp_tunneling=junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling.from_xml(yang.gdata.get_xml_opt_child(n, "udp-tunneling")), srgb=junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb.from_xml(yang.gdata.get_xml_opt_child(n, "srgb")), node_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment.from_xml(yang.gdata.get_xml_opt_child(n, "node-segment")), flex_algorithm=yang.gdata.from_xml_opt_values(n, "flex-algorithm"), use_flex_algorithm_metric_always=yang.gdata.from_xml_opt_bool(n, "use-flex-algorithm-metric-always"), strict_asla_based_flex_algorithm=yang.gdata.from_xml_opt_bool(n, "strict-asla-based-flex-algorithm"), new_capability_subtlv=yang.gdata.from_xml_opt_bool(n, "new-capability-subtlv"), explicit_null=yang.gdata.from_xml_opt_bool(n, "explicit-null"), mapping_server=yang.gdata.from_xml_opt_str(n, "mapping-server"), no_strict_spf=yang.gdata.from_xml_opt_bool(n, "no-strict-spf"), no_binding_sid_leaking=yang.gdata.from_xml_opt_bool(n, "no-binding-sid-leaking"), ldp_stitching=yang.gdata.from_xml_opt_bool(n, "ldp-stitching"), srv6=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6.from_xml(yang.gdata.get_xml_opt_child(n, "srv6")), sensor_based_stats=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats.from_xml(yang.gdata.get_xml_opt_child(n, "sensor-based-stats")), traffic_statistics=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics.from_xml(yang.gdata.get_xml_opt_child(n, "traffic-statistics")))
         return None
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__level__name(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__level__disable(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -8903,7 +8910,7 @@ mut def from_json_junos_conf_root__configuration__protocols__isis__level__wide_m
     return yang.gdata.Leaf("empty", val)
 
 class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MNode):
-    name: int
+    name: value
     disable: ?bool
     authentication_key: ?str
     authentication_type: ?str
@@ -8912,7 +8919,7 @@ class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MN
     no_psnp_authentication: ?bool
     wide_metrics_only: ?bool
 
-    mut def __init__(self, name: int, disable: ?bool, authentication_key: ?str, authentication_type: ?str, no_hello_authentication: ?bool, no_csnp_authentication: ?bool, no_psnp_authentication: ?bool, wide_metrics_only: ?bool):
+    mut def __init__(self, name: value, disable: ?bool, authentication_key: ?str, authentication_type: ?str, no_hello_authentication: ?bool, no_csnp_authentication: ?bool, no_psnp_authentication: ?bool, wide_metrics_only: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.name = name
         self.disable = disable
@@ -8934,7 +8941,7 @@ class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MN
         _no_psnp_authentication = self.no_psnp_authentication
         _wide_metrics_only = self.wide_metrics_only
         if _name is not None:
-            children['name'] = yang.gdata.Leaf('uint32', _name)
+            children['name'] = yang.gdata.Leaf('union', _name)
         if _disable is not None:
             children['disable'] = yang.gdata.Leaf('empty', _disable)
         if _authentication_key is not None:
@@ -8953,11 +8960,11 @@ class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MN
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__level_entry:
-        return junos_conf_root__configuration__protocols__isis__level_entry(name=n.get_int("name"), disable=n.get_opt_bool("disable"), authentication_key=n.get_opt_str("authentication-key"), authentication_type=n.get_opt_str("authentication-type"), no_hello_authentication=n.get_opt_bool("no-hello-authentication"), no_csnp_authentication=n.get_opt_bool("no-csnp-authentication"), no_psnp_authentication=n.get_opt_bool("no-psnp-authentication"), wide_metrics_only=n.get_opt_bool("wide-metrics-only"))
+        return junos_conf_root__configuration__protocols__isis__level_entry(name=n.get_value("name"), disable=n.get_opt_bool("disable"), authentication_key=n.get_opt_str("authentication-key"), authentication_type=n.get_opt_str("authentication-type"), no_hello_authentication=n.get_opt_bool("no-hello-authentication"), no_csnp_authentication=n.get_opt_bool("no-csnp-authentication"), no_psnp_authentication=n.get_opt_bool("no-psnp-authentication"), wide_metrics_only=n.get_opt_bool("wide-metrics-only"))
 
     @staticmethod
     mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__level_entry:
-        return junos_conf_root__configuration__protocols__isis__level_entry(name=yang.gdata.from_xml_int(n, "name"), disable=yang.gdata.from_xml_opt_bool(n, "disable"), authentication_key=yang.gdata.from_xml_opt_str(n, "authentication-key"), authentication_type=yang.gdata.from_xml_opt_str(n, "authentication-type"), no_hello_authentication=yang.gdata.from_xml_opt_bool(n, "no-hello-authentication"), no_csnp_authentication=yang.gdata.from_xml_opt_bool(n, "no-csnp-authentication"), no_psnp_authentication=yang.gdata.from_xml_opt_bool(n, "no-psnp-authentication"), wide_metrics_only=yang.gdata.from_xml_opt_bool(n, "wide-metrics-only"))
+        return junos_conf_root__configuration__protocols__isis__level_entry(name=yang.gdata.from_xml_value(n, "name"), disable=yang.gdata.from_xml_opt_bool(n, "disable"), authentication_key=yang.gdata.from_xml_opt_str(n, "authentication-key"), authentication_type=yang.gdata.from_xml_opt_str(n, "authentication-type"), no_hello_authentication=yang.gdata.from_xml_opt_bool(n, "no-hello-authentication"), no_csnp_authentication=yang.gdata.from_xml_opt_bool(n, "no-csnp-authentication"), no_psnp_authentication=yang.gdata.from_xml_opt_bool(n, "no-psnp-authentication"), wide_metrics_only=yang.gdata.from_xml_opt_bool(n, "wide-metrics-only"))
 
 class junos_conf_root__configuration__protocols__isis__level(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__level_entry]
@@ -8969,9 +8976,16 @@ class junos_conf_root__configuration__protocols__isis__level(yang.adata.MNode):
     mut def create(self, name):
         for e in self.elements:
             match = True
-            if e.name != name:
-                match = False
-                continue
+            e_name = e.name
+            if isinstance(e_name, str) and isinstance(name, str):
+                if e_name != name:
+                    match = False
+                    continue
+            e_name = e.name
+            if isinstance(e_name, int) and isinstance(name, int):
+                if e_name != name:
+                    match = False
+                    continue
             if match:
                 return e
 
@@ -9005,15 +9019,15 @@ class junos_conf_root__configuration__protocols__isis__level(yang.adata.MNode):
 
 
 mut def from_json_junos_conf_root__configuration__protocols__isis__lsp_lifetime(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
     interface: junos_conf_root__configuration__protocols__isis__interface
     source_packet_routing: ?junos_conf_root__configuration__protocols__isis__source_packet_routing
     level: junos_conf_root__configuration__protocols__isis__level
-    lsp_lifetime: ?int
+    lsp_lifetime: ?value
 
-    mut def __init__(self, interface: list[junos_conf_root__configuration__protocols__isis__interface_entry]=[], source_packet_routing: ?junos_conf_root__configuration__protocols__isis__source_packet_routing=None, level: list[junos_conf_root__configuration__protocols__isis__level_entry]=[], lsp_lifetime: ?int):
+    mut def __init__(self, interface: list[junos_conf_root__configuration__protocols__isis__interface_entry]=[], source_packet_routing: ?junos_conf_root__configuration__protocols__isis__source_packet_routing=None, level: list[junos_conf_root__configuration__protocols__isis__level_entry]=[], lsp_lifetime: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.interface = junos_conf_root__configuration__protocols__isis__interface(elements=interface)
         self.interface._parent = self
@@ -9043,19 +9057,19 @@ class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
         if _level is not None:
             children['level'] = _level.to_gdata()
         if _lsp_lifetime is not None:
-            children['lsp-lifetime'] = yang.gdata.Leaf('uint32', _lsp_lifetime)
+            children['lsp-lifetime'] = yang.gdata.Leaf('union', _lsp_lifetime)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis(interface=junos_conf_root__configuration__protocols__isis__interface.from_gdata(n.get_opt_list("interface")), source_packet_routing=junos_conf_root__configuration__protocols__isis__source_packet_routing.from_gdata(n.get_opt_container("source-packet-routing")), level=junos_conf_root__configuration__protocols__isis__level.from_gdata(n.get_opt_list("level")), lsp_lifetime=n.get_opt_int("lsp-lifetime"))
+            return junos_conf_root__configuration__protocols__isis(interface=junos_conf_root__configuration__protocols__isis__interface.from_gdata(n.get_opt_list("interface")), source_packet_routing=junos_conf_root__configuration__protocols__isis__source_packet_routing.from_gdata(n.get_opt_container("source-packet-routing")), level=junos_conf_root__configuration__protocols__isis__level.from_gdata(n.get_opt_list("level")), lsp_lifetime=n.get_opt_value("lsp-lifetime"))
         return junos_conf_root__configuration__protocols__isis()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis:
         if n != None:
-            return junos_conf_root__configuration__protocols__isis(interface=junos_conf_root__configuration__protocols__isis__interface.from_xml(yang.gdata.get_xml_children(n, "interface")), source_packet_routing=junos_conf_root__configuration__protocols__isis__source_packet_routing.from_xml(yang.gdata.get_xml_opt_child(n, "source-packet-routing")), level=junos_conf_root__configuration__protocols__isis__level.from_xml(yang.gdata.get_xml_children(n, "level")), lsp_lifetime=yang.gdata.from_xml_opt_int(n, "lsp-lifetime"))
+            return junos_conf_root__configuration__protocols__isis(interface=junos_conf_root__configuration__protocols__isis__interface.from_xml(yang.gdata.get_xml_children(n, "interface")), source_packet_routing=junos_conf_root__configuration__protocols__isis__source_packet_routing.from_xml(yang.gdata.get_xml_opt_child(n, "source-packet-routing")), level=junos_conf_root__configuration__protocols__isis__level.from_xml(yang.gdata.get_xml_children(n, "level")), lsp_lifetime=yang.gdata.from_xml_opt_value(n, "lsp-lifetime"))
         return junos_conf_root__configuration__protocols__isis()
 
 
@@ -9070,7 +9084,7 @@ mut def from_json_junos_conf_root__configuration__protocols__ldp__traffic_statis
     return yang.gdata.Leaf("string", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__files(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__no_stamp(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -9085,12 +9099,12 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(y
     filename: ?str
     replace: ?bool
     size: ?str
-    files: int
+    files: value
     no_stamp: ?bool
     world_readable: ?bool
     no_world_readable: ?bool
 
-    mut def __init__(self, filename: ?str, replace: ?bool, size: ?str, files: ?int=None, no_stamp: ?bool, world_readable: ?bool, no_world_readable: ?bool):
+    mut def __init__(self, filename: ?str, replace: ?bool, size: ?str, files: ?value=None, no_stamp: ?bool, world_readable: ?bool, no_world_readable: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.filename = filename
         self.replace = replace
@@ -9119,7 +9133,7 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(y
         if _size is not None:
             children['size'] = yang.gdata.Leaf('string', _size)
         if _files is not None:
-            children['files'] = yang.gdata.Leaf('uint32', _files)
+            children['files'] = yang.gdata.Leaf('union', _files)
         if _no_stamp is not None:
             children['no-stamp'] = yang.gdata.Leaf('empty', _no_stamp)
         if _world_readable is not None:
@@ -9131,19 +9145,19 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(y
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__traffic_statistics__file:
         if n != None:
-            return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(filename=n.get_opt_str("filename"), replace=n.get_opt_bool("replace"), size=n.get_opt_str("size"), files=n.get_opt_int("files"), no_stamp=n.get_opt_bool("no-stamp"), world_readable=n.get_opt_bool("world-readable"), no_world_readable=n.get_opt_bool("no-world-readable"))
+            return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(filename=n.get_opt_str("filename"), replace=n.get_opt_bool("replace"), size=n.get_opt_str("size"), files=n.get_opt_value("files"), no_stamp=n.get_opt_bool("no-stamp"), world_readable=n.get_opt_bool("world-readable"), no_world_readable=n.get_opt_bool("no-world-readable"))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__ldp__traffic_statistics__file:
         if n != None:
-            return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(filename=yang.gdata.from_xml_opt_str(n, "filename"), replace=yang.gdata.from_xml_opt_bool(n, "replace"), size=yang.gdata.from_xml_opt_str(n, "size"), files=yang.gdata.from_xml_opt_int(n, "files"), no_stamp=yang.gdata.from_xml_opt_bool(n, "no-stamp"), world_readable=yang.gdata.from_xml_opt_bool(n, "world-readable"), no_world_readable=yang.gdata.from_xml_opt_bool(n, "no-world-readable"))
+            return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(filename=yang.gdata.from_xml_opt_str(n, "filename"), replace=yang.gdata.from_xml_opt_bool(n, "replace"), size=yang.gdata.from_xml_opt_str(n, "size"), files=yang.gdata.from_xml_opt_value(n, "files"), no_stamp=yang.gdata.from_xml_opt_bool(n, "no-stamp"), world_readable=yang.gdata.from_xml_opt_bool(n, "world-readable"), no_world_readable=yang.gdata.from_xml_opt_bool(n, "no-world-readable"))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__traffic_statistics__interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("int32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__traffic_statistics__sensor_based_stats(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -9153,11 +9167,11 @@ mut def from_json_junos_conf_root__configuration__protocols__ldp__traffic_statis
 
 class junos_conf_root__configuration__protocols__ldp__traffic_statistics(yang.adata.MNode):
     file: junos_conf_root__configuration__protocols__ldp__traffic_statistics__file
-    interval: ?int
+    interval: ?value
     sensor_based_stats: ?bool
     no_penultimate_hop: ?bool
 
-    mut def __init__(self, file: ?junos_conf_root__configuration__protocols__ldp__traffic_statistics__file=None, interval: ?int, sensor_based_stats: ?bool, no_penultimate_hop: ?bool):
+    mut def __init__(self, file: ?junos_conf_root__configuration__protocols__ldp__traffic_statistics__file=None, interval: ?value, sensor_based_stats: ?bool, no_penultimate_hop: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         if file is not None:
             self.file = file
@@ -9179,7 +9193,7 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics(yang.ad
         if _file is not None:
             children['file'] = _file.to_gdata()
         if _interval is not None:
-            children['interval'] = yang.gdata.Leaf('int32', _interval)
+            children['interval'] = yang.gdata.Leaf('union', _interval)
         if _sensor_based_stats is not None:
             children['sensor-based-stats'] = yang.gdata.Leaf('empty', _sensor_based_stats)
         if _no_penultimate_hop is not None:
@@ -9189,19 +9203,19 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics(yang.ad
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__traffic_statistics:
         if n != None:
-            return junos_conf_root__configuration__protocols__ldp__traffic_statistics(file=junos_conf_root__configuration__protocols__ldp__traffic_statistics__file.from_gdata(n.get_opt_container("file")), interval=n.get_opt_int("interval"), sensor_based_stats=n.get_opt_bool("sensor-based-stats"), no_penultimate_hop=n.get_opt_bool("no-penultimate-hop"))
+            return junos_conf_root__configuration__protocols__ldp__traffic_statistics(file=junos_conf_root__configuration__protocols__ldp__traffic_statistics__file.from_gdata(n.get_opt_container("file")), interval=n.get_opt_value("interval"), sensor_based_stats=n.get_opt_bool("sensor-based-stats"), no_penultimate_hop=n.get_opt_bool("no-penultimate-hop"))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__ldp__traffic_statistics:
         if n != None:
-            return junos_conf_root__configuration__protocols__ldp__traffic_statistics(file=junos_conf_root__configuration__protocols__ldp__traffic_statistics__file.from_xml(yang.gdata.get_xml_opt_child(n, "file")), interval=yang.gdata.from_xml_opt_int(n, "interval"), sensor_based_stats=yang.gdata.from_xml_opt_bool(n, "sensor-based-stats"), no_penultimate_hop=yang.gdata.from_xml_opt_bool(n, "no-penultimate-hop"))
+            return junos_conf_root__configuration__protocols__ldp__traffic_statistics(file=junos_conf_root__configuration__protocols__ldp__traffic_statistics__file.from_xml(yang.gdata.get_xml_opt_child(n, "file")), interval=yang.gdata.from_xml_opt_value(n, "interval"), sensor_based_stats=yang.gdata.from_xml_opt_bool(n, "sensor-based-stats"), no_penultimate_hop=yang.gdata.from_xml_opt_bool(n, "no-penultimate-hop"))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics()
 
 
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__preference(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__transport_address__router_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -9251,16 +9265,16 @@ class junos_conf_root__configuration__protocols__ldp__transport_address(yang.ada
 
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__interface__name(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("string", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__interface__disable(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__interface__hello_interval(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__interface__hold_time(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__ldp__interface__link_protection__disable(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -9357,14 +9371,14 @@ mut def from_json_junos_conf_root__configuration__protocols__ldp__interface__no_
 class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata.MNode):
     name: str
     disable: ?bool
-    hello_interval: ?int
-    hold_time: ?int
+    hello_interval: ?value
+    hold_time: ?value
     link_protection: ?junos_conf_root__configuration__protocols__ldp__interface__link_protection
     transport_address: junos_conf_root__configuration__protocols__ldp__interface__transport_address
     allow_subnet_mismatch: ?bool
     no_allow_subnet_mismatch: ?bool
 
-    mut def __init__(self, name: str, disable: ?bool, hello_interval: ?int, hold_time: ?int, link_protection: ?junos_conf_root__configuration__protocols__ldp__interface__link_protection=None, transport_address: ?junos_conf_root__configuration__protocols__ldp__interface__transport_address=None, allow_subnet_mismatch: ?bool, no_allow_subnet_mismatch: ?bool):
+    mut def __init__(self, name: str, disable: ?bool, hello_interval: ?value, hold_time: ?value, link_protection: ?junos_conf_root__configuration__protocols__ldp__interface__link_protection=None, transport_address: ?junos_conf_root__configuration__protocols__ldp__interface__transport_address=None, allow_subnet_mismatch: ?bool, no_allow_subnet_mismatch: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.name = name
         self.disable = disable
@@ -9400,13 +9414,13 @@ class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata
         _allow_subnet_mismatch = self.allow_subnet_mismatch
         _no_allow_subnet_mismatch = self.no_allow_subnet_mismatch
         if _name is not None:
-            children['name'] = yang.gdata.Leaf('string', _name)
+            children['name'] = yang.gdata.Leaf('union', _name)
         if _disable is not None:
             children['disable'] = yang.gdata.Leaf('empty', _disable)
         if _hello_interval is not None:
-            children['hello-interval'] = yang.gdata.Leaf('uint32', _hello_interval)
+            children['hello-interval'] = yang.gdata.Leaf('union', _hello_interval)
         if _hold_time is not None:
-            children['hold-time'] = yang.gdata.Leaf('uint32', _hold_time)
+            children['hold-time'] = yang.gdata.Leaf('union', _hold_time)
         if _link_protection is not None:
             children['link-protection'] = _link_protection.to_gdata()
         if _transport_address is not None:
@@ -9419,11 +9433,11 @@ class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__interface_entry:
-        return junos_conf_root__configuration__protocols__ldp__interface_entry(name=n.get_str("name"), disable=n.get_opt_bool("disable"), hello_interval=n.get_opt_int("hello-interval"), hold_time=n.get_opt_int("hold-time"), link_protection=junos_conf_root__configuration__protocols__ldp__interface__link_protection.from_gdata(n.get_opt_container("link-protection")), transport_address=junos_conf_root__configuration__protocols__ldp__interface__transport_address.from_gdata(n.get_opt_container("transport-address")), allow_subnet_mismatch=n.get_opt_bool("allow-subnet-mismatch"), no_allow_subnet_mismatch=n.get_opt_bool("no-allow-subnet-mismatch"))
+        return junos_conf_root__configuration__protocols__ldp__interface_entry(name=n.get_str("name"), disable=n.get_opt_bool("disable"), hello_interval=n.get_opt_value("hello-interval"), hold_time=n.get_opt_value("hold-time"), link_protection=junos_conf_root__configuration__protocols__ldp__interface__link_protection.from_gdata(n.get_opt_container("link-protection")), transport_address=junos_conf_root__configuration__protocols__ldp__interface__transport_address.from_gdata(n.get_opt_container("transport-address")), allow_subnet_mismatch=n.get_opt_bool("allow-subnet-mismatch"), no_allow_subnet_mismatch=n.get_opt_bool("no-allow-subnet-mismatch"))
 
     @staticmethod
     mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__ldp__interface_entry:
-        return junos_conf_root__configuration__protocols__ldp__interface_entry(name=yang.gdata.from_xml_str(n, "name"), disable=yang.gdata.from_xml_opt_bool(n, "disable"), hello_interval=yang.gdata.from_xml_opt_int(n, "hello-interval"), hold_time=yang.gdata.from_xml_opt_int(n, "hold-time"), link_protection=junos_conf_root__configuration__protocols__ldp__interface__link_protection.from_xml(yang.gdata.get_xml_opt_child(n, "link-protection")), transport_address=junos_conf_root__configuration__protocols__ldp__interface__transport_address.from_xml(yang.gdata.get_xml_opt_child(n, "transport-address")), allow_subnet_mismatch=yang.gdata.from_xml_opt_bool(n, "allow-subnet-mismatch"), no_allow_subnet_mismatch=yang.gdata.from_xml_opt_bool(n, "no-allow-subnet-mismatch"))
+        return junos_conf_root__configuration__protocols__ldp__interface_entry(name=yang.gdata.from_xml_str(n, "name"), disable=yang.gdata.from_xml_opt_bool(n, "disable"), hello_interval=yang.gdata.from_xml_opt_value(n, "hello-interval"), hold_time=yang.gdata.from_xml_opt_value(n, "hold-time"), link_protection=junos_conf_root__configuration__protocols__ldp__interface__link_protection.from_xml(yang.gdata.get_xml_opt_child(n, "link-protection")), transport_address=junos_conf_root__configuration__protocols__ldp__interface__transport_address.from_xml(yang.gdata.get_xml_opt_child(n, "transport-address")), allow_subnet_mismatch=yang.gdata.from_xml_opt_bool(n, "allow-subnet-mismatch"), no_allow_subnet_mismatch=yang.gdata.from_xml_opt_bool(n, "no-allow-subnet-mismatch"))
 
 class junos_conf_root__configuration__protocols__ldp__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__ldp__interface_entry]
@@ -9472,11 +9486,11 @@ class junos_conf_root__configuration__protocols__ldp__interface(yang.adata.MNode
 
 class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
     traffic_statistics: junos_conf_root__configuration__protocols__ldp__traffic_statistics
-    preference: ?int
+    preference: ?value
     transport_address: junos_conf_root__configuration__protocols__ldp__transport_address
     interface: junos_conf_root__configuration__protocols__ldp__interface
 
-    mut def __init__(self, traffic_statistics: ?junos_conf_root__configuration__protocols__ldp__traffic_statistics=None, preference: ?int, transport_address: ?junos_conf_root__configuration__protocols__ldp__transport_address=None, interface: list[junos_conf_root__configuration__protocols__ldp__interface_entry]=[]):
+    mut def __init__(self, traffic_statistics: ?junos_conf_root__configuration__protocols__ldp__traffic_statistics=None, preference: ?value, transport_address: ?junos_conf_root__configuration__protocols__ldp__transport_address=None, interface: list[junos_conf_root__configuration__protocols__ldp__interface_entry]=[]):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         if traffic_statistics is not None:
             self.traffic_statistics = traffic_statistics
@@ -9505,7 +9519,7 @@ class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
         if _traffic_statistics is not None:
             children['traffic-statistics'] = _traffic_statistics.to_gdata()
         if _preference is not None:
-            children['preference'] = yang.gdata.Leaf('uint32', _preference)
+            children['preference'] = yang.gdata.Leaf('union', _preference)
         if _transport_address is not None:
             children['transport-address'] = _transport_address.to_gdata()
         if _interface is not None:
@@ -9515,13 +9529,13 @@ class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp:
         if n != None:
-            return junos_conf_root__configuration__protocols__ldp(traffic_statistics=junos_conf_root__configuration__protocols__ldp__traffic_statistics.from_gdata(n.get_opt_container("traffic-statistics")), preference=n.get_opt_int("preference"), transport_address=junos_conf_root__configuration__protocols__ldp__transport_address.from_gdata(n.get_opt_container("transport-address")), interface=junos_conf_root__configuration__protocols__ldp__interface.from_gdata(n.get_opt_list("interface")))
+            return junos_conf_root__configuration__protocols__ldp(traffic_statistics=junos_conf_root__configuration__protocols__ldp__traffic_statistics.from_gdata(n.get_opt_container("traffic-statistics")), preference=n.get_opt_value("preference"), transport_address=junos_conf_root__configuration__protocols__ldp__transport_address.from_gdata(n.get_opt_container("transport-address")), interface=junos_conf_root__configuration__protocols__ldp__interface.from_gdata(n.get_opt_list("interface")))
         return junos_conf_root__configuration__protocols__ldp()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__ldp:
         if n != None:
-            return junos_conf_root__configuration__protocols__ldp(traffic_statistics=junos_conf_root__configuration__protocols__ldp__traffic_statistics.from_xml(yang.gdata.get_xml_opt_child(n, "traffic-statistics")), preference=yang.gdata.from_xml_opt_int(n, "preference"), transport_address=junos_conf_root__configuration__protocols__ldp__transport_address.from_xml(yang.gdata.get_xml_opt_child(n, "transport-address")), interface=junos_conf_root__configuration__protocols__ldp__interface.from_xml(yang.gdata.get_xml_children(n, "interface")))
+            return junos_conf_root__configuration__protocols__ldp(traffic_statistics=junos_conf_root__configuration__protocols__ldp__traffic_statistics.from_xml(yang.gdata.get_xml_opt_child(n, "traffic-statistics")), preference=yang.gdata.from_xml_opt_value(n, "preference"), transport_address=junos_conf_root__configuration__protocols__ldp__transport_address.from_xml(yang.gdata.get_xml_opt_child(n, "transport-address")), interface=junos_conf_root__configuration__protocols__ldp__interface.from_xml(yang.gdata.get_xml_children(n, "interface")))
         return junos_conf_root__configuration__protocols__ldp()
 
 
@@ -9533,7 +9547,7 @@ mut def from_json_junos_conf_root__configuration__protocols__mpls__ipv6_tunnelin
     return yang.gdata.Leaf("empty", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__mpls__interface__name(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("string", val)
+    return yang.gdata.Leaf("union", val)
 
 mut def from_json_junos_conf_root__configuration__protocols__mpls__interface__disable(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("empty", val)
@@ -9554,12 +9568,12 @@ mut def from_json_junos_conf_root__configuration__protocols__mpls__interface__ad
     return yang.gdata.LeafList(val)
 
 mut def from_json_junos_conf_root__configuration__protocols__mpls__interface__static__protection_revert_time(val: value) -> yang.gdata.Leaf:
-    return yang.gdata.Leaf("uint32", val)
+    return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__mpls__interface__static(yang.adata.MNode):
-    protection_revert_time: ?int
+    protection_revert_time: ?value
 
-    mut def __init__(self, protection_revert_time: ?int):
+    mut def __init__(self, protection_revert_time: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.protection_revert_time = protection_revert_time
 
@@ -9567,19 +9581,19 @@ class junos_conf_root__configuration__protocols__mpls__interface__static(yang.ad
         children = {}
         _protection_revert_time = self.protection_revert_time
         if _protection_revert_time is not None:
-            children['protection-revert-time'] = yang.gdata.Leaf('uint32', _protection_revert_time)
+            children['protection-revert-time'] = yang.gdata.Leaf('union', _protection_revert_time)
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> junos_conf_root__configuration__protocols__mpls__interface__static:
         if n != None:
-            return junos_conf_root__configuration__protocols__mpls__interface__static(protection_revert_time=n.get_opt_int("protection-revert-time"))
+            return junos_conf_root__configuration__protocols__mpls__interface__static(protection_revert_time=n.get_opt_value("protection-revert-time"))
         return junos_conf_root__configuration__protocols__mpls__interface__static()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__mpls__interface__static:
         if n != None:
-            return junos_conf_root__configuration__protocols__mpls__interface__static(protection_revert_time=yang.gdata.from_xml_opt_int(n, "protection-revert-time"))
+            return junos_conf_root__configuration__protocols__mpls__interface__static(protection_revert_time=yang.gdata.from_xml_opt_value(n, "protection-revert-time"))
         return junos_conf_root__configuration__protocols__mpls__interface__static()
 
 
@@ -9628,7 +9642,7 @@ class junos_conf_root__configuration__protocols__mpls__interface_entry(yang.adat
         _switch_away_lsps = self.switch_away_lsps
         _static = self.static
         if _name is not None:
-            children['name'] = yang.gdata.Leaf('string', _name)
+            children['name'] = yang.gdata.Leaf('union', _name)
         if _disable is not None:
             children['disable'] = yang.gdata.Leaf('empty', _disable)
         children['srlg'] = yang.gdata.LeafList(self.srlg)


### PR DESCRIPTION
- https://github.com/orchestron-orchestrator/acton-yang/pull/88
- https://github.com/orchestron-orchestrator/acton-yang/pull/89

We no longer need to rewrite Junos pattern unions, where the type is a union of a string pattern and some other non-string type with a default value!