### PR TITLE
Uese the location street address in l3pvn-svc

### DIFF
--- a/src/respnet/cfs.act
+++ b/src/respnet/cfs.act
@@ -5,6 +5,14 @@ from respnet.conf import IGBP_AUTHENTICATION_KEY
 import respnet.layers.base_0 as base
 import respnet.layers.y_1_loose
 
+#  City to router interface mapping
+CITY_ROUTER_INTERFACE_MAP = {
+    "amsterdam": ("AMS-CORE-1", "GigabitEthernet0/0/0/2.100"),
+    "frankfurt": ("FRA-CORE-1", "GigabitEthernet0/0/0/3.100"),
+    "stockholm": ("STO-CORE-1", "eth4.100"),
+    "ljubljana": ("LJU-CORE-1", "eth3.100"),
+}
+
 class Router(base.Router):
     def transform(self, i):
         o = base.o_root()
@@ -50,13 +58,14 @@ class L3VpnSite(base.L3VpnSite):
         o = base.o_root()
         for sna in i.site_network_accesses.site_network_access.elements:
             vpn_id = sna.vpn_attachment.vpn_id
-            bearer_ref = sna.bearer.bearer_reference
-            if bearer_ref != None:
-                parts = bearer_ref.split(",")
-                device = parts[0]
-                interface = parts[1]
-            else:
-                device, interface = None, None
+
+            device, interface = None, None
+            for l in i.locations.location.elements:
+                if l.location_id == sna.location_reference:
+                    city = l.city
+                    if city != None:
+                        device, interface = CITY_ROUTER_INTERFACE_MAP.get_def(city.lower(), (None, None))
+
             provider_ipv4_address = sna.ip_connection.ipv4.addresses.provider_address
             customer_ipv4_address = sna.ip_connection.ipv4.addresses.customer_address
             ipv4_len = sna.ip_connection.ipv4.addresses.prefix_length

--- a/src/test_respnet.act
+++ b/src/test_respnet.act
@@ -154,6 +154,8 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Amsterdam</city>
+                        <country-code>NL</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -178,9 +180,6 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>AMS-CORE-1,GigabitEthernet0/0/0/2.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -201,6 +200,8 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Frankfurt</city>
+                        <country-code>DE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -225,9 +226,6 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>FRA-CORE-1,GigabitEthernet0/0/0/3.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -248,6 +246,8 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Stockholm</city>
+                        <country-code>SE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -272,9 +272,6 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>STO-CORE-1,eth4.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -295,6 +292,8 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Ljubljana</city>
+                        <country-code>SI</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -319,9 +318,6 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>LJU-CORE-1,eth3.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>

--- a/test/quicklab-crpd/l3vpn-svc.json
+++ b/test/quicklab-crpd/l3vpn-svc.json
@@ -21,7 +21,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Amsterdam",
+                                "country-code": "NL"
                             }
                         ]
                     },
@@ -48,9 +50,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "AMS-CORE-1,eth3.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -74,7 +73,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Frankfurt",
+                                "country-code": "DE"
                             }
                         ]
                     },
@@ -101,9 +102,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "FRA-CORE-1,eth4.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -127,7 +125,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Stockholm",
+                                "country-code": "SE"
                             }
                         ]
                     },
@@ -154,9 +154,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "STO-CORE-1,eth4.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -180,7 +177,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Ljubljana",
+                                "country-code": "SI"
                             }
                         ]
                     },
@@ -206,9 +205,6 @@
                                             "prefix-length": 30
                                         }
                                     }
-                                },
-                                "bearer": {
-                                    "bearer-reference": "LJU-CORE-1,eth3.100"
                                 },
                                 "routing-protocols": {
                                     "routing-protocol": [

--- a/test/quicklab-crpd/l3vpn-svc.xml
+++ b/test/quicklab-crpd/l3vpn-svc.xml
@@ -19,6 +19,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Amsterdam</city>
+                        <country-code>NL</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -43,9 +45,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>AMS-CORE-1,eth3.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -66,6 +65,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Frankfurt</city>
+                        <country-code>DE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -90,9 +91,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>FRA-CORE-1,eth4.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -113,6 +111,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Stockholm</city>
+                        <country-code>SE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -137,9 +137,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>STO-CORE-1,eth4.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -160,6 +157,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Ljubljana</city>
+                        <country-code>SI</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -184,9 +183,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>LJU-CORE-1,eth3.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>

--- a/test/quicklab-notconf/l3vpn-svc.json
+++ b/test/quicklab-notconf/l3vpn-svc.json
@@ -21,7 +21,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Amsterdam",
+                                "country-code": "NL"
                             }
                         ]
                     },
@@ -48,9 +50,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "AMS-CORE-1,GigabitEthernet0/0/0/2.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -74,7 +73,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Frankfurt",
+                                "country-code": "DE"
                             }
                         ]
                     },
@@ -101,9 +102,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "FRA-CORE-1,GigabitEthernet0/0/0/3.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -127,7 +125,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Stockholm",
+                                "country-code": "SE"
                             }
                         ]
                     },
@@ -154,9 +154,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "STO-CORE-1,eth4.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -180,7 +177,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Ljubljana",
+                                "country-code": "SI"
                             }
                         ]
                     },
@@ -206,9 +205,6 @@
                                             "prefix-length": 30
                                         }
                                     }
-                                },
-                                "bearer": {
-                                    "bearer-reference": "LJU-CORE-1,eth3.100"
                                 },
                                 "routing-protocols": {
                                     "routing-protocol": [

--- a/test/quicklab-notconf/l3vpn-svc.xml
+++ b/test/quicklab-notconf/l3vpn-svc.xml
@@ -19,6 +19,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Amsterdam</city>
+                        <country-code>NL</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -43,9 +45,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>AMS-CORE-1,GigabitEthernet0/0/0/2.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -66,6 +65,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Frankfurt</city>
+                        <country-code>DE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -90,9 +91,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>FRA-CORE-1,GigabitEthernet0/0/0/3.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -113,6 +111,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Stockholm</city>
+                        <country-code>SE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -137,9 +137,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>STO-CORE-1,eth4.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -160,6 +157,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Ljubljana</city>
+                        <country-code>SI</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -184,9 +183,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>LJU-CORE-1,eth3.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>

--- a/test/quicklab/l3vpn-svc.json
+++ b/test/quicklab/l3vpn-svc.json
@@ -21,7 +21,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Amsterdam",
+                                "country-code": "NL"
                             }
                         ]
                     },
@@ -48,9 +50,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "AMS-CORE-1,GigabitEthernet0/0/0/2.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -74,7 +73,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Frankfurt",
+                                "country-code": "DE"
                             }
                         ]
                     },
@@ -101,9 +102,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "FRA-CORE-1,GigabitEthernet0/0/0/3.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -127,7 +125,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Stockholm",
+                                "country-code": "SE"
                             }
                         ]
                     },
@@ -154,9 +154,6 @@
                                         }
                                     }
                                 },
-                                "bearer": {
-                                    "bearer-reference": "STO-CORE-1,eth4.100"
-                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -180,7 +177,9 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN"
+                                "location-id": "MAIN",
+                                "city": "Ljubljana",
+                                "country-code": "SI"
                             }
                         ]
                     },
@@ -206,9 +205,6 @@
                                             "prefix-length": 30
                                         }
                                     }
-                                },
-                                "bearer": {
-                                    "bearer-reference": "LJU-CORE-1,eth3.100"
                                 },
                                 "routing-protocols": {
                                     "routing-protocol": [

--- a/test/quicklab/l3vpn-svc.xml
+++ b/test/quicklab/l3vpn-svc.xml
@@ -19,6 +19,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Amsterdam</city>
+                        <country-code>NL</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -43,9 +45,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>AMS-CORE-1,GigabitEthernet0/0/0/2.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -66,6 +65,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Frankfurt</city>
+                        <country-code>DE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -90,9 +91,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>FRA-CORE-1,GigabitEthernet0/0/0/3.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -113,6 +111,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Stockholm</city>
+                        <country-code>SE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -137,9 +137,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>STO-CORE-1,eth4.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -160,6 +157,8 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
+                        <city>Ljubljana</city>
+                        <country-code>SI</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -184,9 +183,6 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
-                        <bearer>
-                            <bearer-reference>LJU-CORE-1,eth3.100</bearer-reference>
-                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>


### PR DESCRIPTION
Using the street address under the l3vpn asvc location is a more realistic example of how the model is (supposed to be) used.

The mapping from city name to a router name & interface happens through a silmple dictionary lookup for now, this can be expanded on later to move to a proper asset database.