### PR TITLE
Revert "Uese the location street address in l3pvn-svc"

### DIFF
--- a/src/respnet/cfs.act
+++ b/src/respnet/cfs.act
@@ -5,14 +5,6 @@ from respnet.conf import IGBP_AUTHENTICATION_KEY
 import respnet.layers.base_0 as base
 import respnet.layers.y_1_loose
 
-#  City to router interface mapping
-CITY_ROUTER_INTERFACE_MAP = {
-    "amsterdam": ("AMS-CORE-1", "GigabitEthernet0/0/0/2.100"),
-    "frankfurt": ("FRA-CORE-1", "GigabitEthernet0/0/0/3.100"),
-    "stockholm": ("STO-CORE-1", "eth4.100"),
-    "ljubljana": ("LJU-CORE-1", "eth3.100"),
-}
-
 class Router(base.Router):
     def transform(self, i):
         o = base.o_root()
@@ -58,14 +50,13 @@ class L3VpnSite(base.L3VpnSite):
         o = base.o_root()
         for sna in i.site_network_accesses.site_network_access.elements:
             vpn_id = sna.vpn_attachment.vpn_id
-
-            device, interface = None, None
-            for l in i.locations.location.elements:
-                if l.location_id == sna.location_reference:
-                    city = l.city
-                    if city != None:
-                        device, interface = CITY_ROUTER_INTERFACE_MAP.get_def(city.lower(), (None, None))
-
+            bearer_ref = sna.bearer.bearer_reference
+            if bearer_ref != None:
+                parts = bearer_ref.split(",")
+                device = parts[0]
+                interface = parts[1]
+            else:
+                device, interface = None, None
             provider_ipv4_address = sna.ip_connection.ipv4.addresses.provider_address
             customer_ipv4_address = sna.ip_connection.ipv4.addresses.customer_address
             ipv4_len = sna.ip_connection.ipv4.addresses.prefix_length

--- a/src/test_respnet.act
+++ b/src/test_respnet.act
@@ -154,8 +154,6 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Amsterdam</city>
-                        <country-code>NL</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -180,6 +178,9 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>AMS-CORE-1,GigabitEthernet0/0/0/2.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -200,8 +201,6 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Frankfurt</city>
-                        <country-code>DE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -226,6 +225,9 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>FRA-CORE-1,GigabitEthernet0/0/0/3.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -246,8 +248,6 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Stockholm</city>
-                        <country-code>SE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -272,6 +272,9 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>STO-CORE-1,eth4.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -292,8 +295,6 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Ljubljana</city>
-                        <country-code>SI</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -318,6 +319,9 @@ def _test_l3vpn_svc(log_handler: logging.Handler) -> str:
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>LJU-CORE-1,eth3.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>

--- a/test/quicklab-crpd/l3vpn-svc.json
+++ b/test/quicklab-crpd/l3vpn-svc.json
@@ -21,9 +21,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Amsterdam",
-                                "country-code": "NL"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -50,6 +48,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "AMS-CORE-1,eth3.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -73,9 +74,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Frankfurt",
-                                "country-code": "DE"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -102,6 +101,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "FRA-CORE-1,eth4.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -125,9 +127,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Stockholm",
-                                "country-code": "SE"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -154,6 +154,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "STO-CORE-1,eth4.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -177,9 +180,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Ljubljana",
-                                "country-code": "SI"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -205,6 +206,9 @@
                                             "prefix-length": 30
                                         }
                                     }
+                                },
+                                "bearer": {
+                                    "bearer-reference": "LJU-CORE-1,eth3.100"
                                 },
                                 "routing-protocols": {
                                     "routing-protocol": [

--- a/test/quicklab-crpd/l3vpn-svc.xml
+++ b/test/quicklab-crpd/l3vpn-svc.xml
@@ -19,8 +19,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Amsterdam</city>
-                        <country-code>NL</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -45,6 +43,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>AMS-CORE-1,eth3.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -65,8 +66,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Frankfurt</city>
-                        <country-code>DE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -91,6 +90,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>FRA-CORE-1,eth4.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -111,8 +113,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Stockholm</city>
-                        <country-code>SE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -137,6 +137,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>STO-CORE-1,eth4.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -157,8 +160,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Ljubljana</city>
-                        <country-code>SI</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -183,6 +184,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>LJU-CORE-1,eth3.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>

--- a/test/quicklab-notconf/l3vpn-svc.json
+++ b/test/quicklab-notconf/l3vpn-svc.json
@@ -21,9 +21,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Amsterdam",
-                                "country-code": "NL"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -50,6 +48,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "AMS-CORE-1,GigabitEthernet0/0/0/2.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -73,9 +74,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Frankfurt",
-                                "country-code": "DE"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -102,6 +101,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "FRA-CORE-1,GigabitEthernet0/0/0/3.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -125,9 +127,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Stockholm",
-                                "country-code": "SE"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -154,6 +154,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "STO-CORE-1,eth4.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -177,9 +180,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Ljubljana",
-                                "country-code": "SI"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -205,6 +206,9 @@
                                             "prefix-length": 30
                                         }
                                     }
+                                },
+                                "bearer": {
+                                    "bearer-reference": "LJU-CORE-1,eth3.100"
                                 },
                                 "routing-protocols": {
                                     "routing-protocol": [

--- a/test/quicklab-notconf/l3vpn-svc.xml
+++ b/test/quicklab-notconf/l3vpn-svc.xml
@@ -19,8 +19,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Amsterdam</city>
-                        <country-code>NL</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -45,6 +43,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>AMS-CORE-1,GigabitEthernet0/0/0/2.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -65,8 +66,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Frankfurt</city>
-                        <country-code>DE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -91,6 +90,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>FRA-CORE-1,GigabitEthernet0/0/0/3.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -111,8 +113,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Stockholm</city>
-                        <country-code>SE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -137,6 +137,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>STO-CORE-1,eth4.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -157,8 +160,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Ljubljana</city>
-                        <country-code>SI</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -183,6 +184,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>LJU-CORE-1,eth3.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>

--- a/test/quicklab/l3vpn-svc.json
+++ b/test/quicklab/l3vpn-svc.json
@@ -21,9 +21,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Amsterdam",
-                                "country-code": "NL"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -50,6 +48,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "AMS-CORE-1,GigabitEthernet0/0/0/2.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -73,9 +74,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Frankfurt",
-                                "country-code": "DE"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -102,6 +101,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "FRA-CORE-1,GigabitEthernet0/0/0/3.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -125,9 +127,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Stockholm",
-                                "country-code": "SE"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -154,6 +154,9 @@
                                         }
                                     }
                                 },
+                                "bearer": {
+                                    "bearer-reference": "STO-CORE-1,eth4.100"
+                                },
                                 "routing-protocols": {
                                     "routing-protocol": [
                                         {
@@ -177,9 +180,7 @@
                     "locations": {
                         "location": [
                             {
-                                "location-id": "MAIN",
-                                "city": "Ljubljana",
-                                "country-code": "SI"
+                                "location-id": "MAIN"
                             }
                         ]
                     },
@@ -205,6 +206,9 @@
                                             "prefix-length": 30
                                         }
                                     }
+                                },
+                                "bearer": {
+                                    "bearer-reference": "LJU-CORE-1,eth3.100"
                                 },
                                 "routing-protocols": {
                                     "routing-protocol": [

--- a/test/quicklab/l3vpn-svc.xml
+++ b/test/quicklab/l3vpn-svc.xml
@@ -19,8 +19,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Amsterdam</city>
-                        <country-code>NL</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -45,6 +43,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>AMS-CORE-1,GigabitEthernet0/0/0/2.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -65,8 +66,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Frankfurt</city>
-                        <country-code>DE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -91,6 +90,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>FRA-CORE-1,GigabitEthernet0/0/0/3.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -111,8 +113,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Stockholm</city>
-                        <country-code>SE</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -137,6 +137,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>STO-CORE-1,eth4.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>
@@ -157,8 +160,6 @@
                 <locations>
                     <location>
                         <location-id>MAIN</location-id>
-                        <city>Ljubljana</city>
-                        <country-code>SI</country-code>
                     </location>
                 </locations>
                 <site-network-accesses>
@@ -183,6 +184,9 @@
                                 </addresses>
                             </ipv4>
                         </ip-connection>
+                        <bearer>
+                            <bearer-reference>LJU-CORE-1,eth3.100</bearer-reference>
+                        </bearer>
                         <routing-protocols>
                             <routing-protocol>
                                 <type>bgp</type>


### PR DESCRIPTION
This reverts commit d8a9407eae945281b13eb7b0edeb58f34dd58112. The hardcoded values are specific to Cisco devices and do not work for the `quicklab-crpd` network where it's all Juniper. We discussed other means of providing this data in meeting, but for the short term let's keep interface identifiers as part of the inputs.