### PR TITLE
Use "loose" device models

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/c4b414354ab01dd416d77cfdffd76a6ef27309ee.zip",
-            "hash": "1220de2b8261d81f51745ffd0c2f5a6bee87f7d91667af577746b14bdf6838177212"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/0dd7b5cf09f9ac99708ef6ac8f76de56fbda85ab.zip",
+            "hash": "12200496934deb459674bb93d8606f9561a87ce947a27763d7d2ad2ec21f08bcf4c2"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/0823d493035a1a5ef8c5f68fce9ee5ee83fa36fc.zip",
-            "hash": "1220d49508d337f8b2341be42e51ad96d5ab4ef9c7c026bdc3a9fcd4769d527fe3eb"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/49afee4afa257658f8e9de0b319f6a06ab8e246f.zip",
+            "hash": "122080086cfebd91c0ac90a8477f9ca9ee3803898a9de5a0a2c8d2d583881a47477f"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/c4b414354ab01dd416d77cfdffd76a6ef27309ee.zip",
-            "hash": "1220de2b8261d81f51745ffd0c2f5a6bee87f7d91667af577746b14bdf6838177212"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/0dd7b5cf09f9ac99708ef6ac8f76de56fbda85ab.zip",
+            "hash": "12200496934deb459674bb93d8606f9561a87ce947a27763d7d2ad2ec21f08bcf4c2"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/0823d493035a1a5ef8c5f68fce9ee5ee83fa36fc.zip",
-            "hash": "1220d49508d337f8b2341be42e51ad96d5ab4ef9c7c026bdc3a9fcd4769d527fe3eb"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/49afee4afa257658f8e9de0b319f6a06ab8e246f.zip",
+            "hash": "122080086cfebd91c0ac90a8477f9ca9ee3803898a9de5a0a2c8d2d583881a47477f"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/src/respnet/devices/CiscoIosXr_24_1_ncs55a1.act
+++ b/src/respnet/devices/CiscoIosXr_24_1_ncs55a1.act
@@ -1697,10 +1697,10 @@ mut def from_json_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as__index(val
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(yang.adata.MNode):
-    as_number: str
-    index: int
+    as_number: ?str
+    index: ?int
 
-    mut def __init__(self, as_number: str, index: int):
+    mut def __init__(self, as_number: ?str, index: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg"
         self.as_number = as_number
         self.index = index
@@ -1735,10 +1735,10 @@ mut def from_json_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as__index(va
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(yang.adata.MNode):
-    as_number: str
-    index: int
+    as_number: ?str
+    index: ?int
 
-    mut def __init__(self, as_number: str, index: int):
+    mut def __init__(self, as_number: ?str, index: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg"
         self.as_number = as_number
         self.index = index
@@ -1773,10 +1773,10 @@ mut def from_json_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address__index(val:
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(yang.adata.MNode):
-    ipv4_address: str
-    index: int
+    ipv4_address: ?str
+    index: ?int
 
-    mut def __init__(self, ipv4_address: str, index: int):
+    mut def __init__(self, ipv4_address: ?str, index: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg"
         self.ipv4_address = ipv4_address
         self.index = index
@@ -2239,10 +2239,10 @@ mut def from_json_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes_
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry(yang.adata.MNode):
     index_number: int
-    value: int
-    priority: str
+    value: ?int
+    priority: ?str
 
-    mut def __init__(self, index_number: int, value: int, priority: str):
+    mut def __init__(self, index_number: int, value: ?int, priority: ?str):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg"
         self.index_number = index_number
         self.value = value
@@ -2446,9 +2446,9 @@ mut def from_json_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry(yang.adata.MNode):
     index_number: int
-    group_name: str
+    group_name: ?str
 
-    mut def __init__(self, index_number: int, group_name: str):
+    mut def __init__(self, index_number: int, group_name: ?str):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg"
         self.index_number = index_number
         self.group_name = group_name
@@ -2699,10 +2699,10 @@ mut def from_json_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index__
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry(yang.adata.MNode):
     index_number: int
-    value: int
-    priority: str
+    value: ?int
+    priority: ?str
 
-    mut def __init__(self, index_number: int, value: int, priority: str):
+    mut def __init__(self, index_number: int, value: ?int, priority: ?str):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg"
         self.index_number = index_number
         self.value = value
@@ -2920,10 +2920,10 @@ mut def from_json_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_loca
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry(yang.adata.MNode):
     index_number: int
-    value: int
-    priority: str
+    value: ?int
+    priority: ?str
 
-    mut def __init__(self, index_number: int, value: int, priority: str):
+    mut def __init__(self, index_number: int, value: ?int, priority: ?str):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg"
         self.index_number = index_number
         self.value = value
@@ -4463,9 +4463,9 @@ mut def from_json_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__proc
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index(yang.adata.MNode):
-    sid_index: int
+    sid_index: ?int
 
-    mut def __init__(self, sid_index: int):
+    mut def __init__(self, sid_index: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-isis-cfg"
         self.sid_index = sid_index
 
@@ -4534,8 +4534,8 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
         if self_sid is not None:
             self_sid._parent = self
 
-    mut def create_sid(self, index):
-        res = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid(index)
+    mut def create_sid(self):
+        res = Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid()
         self.sid = res
         return res
 
@@ -5155,10 +5155,10 @@ mut def from_json_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host__po
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(yang.adata.MNode):
-    host_name: str
+    host_name: ?str
     port: ?int
 
-    mut def __init__(self, host_name: str, port: ?int):
+    mut def __init__(self, host_name: ?str, port: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg"
         self.host_name = host_name
         self.port = port
@@ -5202,10 +5202,10 @@ mut def from_json_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay(yang.adata.MNode):
-    initial_delay: int
+    initial_delay: ?int
     spread: ?int
 
-    mut def __init__(self, initial_delay: int, spread: ?int):
+    mut def __init__(self, initial_delay: ?int, spread: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg"
         self.initial_delay = initial_delay
         self.spread = spread
@@ -5482,7 +5482,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server(yang.adata.MNode):
         self._name = 'server'
         self.elements = elements
 
-    mut def create(self, bmp_server_id, host):
+    mut def create(self, bmp_server_id):
         for e in self.elements:
             match = True
             if e.bmp_server_id != bmp_server_id:
@@ -5491,7 +5491,7 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server(yang.adata.MNode):
             if match:
                 return e
 
-        res = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry(bmp_server_id, host)
+        res = Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry(bmp_server_id)
         self.elements.append(res)
         return res
 
@@ -7659,10 +7659,10 @@ mut def from_json_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as(yang.adata.MNode):
-    as_number: str
-    index: int
+    as_number: ?str
+    index: ?int
 
-    mut def __init__(self, as_number: str, index: int):
+    mut def __init__(self, as_number: ?str, index: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg"
         self.as_number = as_number
         self.index = index
@@ -7697,10 +7697,10 @@ mut def from_json_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as(yang.adata.MNode):
-    as_number: str
-    index: int
+    as_number: ?str
+    index: ?int
 
-    mut def __init__(self, as_number: str, index: int):
+    mut def __init__(self, as_number: ?str, index: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg"
         self.as_number = as_number
         self.index = index
@@ -7735,10 +7735,10 @@ mut def from_json_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address(yang.adata.MNode):
-    ipv4_address: str
-    index: int
+    ipv4_address: ?str
+    index: ?int
 
-    mut def __init__(self, ipv4_address: str, index: int):
+    mut def __init__(self, ipv4_address: ?str, index: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg"
         self.ipv4_address = ipv4_address
         self.index = index
@@ -7868,8 +7868,8 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry(yang.adat
         if self_rd is not None:
             self_rd._parent = self
 
-    mut def create_rd(self, two_byte_as, four_byte_as, ip_address):
-        res = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(two_byte_as, four_byte_as, ip_address)
+    mut def create_rd(self):
+        res = Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd()
         self.rd = res
         return res
 
@@ -8581,12 +8581,12 @@ mut def from_json_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__ad
     return yang.gdata.Leaf("uint32", val)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address(yang.adata.MNode):
-    address: str
-    netmask: str
+    address: ?str
+    netmask: ?str
     route_tag: ?int
     algorithm: ?int
 
-    mut def __init__(self, address: str, netmask: str, route_tag: ?int, algorithm: ?int):
+    mut def __init__(self, address: ?str, netmask: ?str, route_tag: ?int, algorithm: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ip-address-cfg"
         self.address = address
         self.netmask = netmask
@@ -8636,11 +8636,11 @@ mut def from_json_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__ad
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry(yang.adata.MNode):
     address: str
-    netmask: str
+    netmask: ?str
     route_tag: ?int
     algorithm: ?int
 
-    mut def __init__(self, address: str, netmask: str, route_tag: ?int, algorithm: ?int):
+    mut def __init__(self, address: str, netmask: ?str, route_tag: ?int, algorithm: ?int):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ip-address-cfg"
         self.address = address
         self.netmask = netmask
@@ -9471,9 +9471,9 @@ mut def from_json_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_poli
 
 class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry(yang.adata.MNode):
     route_policy_name: str
-    rpl_route_policy: str
+    rpl_route_policy: ?str
 
-    mut def __init__(self, route_policy_name: str, rpl_route_policy: str):
+    mut def __init__(self, route_policy_name: str, rpl_route_policy: ?str):
         self._ns = "http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg"
         self.route_policy_name = route_policy_name
         self.rpl_route_policy = rpl_route_policy

--- a/src/respnet/devices/JuniperCRPD_23_4R1_9.act
+++ b/src/respnet/devices/JuniperCRPD_23_4R1_9.act
@@ -3445,19 +3445,13 @@ mut def from_json_junos_conf_root__configuration__protocols__bgp__path_selection
     return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(yang.adata.MNode):
-    med_multiplier: value
-    igp_multiplier: value
+    med_multiplier: ?value
+    igp_multiplier: ?value
 
-    mut def __init__(self, med_multiplier: ?value=None, igp_multiplier: ?value=None):
+    mut def __init__(self, med_multiplier: ?value, igp_multiplier: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
-        if med_multiplier != None:
-            self.med_multiplier = med_multiplier
-        else:
-            self.med_multiplier = 1
-        if igp_multiplier != None:
-            self.igp_multiplier = igp_multiplier
-        else:
-            self.igp_multiplier = 1
+        self.med_multiplier = med_multiplier
+        self.igp_multiplier = igp_multiplier
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
@@ -7496,13 +7490,13 @@ mut def from_json_junos_conf_root__configuration__protocols__isis__interface__fa
     return yang.gdata.Leaf("union", val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(yang.adata.MNode):
-    version: str
+    version: ?str
     minimum_interval: ?value
     minimum_transmit_interval: ?value
     minimum_receive_interval: ?value
-    multiplier: value
+    multiplier: ?value
     inline_disable: ?bool
-    pdu_size: value
+    pdu_size: ?value
     no_adaptation: ?bool
     transmit_interval: junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval
     detection_time: junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time
@@ -7511,24 +7505,15 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
     echo_lite: junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite
     holddown_interval: ?value
 
-    mut def __init__(self, version: ?str=None, minimum_interval: ?value, minimum_transmit_interval: ?value, minimum_receive_interval: ?value, multiplier: ?value=None, inline_disable: ?bool, pdu_size: ?value=None, no_adaptation: ?bool, transmit_interval: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval=None, detection_time: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time=None, authentication: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication=None, echo: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo=None, echo_lite: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite=None, holddown_interval: ?value):
+    mut def __init__(self, version: ?str, minimum_interval: ?value, minimum_transmit_interval: ?value, minimum_receive_interval: ?value, multiplier: ?value, inline_disable: ?bool, pdu_size: ?value, no_adaptation: ?bool, transmit_interval: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval=None, detection_time: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time=None, authentication: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication=None, echo: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo=None, echo_lite: ?junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite=None, holddown_interval: ?value):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
-        if version != None:
-            self.version = version
-        else:
-            self.version = "automatic"
+        self.version = version
         self.minimum_interval = minimum_interval
         self.minimum_transmit_interval = minimum_transmit_interval
         self.minimum_receive_interval = minimum_receive_interval
-        if multiplier != None:
-            self.multiplier = multiplier
-        else:
-            self.multiplier = 3
+        self.multiplier = multiplier
         self.inline_disable = inline_disable
-        if pdu_size != None:
-            self.pdu_size = pdu_size
-        else:
-            self.pdu_size = 24
+        self.pdu_size = pdu_size
         self.no_adaptation = no_adaptation
         if transmit_interval is not None:
             self.transmit_interval = transmit_interval
@@ -7707,12 +7692,12 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
     name: str
     ldp_synchronization: ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization
     level: junos_conf_root__configuration__protocols__isis__interface__level
-    lsp_interval: value
+    lsp_interval: ?value
     point_to_point: ?bool
     passive: ?junos_conf_root__configuration__protocols__isis__interface__passive
     family: junos_conf_root__configuration__protocols__isis__interface__family
 
-    mut def __init__(self, name: str, ldp_synchronization: ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization=None, level: list[junos_conf_root__configuration__protocols__isis__interface__level_entry]=[], lsp_interval: ?value=None, point_to_point: ?bool, passive: ?junos_conf_root__configuration__protocols__isis__interface__passive=None, family: list[junos_conf_root__configuration__protocols__isis__interface__family_entry]=[]):
+    mut def __init__(self, name: str, ldp_synchronization: ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization=None, level: list[junos_conf_root__configuration__protocols__isis__interface__level_entry]=[], lsp_interval: ?value, point_to_point: ?bool, passive: ?junos_conf_root__configuration__protocols__isis__interface__passive=None, family: list[junos_conf_root__configuration__protocols__isis__interface__family_entry]=[]):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.name = name
         self.ldp_synchronization = ldp_synchronization
@@ -7721,10 +7706,7 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
             self_ldp_synchronization._parent = self
         self.level = junos_conf_root__configuration__protocols__isis__interface__level(elements=level)
         self.level._parent = self
-        if lsp_interval != None:
-            self.lsp_interval = lsp_interval
-        else:
-            self.lsp_interval = 100
+        self.lsp_interval = lsp_interval
         self.point_to_point = point_to_point
         self.passive = passive
         self_passive = self.passive
@@ -8941,20 +8923,17 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(y
     filename: ?str
     replace: ?bool
     size: ?str
-    files: value
+    files: ?value
     no_stamp: ?bool
     world_readable: ?bool
     no_world_readable: ?bool
 
-    mut def __init__(self, filename: ?str, replace: ?bool, size: ?str, files: ?value=None, no_stamp: ?bool, world_readable: ?bool, no_world_readable: ?bool):
+    mut def __init__(self, filename: ?str, replace: ?bool, size: ?str, files: ?value, no_stamp: ?bool, world_readable: ?bool, no_world_readable: ?bool):
         self._ns = "http://yang.juniper.net/junos/conf/protocols"
         self.filename = filename
         self.replace = replace
         self.size = size
-        if files != None:
-            self.files = files
-        else:
-            self.files = 10
+        self.files = files
         self.no_stamp = no_stamp
         self.world_readable = world_readable
         self.no_world_readable = no_world_readable

--- a/src/respnet/layers/y_2_loose.act
+++ b/src/respnet/layers/y_2_loose.act
@@ -1663,14 +1663,11 @@ class orchestron_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     ipv6_prefix_length: ?int
     remote: orchestron_rfs__rfs__backbone_interface__remote
 
-    mut def __init__(self, name: str, ipv4_address: ?str, ipv4_prefix_length: ?int=None, ipv6_address: ?str, ipv6_prefix_length: ?int, remote: ?orchestron_rfs__rfs__backbone_interface__remote=None):
+    mut def __init__(self, name: str, ipv4_address: ?str, ipv4_prefix_length: ?int, ipv6_address: ?str, ipv6_prefix_length: ?int, remote: ?orchestron_rfs__rfs__backbone_interface__remote=None):
         self._ns = "http://example.com/respnet-rfs"
         self.name = name
         self.ipv4_address = ipv4_address
-        if ipv4_prefix_length != None:
-            self.ipv4_prefix_length = ipv4_prefix_length
-        else:
-            self.ipv4_prefix_length = 30
+        self.ipv4_prefix_length = ipv4_prefix_length
         self.ipv6_address = ipv6_address
         self.ipv6_prefix_length = ipv6_prefix_length
         if remote is not None:
@@ -2298,16 +2295,13 @@ class orchestron_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
     ipv4_address: ?str
     ipv4_prefix_length: ?int
 
-    mut def __init__(self, name: str, description: ?str, vrf: ?str, ipv4_address: ?str, ipv4_prefix_length: ?int=None):
+    mut def __init__(self, name: str, description: ?str, vrf: ?str, ipv4_address: ?str, ipv4_prefix_length: ?int):
         self._ns = "http://example.com/respnet-rfs"
         self.name = name
         self.description = description
         self.vrf = vrf
         self.ipv4_address = ipv4_address
-        if ipv4_prefix_length != None:
-            self.ipv4_prefix_length = ipv4_prefix_length
-        else:
-            self.ipv4_prefix_length = 30
+        self.ipv4_prefix_length = ipv4_prefix_length
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}

--- a/test/golden/respnet.test_inter/inter_bblink
+++ b/test/golden/respnet.test_inter/inter_bblink
@@ -3,7 +3,6 @@
   <backbone-interface xmlns="http://example.com/respnet-rfs">
     <name>GigabitEthernet0/0/0/0</name>
     <ipv4-address>10.0.7.1</ipv4-address>
-    <ipv4-prefix-length>30</ipv4-prefix-length>
     <remote>
       <device>FRA-CORE-1</device>
       <interface>GigabitEthernet0/0/0/0</interface>
@@ -15,7 +14,6 @@
   <backbone-interface xmlns="http://example.com/respnet-rfs">
     <name>GigabitEthernet0/0/0/0</name>
     <ipv4-address>10.0.7.2</ipv4-address>
-    <ipv4-prefix-length>30</ipv4-prefix-length>
     <remote>
       <device>AMS-CORE-1</device>
       <interface>GigabitEthernet0/0/0/0</interface>

--- a/test/golden/respnet.test_rfs/rfs_bbinterface2
+++ b/test/golden/respnet.test_rfs/rfs_bbinterface2
@@ -27,16 +27,10 @@
           <name>2</name>
           <metric>5000</metric>
         </level>
-        <lsp-interval>100</lsp-interval>
         <point-to-point/>
       </interface>
     </isis>
     <ldp>
-      <traffic-statistics>
-        <file>
-          <files>10</files>
-        </file>
-      </traffic-statistics>
       <interface>
         <name>eth1</name>
       </interface>

--- a/test/golden/test_respnet/l3vpn_svc
+++ b/test/golden/test_respnet/l3vpn_svc
@@ -786,7 +786,6 @@ end-policy</rpl-route-policy>
                 <name>2</name>
                 <metric>5000</metric>
               </level>
-              <lsp-interval>100</lsp-interval>
               <point-to-point/>
             </interface>
             <interface>
@@ -799,12 +798,10 @@ end-policy</rpl-route-policy>
                 <name>2</name>
                 <metric>5000</metric>
               </level>
-              <lsp-interval>100</lsp-interval>
               <point-to-point/>
             </interface>
             <interface>
               <name>lo0.0</name>
-              <lsp-interval>100</lsp-interval>
               <passive/>
             </interface>
             <level>
@@ -818,11 +815,6 @@ end-policy</rpl-route-policy>
             <lsp-lifetime>65535</lsp-lifetime>
           </isis>
           <ldp>
-            <traffic-statistics>
-              <file>
-                <files>10</files>
-              </file>
-            </traffic-statistics>
             <interface>
               <name>eth1</name>
             </interface>
@@ -1008,7 +1000,6 @@ end-policy</rpl-route-policy>
                 <name>2</name>
                 <metric>5000</metric>
               </level>
-              <lsp-interval>100</lsp-interval>
               <point-to-point/>
             </interface>
             <interface>
@@ -1021,7 +1012,6 @@ end-policy</rpl-route-policy>
                 <name>2</name>
                 <metric>5000</metric>
               </level>
-              <lsp-interval>100</lsp-interval>
               <point-to-point/>
             </interface>
             <interface>
@@ -1034,12 +1024,10 @@ end-policy</rpl-route-policy>
                 <name>2</name>
                 <metric>5000</metric>
               </level>
-              <lsp-interval>100</lsp-interval>
               <point-to-point/>
             </interface>
             <interface>
               <name>lo0.0</name>
-              <lsp-interval>100</lsp-interval>
               <passive/>
             </interface>
             <level>
@@ -1053,11 +1041,6 @@ end-policy</rpl-route-policy>
             <lsp-lifetime>65535</lsp-lifetime>
           </isis>
           <ldp>
-            <traffic-statistics>
-              <file>
-                <files>10</files>
-              </file>
-            </traffic-statistics>
             <interface>
               <name>eth1</name>
             </interface>

--- a/test/golden/test_respnet/netinfra1
+++ b/test/golden/test_respnet/netinfra1
@@ -392,7 +392,6 @@ end-policy</rpl-route-policy>
           <isis>
             <interface>
               <name>lo0.0</name>
-              <lsp-interval>100</lsp-interval>
               <passive/>
             </interface>
             <level>
@@ -405,13 +404,6 @@ end-policy</rpl-route-policy>
             </level>
             <lsp-lifetime>65535</lsp-lifetime>
           </isis>
-          <ldp>
-            <traffic-statistics>
-              <file>
-                <files>10</files>
-              </file>
-            </traffic-statistics>
-          </ldp>
         </protocols>
       </configuration>
     </config>


### PR DESCRIPTION
This results in Orchestron *not* sending default leaf values to the device, unless they were set explicitly. I have verified the IOS XRd environment works locally, in case this shows up as a CI failure.