### PR TITLE
Store JSON, gdata l3vpn test output

### DIFF
--- a/src/test_respnet.act
+++ b/src/test_respnet.act
@@ -343,7 +343,7 @@ l3vpn_in = """<data>
 </data>
 """
 
-actor l3vpn_tester(t: testing.AsyncT):
+actor l3vpn_tester(t: testing.AsyncT, output_formatter: mut(gdata.Node) -> str):
     xml_conf = xml.decode(l3vpn_in)
     input_config = cfs_root.from_xml(xml_conf)
 
@@ -355,13 +355,21 @@ actor l3vpn_tester(t: testing.AsyncT):
 
     def cont(_r: value):
         res = session.below().below().below().get()
-        print(res.to_xmlstr())
-        t.success(res.to_xmlstr())
+        output = output_formatter(res)
+        print(output)
+        t.success(output)
 
     session.edit_config(input_config.to_gdata(), None, cont)
 
 def _test_l3vpn_svc(t: testing.AsyncT):
-    l3vpn_tester(t)
+    l3vpn_tester(t, lambda n: n.to_xmlstr())
+
+def _test_l3vpn_svc_json(t: testing.AsyncT):
+    l3vpn_tester(t, lambda n: n.to_json())
+
+# TODO: enable once gdata after transform is valid (= sorted where it needs to be)
+# def _test_l3vpn_svc_gdata(t: testing.AsyncT):
+#     l3vpn_tester(t, lambda n: n.prsrc())
 
 actor main(env):
     logh = logging.Handler("Otron")
@@ -369,4 +377,4 @@ actor main(env):
     logh.set_output_level(logging.DEBUG)
     t = testing.AsyncT(lambda ok,ex,out: env.exit(0), logh)
 #    netinfra_tester(t)
-    l3vpn_tester(t)
+    l3vpn_tester(t, lambda n: n.to_xmlstr())

--- a/test/golden/test_respnet/l3vpn_svc_json
+++ b/test/golden/test_respnet/l3vpn_svc_json
@@ -1,0 +1,1652 @@
+{
+    "devices": {
+        "device": [
+            {
+                "name": "AMS-CORE-1",
+                "modset_id": "9171161324580586743",
+                "config": {
+                    "address-family": {
+                        "ipv4": {
+                            "multicast": {
+                                "topologies": {
+                                    "topology": []
+                                }
+                            }
+                        },
+                        "ipv6": {
+                            "multicast": {
+                                "topologies": {
+                                    "topology": []
+                                }
+                            }
+                        }
+                    },
+                    "vrfs": {
+                        "vrf": [
+                            {
+                                "vrf-name": "acme-65501",
+                                "address-family": {
+                                    "ipv4": {
+                                        "unicast": {
+                                            "import": {
+                                                "route-target": {
+                                                    "two-byte-as-rts": {
+                                                        "two-byte-as-rt": [
+                                                            {
+                                                                "as-number": 65001,
+                                                                "index": 65501,
+                                                                "stitching": "false"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "export": {
+                                                "route-target": {
+                                                    "two-byte-as-rts": {
+                                                        "two-byte-as-rt": [
+                                                            {
+                                                                "as-number": 65001,
+                                                                "index": 65501,
+                                                                "stitching": "false"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "ipv6": {}
+                                },
+                                "mode": {},
+                                "vpn": {},
+                                "description": "Customer VPN for CUSTOMER-1",
+                                "remote-route-filtering": {},
+                                "rd": {}
+                            }
+                        ]
+                    },
+                    "selective-vrf-download": {},
+                    "vrf-groups": {
+                        "vrf-group": []
+                    },
+                    "um-router-isis-cfg:router": {
+                        "isis": {
+                            "processes": {
+                                "process": [
+                                    {
+                                        "process-id": "1",
+                                        "is-type": "level-2-only",
+                                        "nets": {
+                                            "net": [
+                                                {
+                                                    "net-id": "49.0001.0100.0000.0001.00"
+                                                }
+                                            ]
+                                        },
+                                        "address-families": {
+                                            "address-family": [
+                                                {
+                                                    "af-name": "ipv4",
+                                                    "saf-name": "unicast",
+                                                    "segment-routing": {
+                                                        "mpls": {}
+                                                    },
+                                                    "metric-style": {
+                                                        "wide": {},
+                                                        "levels": {
+                                                            "level": []
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "interfaces": {
+                                            "interface": [
+                                                {
+                                                    "interface-name": "GigabitEthernet0/0/0/0",
+                                                    "circuit-type": "level-2-only",
+                                                    "point-to-point": {},
+                                                    "bfd": {
+                                                        "fast-detect": {}
+                                                    },
+                                                    "address-families": {
+                                                        "address-family": [
+                                                            {
+                                                                "af-name": "ipv4",
+                                                                "saf-name": "unicast",
+                                                                "metric": {
+                                                                    "levels": {
+                                                                        "level": [
+                                                                            {
+                                                                                "level-id": 2,
+                                                                                "default-metric": 5000
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "prefix-sid": {}
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "interface-name": "GigabitEthernet0/0/0/1",
+                                                    "circuit-type": "level-2-only",
+                                                    "point-to-point": {},
+                                                    "bfd": {
+                                                        "fast-detect": {}
+                                                    },
+                                                    "address-families": {
+                                                        "address-family": [
+                                                            {
+                                                                "af-name": "ipv4",
+                                                                "saf-name": "unicast",
+                                                                "metric": {
+                                                                    "levels": {
+                                                                        "level": [
+                                                                            {
+                                                                                "level-id": 2,
+                                                                                "default-metric": 5000
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "prefix-sid": {}
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "interface-name": "Loopback0",
+                                                    "bfd": {
+                                                        "fast-detect": {}
+                                                    },
+                                                    "passive": {},
+                                                    "address-families": {
+                                                        "address-family": [
+                                                            {
+                                                                "af-name": "ipv4",
+                                                                "saf-name": "unicast",
+                                                                "metric": {
+                                                                    "levels": {
+                                                                        "level": []
+                                                                    }
+                                                                },
+                                                                "prefix-sid": {}
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "as-format": {},
+                    "bmp": {
+                        "servers": {
+                            "server": [],
+                            "all": {
+                                "route-monitoring": {
+                                    "bmp-modes": {
+                                        "bmp-mode": []
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "um-router-bgp-cfg:router": {
+                        "bgp": {
+                            "as": [
+                                {
+                                    "as-number": "65001",
+                                    "rpki": {
+                                        "servers": {
+                                            "server": []
+                                        },
+                                        "routes": {
+                                            "route": []
+                                        }
+                                    },
+                                    "address-families": {
+                                        "address-family": [
+                                            {
+                                                "af-name": "vpnv4-unicast"
+                                            },
+                                            {
+                                                "af-name": "vpnv6-unicast"
+                                            }
+                                        ]
+                                    },
+                                    "neighbors": {
+                                        "neighbor": [
+                                            {
+                                                "neighbor-address": "10.0.0.2",
+                                                "use": {
+                                                    "neighbor-group": "IPV4-IBGP"
+                                                },
+                                                "description": "FRA-CORE-1"
+                                            },
+                                            {
+                                                "neighbor-address": "10.0.0.3",
+                                                "use": {
+                                                    "neighbor-group": "IPV4-IBGP"
+                                                },
+                                                "description": "STO-CORE-1"
+                                            },
+                                            {
+                                                "neighbor-address": "10.0.0.4",
+                                                "use": {
+                                                    "neighbor-group": "IPV4-IBGP"
+                                                },
+                                                "description": "LJU-CORE-1"
+                                            }
+                                        ]
+                                    },
+                                    "neighbor-groups": {
+                                        "neighbor-group": [
+                                            {
+                                                "neighbor-group-name": "IPV4-IBGP",
+                                                "address-families": {
+                                                    "address-family": [
+                                                        {
+                                                            "af-name": "vpnv4-unicast"
+                                                        },
+                                                        {
+                                                            "af-name": "vpnv6-unicast"
+                                                        }
+                                                    ]
+                                                },
+                                                "remote-as": "65001",
+                                                "password": {
+                                                    "encrypted": "045209011F6C4D5B1D11001906020F053E222B267E3E270A"
+                                                },
+                                                "update-source": "Loopback0"
+                                            }
+                                        ]
+                                    },
+                                    "bgp": {
+                                        "router-id": "10.0.0.1"
+                                    },
+                                    "vrfs": {
+                                        "vrf": [
+                                            {
+                                                "vrf-name": "acme-65501",
+                                                "address-families": {
+                                                    "address-family": [
+                                                        {
+                                                            "af-name": "ipv4-unicast"
+                                                        }
+                                                    ]
+                                                },
+                                                "neighbors": {
+                                                    "neighbor": [
+                                                        {
+                                                            "neighbor-address": "10.201.1.2",
+                                                            "address-families": {
+                                                                "address-family": [
+                                                                    {
+                                                                        "af-name": "ipv4-unicast",
+                                                                        "route-policy": {
+                                                                            "in": "ACCEPT",
+                                                                            "out": "ACCEPT",
+                                                                            "retention": {}
+                                                                        },
+                                                                        "as-override": {}
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "remote-as": "65501",
+                                                            "description": "Customer eBGP SITE-1 [SNA-1-1] in VPN acme-65501 to 10.201.1.2",
+                                                            "password": {
+                                                                "encrypted": "045A080B0A6C1A1B5C4954"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "rd": {
+                                                    "two-byte-as": {
+                                                        "as-number": "65001",
+                                                        "index": 655011
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "mpls": {
+                        "ldp": {
+                            "address-families": {
+                                "address-family": [
+                                    {
+                                        "af-name": "ipv4"
+                                    }
+                                ]
+                            },
+                            "interfaces": {
+                                "interface": [
+                                    {
+                                        "interface-name": "GigabitEthernet0/0/0/0"
+                                    },
+                                    {
+                                        "interface-name": "GigabitEthernet0/0/0/1"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "interfaces": {
+                        "interface": [
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/0",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.0.7.1",
+                                            "netmask": "255.255.255.252"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "description": "Link to FRA-CORE-1 [GigabitEthernet0/0/0/0]",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            },
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/1",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.0.20.1",
+                                            "netmask": "255.255.255.252"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "description": "Link to STO-CORE-1 [eth1]",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            },
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/2",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            },
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/2.100",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.201.1.1",
+                                            "netmask": "255.255.255.252"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "description": "Customer VPN access SITE-1 [SNA-1-1] in VPN acme-65501",
+                                "vrf": "acme-65501",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {
+                                        "vlan-id": 100
+                                    }
+                                }
+                            },
+                            {
+                                "interface-name": "Loopback0",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.0.0.1",
+                                            "netmask": "255.255.255.255"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            }
+                        ]
+                    },
+                    "ethernet": {
+                        "egress-filter": {}
+                    },
+                    "hostname": {
+                        "system-network-name": "AMS-CORE-1"
+                    },
+                    "routing-policy": {
+                        "route-policies": {
+                            "route-policy": [
+                                {
+                                    "route-policy-name": "ACCEPT",
+                                    "rpl-route-policy": "route-policy ACCEPT\n  done\nend-policy"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "name": "FRA-CORE-1",
+                "modset_id": "9171161324580586743",
+                "config": {
+                    "address-family": {
+                        "ipv4": {
+                            "multicast": {
+                                "topologies": {
+                                    "topology": []
+                                }
+                            }
+                        },
+                        "ipv6": {
+                            "multicast": {
+                                "topologies": {
+                                    "topology": []
+                                }
+                            }
+                        }
+                    },
+                    "vrfs": {
+                        "vrf": [
+                            {
+                                "vrf-name": "acme-65501",
+                                "address-family": {
+                                    "ipv4": {
+                                        "unicast": {
+                                            "import": {
+                                                "route-target": {
+                                                    "two-byte-as-rts": {
+                                                        "two-byte-as-rt": [
+                                                            {
+                                                                "as-number": 65001,
+                                                                "index": 65501,
+                                                                "stitching": "false"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "export": {
+                                                "route-target": {
+                                                    "two-byte-as-rts": {
+                                                        "two-byte-as-rt": [
+                                                            {
+                                                                "as-number": 65001,
+                                                                "index": 65501,
+                                                                "stitching": "false"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "ipv6": {}
+                                },
+                                "mode": {},
+                                "vpn": {},
+                                "description": "Customer VPN for CUSTOMER-1",
+                                "remote-route-filtering": {},
+                                "rd": {}
+                            }
+                        ]
+                    },
+                    "selective-vrf-download": {},
+                    "vrf-groups": {
+                        "vrf-group": []
+                    },
+                    "um-router-isis-cfg:router": {
+                        "isis": {
+                            "processes": {
+                                "process": [
+                                    {
+                                        "process-id": "1",
+                                        "is-type": "level-2-only",
+                                        "nets": {
+                                            "net": [
+                                                {
+                                                    "net-id": "49.0001.0100.0000.0002.00"
+                                                }
+                                            ]
+                                        },
+                                        "address-families": {
+                                            "address-family": [
+                                                {
+                                                    "af-name": "ipv4",
+                                                    "saf-name": "unicast",
+                                                    "segment-routing": {
+                                                        "mpls": {}
+                                                    },
+                                                    "metric-style": {
+                                                        "wide": {},
+                                                        "levels": {
+                                                            "level": []
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "interfaces": {
+                                            "interface": [
+                                                {
+                                                    "interface-name": "GigabitEthernet0/0/0/0",
+                                                    "circuit-type": "level-2-only",
+                                                    "point-to-point": {},
+                                                    "bfd": {
+                                                        "fast-detect": {}
+                                                    },
+                                                    "address-families": {
+                                                        "address-family": [
+                                                            {
+                                                                "af-name": "ipv4",
+                                                                "saf-name": "unicast",
+                                                                "metric": {
+                                                                    "levels": {
+                                                                        "level": [
+                                                                            {
+                                                                                "level-id": 2,
+                                                                                "default-metric": 5000
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "prefix-sid": {}
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "interface-name": "GigabitEthernet0/0/0/1",
+                                                    "circuit-type": "level-2-only",
+                                                    "point-to-point": {},
+                                                    "bfd": {
+                                                        "fast-detect": {}
+                                                    },
+                                                    "address-families": {
+                                                        "address-family": [
+                                                            {
+                                                                "af-name": "ipv4",
+                                                                "saf-name": "unicast",
+                                                                "metric": {
+                                                                    "levels": {
+                                                                        "level": [
+                                                                            {
+                                                                                "level-id": 2,
+                                                                                "default-metric": 5000
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "prefix-sid": {}
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "interface-name": "GigabitEthernet0/0/0/2",
+                                                    "circuit-type": "level-2-only",
+                                                    "point-to-point": {},
+                                                    "bfd": {
+                                                        "fast-detect": {}
+                                                    },
+                                                    "address-families": {
+                                                        "address-family": [
+                                                            {
+                                                                "af-name": "ipv4",
+                                                                "saf-name": "unicast",
+                                                                "metric": {
+                                                                    "levels": {
+                                                                        "level": [
+                                                                            {
+                                                                                "level-id": 2,
+                                                                                "default-metric": 5000
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "prefix-sid": {}
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "interface-name": "Loopback0",
+                                                    "bfd": {
+                                                        "fast-detect": {}
+                                                    },
+                                                    "passive": {},
+                                                    "address-families": {
+                                                        "address-family": [
+                                                            {
+                                                                "af-name": "ipv4",
+                                                                "saf-name": "unicast",
+                                                                "metric": {
+                                                                    "levels": {
+                                                                        "level": []
+                                                                    }
+                                                                },
+                                                                "prefix-sid": {}
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "as-format": {},
+                    "bmp": {
+                        "servers": {
+                            "server": [],
+                            "all": {
+                                "route-monitoring": {
+                                    "bmp-modes": {
+                                        "bmp-mode": []
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "um-router-bgp-cfg:router": {
+                        "bgp": {
+                            "as": [
+                                {
+                                    "as-number": "65001",
+                                    "rpki": {
+                                        "servers": {
+                                            "server": []
+                                        },
+                                        "routes": {
+                                            "route": []
+                                        }
+                                    },
+                                    "address-families": {
+                                        "address-family": [
+                                            {
+                                                "af-name": "vpnv4-unicast"
+                                            },
+                                            {
+                                                "af-name": "vpnv6-unicast"
+                                            }
+                                        ]
+                                    },
+                                    "neighbors": {
+                                        "neighbor": [
+                                            {
+                                                "neighbor-address": "10.0.0.1",
+                                                "use": {
+                                                    "neighbor-group": "IPV4-IBGP"
+                                                },
+                                                "description": "AMS-CORE-1"
+                                            },
+                                            {
+                                                "neighbor-address": "10.0.0.3",
+                                                "use": {
+                                                    "neighbor-group": "IPV4-IBGP"
+                                                },
+                                                "description": "STO-CORE-1"
+                                            },
+                                            {
+                                                "neighbor-address": "10.0.0.4",
+                                                "use": {
+                                                    "neighbor-group": "IPV4-IBGP"
+                                                },
+                                                "description": "LJU-CORE-1"
+                                            }
+                                        ]
+                                    },
+                                    "neighbor-groups": {
+                                        "neighbor-group": [
+                                            {
+                                                "neighbor-group-name": "IPV4-IBGP",
+                                                "address-families": {
+                                                    "address-family": [
+                                                        {
+                                                            "af-name": "vpnv4-unicast"
+                                                        },
+                                                        {
+                                                            "af-name": "vpnv6-unicast"
+                                                        }
+                                                    ]
+                                                },
+                                                "remote-as": "65001",
+                                                "password": {
+                                                    "encrypted": "045209011F6C4D5B1D11001906020F053E222B267E3E270A"
+                                                },
+                                                "update-source": "Loopback0"
+                                            }
+                                        ]
+                                    },
+                                    "bgp": {
+                                        "router-id": "10.0.0.2"
+                                    },
+                                    "vrfs": {
+                                        "vrf": [
+                                            {
+                                                "vrf-name": "acme-65501",
+                                                "address-families": {
+                                                    "address-family": [
+                                                        {
+                                                            "af-name": "ipv4-unicast"
+                                                        }
+                                                    ]
+                                                },
+                                                "neighbors": {
+                                                    "neighbor": [
+                                                        {
+                                                            "neighbor-address": "10.202.1.2",
+                                                            "address-families": {
+                                                                "address-family": [
+                                                                    {
+                                                                        "af-name": "ipv4-unicast",
+                                                                        "route-policy": {
+                                                                            "in": "ACCEPT",
+                                                                            "out": "ACCEPT",
+                                                                            "retention": {}
+                                                                        },
+                                                                        "as-override": {}
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "remote-as": "65501",
+                                                            "description": "Customer eBGP SITE-2 [SNA-2-1] in VPN acme-65501 to 10.202.1.2",
+                                                            "password": {
+                                                                "encrypted": "045A080B0A6C1A1B5C4954"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "rd": {
+                                                    "two-byte-as": {
+                                                        "as-number": "65001",
+                                                        "index": 655012
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "mpls": {
+                        "ldp": {
+                            "address-families": {
+                                "address-family": [
+                                    {
+                                        "af-name": "ipv4"
+                                    }
+                                ]
+                            },
+                            "interfaces": {
+                                "interface": [
+                                    {
+                                        "interface-name": "GigabitEthernet0/0/0/0"
+                                    },
+                                    {
+                                        "interface-name": "GigabitEthernet0/0/0/1"
+                                    },
+                                    {
+                                        "interface-name": "GigabitEthernet0/0/0/2"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "interfaces": {
+                        "interface": [
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/0",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.0.7.2",
+                                            "netmask": "255.255.255.252"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "description": "Link to AMS-CORE-1 [GigabitEthernet0/0/0/0]",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            },
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/1",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.0.25.1",
+                                            "netmask": "255.255.255.252"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "description": "Link to STO-CORE-1 [eth2]",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            },
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/2",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.0.18.1",
+                                            "netmask": "255.255.255.252"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "description": "Link to LJU-CORE-1 [eth1]",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            },
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/3",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            },
+                            {
+                                "interface-name": "GigabitEthernet0/0/0/3.100",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.202.1.1",
+                                            "netmask": "255.255.255.252"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "shutdown": "false",
+                                "description": "Customer VPN access SITE-2 [SNA-2-1] in VPN acme-65501",
+                                "vrf": "acme-65501",
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {
+                                        "vlan-id": 100
+                                    }
+                                }
+                            },
+                            {
+                                "interface-name": "Loopback0",
+                                "sub-interface-type": {},
+                                "ipv4": {
+                                    "addresses": {
+                                        "address": {
+                                            "address": "10.0.0.2",
+                                            "netmask": "255.255.255.255"
+                                        },
+                                        "secondaries": {
+                                            "secondary": []
+                                        }
+                                    }
+                                },
+                                "ipv6": {},
+                                "um-interface-cfg:encapsulation": {},
+                                "um-l2-ethernet-cfg:encapsulation": {
+                                    "dot1q": {}
+                                }
+                            }
+                        ]
+                    },
+                    "ethernet": {
+                        "egress-filter": {}
+                    },
+                    "hostname": {
+                        "system-network-name": "FRA-CORE-1"
+                    },
+                    "routing-policy": {
+                        "route-policies": {
+                            "route-policy": [
+                                {
+                                    "route-policy-name": "ACCEPT",
+                                    "rpl-route-policy": "route-policy ACCEPT\n  done\nend-policy"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "name": "LJU-CORE-1",
+                "modset_id": "-2634619533265032106",
+                "config": {
+                    "configuration": {
+                        "system": {
+                            "host-name": "LJU-CORE-1"
+                        },
+                        "interfaces": {
+                            "interface": [
+                                {
+                                    "name": "eth1",
+                                    "unit": [
+                                        {
+                                            "name": "0",
+                                            "description": "Link to FRA-CORE-1 [GigabitEthernet0/0/0/2]",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.0.18.2/30"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "eth2",
+                                    "unit": [
+                                        {
+                                            "name": "0",
+                                            "description": "Link to STO-CORE-1 [eth3]",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.0.31.2/30"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "eth3",
+                                    "description": "Customer VPN access SITE-4 [SNA-4-1] in VPN acme-65501",
+                                    "unit": [
+                                        {
+                                            "name": "100",
+                                            "description": "Customer VPN access SITE-4 [SNA-4-1] in VPN acme-65501",
+                                            "vlan-id": "100",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.204.1.1/30"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "encapsulation": "flexible-ethernet-services",
+                                    "flexible-vlan-tagging": "true"
+                                },
+                                {
+                                    "name": "lo0",
+                                    "unit": [
+                                        {
+                                            "name": "0",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.0.0.4/32"
+                                                        }
+                                                    ]
+                                                },
+                                                "iso": {
+                                                    "address": [
+                                                        {
+                                                            "name": "49.0001.0100.0000.0004.00"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "routing-instances": {
+                            "instance": [
+                                {
+                                    "name": "acme-65501",
+                                    "apply-groups": [],
+                                    "apply-groups-except": [],
+                                    "instance-type": "vrf",
+                                    "interface": [
+                                        {
+                                            "name": "eth3.100"
+                                        }
+                                    ],
+                                    "route-distinguisher": {
+                                        "rd-type": "65001:655014"
+                                    },
+                                    "vrf-target": {
+                                        "community": "target:65001:65501"
+                                    },
+                                    "vrf-table-label": {},
+                                    "protocols": {
+                                        "bgp": {
+                                            "group": [
+                                                {
+                                                    "name": "customer",
+                                                    "passive": "true",
+                                                    "import": [],
+                                                    "export": [],
+                                                    "neighbor": [
+                                                        {
+                                                            "name": "10.204.1.2",
+                                                            "description": "Customer eBGP SITE-4 [SNA-4-1] in VPN acme-65501 to 10.204.1.2",
+                                                            "peer-as": "65501",
+                                                            "authentication-key": "acme-65501",
+                                                            "as-override": "true"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "groups": [],
+                        "routing-options": {
+                            "autonomous-system": {
+                                "as-number": "65001"
+                            }
+                        },
+                        "protocols": {
+                            "bgp": {
+                                "path-selection": {},
+                                "group": [
+                                    {
+                                        "name": "IPV4-IBGP",
+                                        "type": "internal",
+                                        "local-address": "10.0.0.4",
+                                        "hold-time": 90,
+                                        "family": {
+                                            "inet-vpn": {
+                                                "unicast": {
+                                                    "prefix-limit": {},
+                                                    "accepted-prefix-limit": {},
+                                                    "rib-group": {},
+                                                    "add-path": {},
+                                                    "loops": {},
+                                                    "nexthop-resolution": {},
+                                                    "graceful-restart": {
+                                                        "long-lived": {
+                                                            "restarter": {},
+                                                            "extended-route-retention": {
+                                                                "retention-policy": []
+                                                            }
+                                                        }
+                                                    },
+                                                    "output-queue-priority": {},
+                                                    "route-refresh-priority": {},
+                                                    "withdraw-priority": {}
+                                                }
+                                            },
+                                            "inet6-vpn": {
+                                                "unicast": {
+                                                    "prefix-limit": {},
+                                                    "accepted-prefix-limit": {},
+                                                    "rib-group": {},
+                                                    "add-path": {},
+                                                    "loops": {},
+                                                    "nexthop-resolution": {},
+                                                    "graceful-restart": {
+                                                        "long-lived": {
+                                                            "restarter": {},
+                                                            "extended-route-retention": {
+                                                                "retention-policy": []
+                                                            }
+                                                        }
+                                                    },
+                                                    "output-queue-priority": {},
+                                                    "route-refresh-priority": {},
+                                                    "withdraw-priority": {}
+                                                }
+                                            },
+                                            "evpn": {},
+                                            "route-target": {}
+                                        },
+                                        "authentication-key": "ibgp-authentication-key",
+                                        "export": [],
+                                        "neighbor": [
+                                            {
+                                                "name": "10.0.0.1",
+                                                "description": "AMS-CORE-1"
+                                            },
+                                            {
+                                                "name": "10.0.0.2",
+                                                "description": "FRA-CORE-1"
+                                            },
+                                            {
+                                                "name": "10.0.0.3",
+                                                "description": "STO-CORE-1"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "log-updown": "true"
+                            },
+                            "isis": {
+                                "interface": [
+                                    {
+                                        "name": "eth1",
+                                        "level": [
+                                            {
+                                                "name": 1,
+                                                "disable": "true"
+                                            },
+                                            {
+                                                "name": 2,
+                                                "metric": 5000
+                                            }
+                                        ],
+                                        "point-to-point": "true",
+                                        "family": []
+                                    },
+                                    {
+                                        "name": "eth2",
+                                        "level": [
+                                            {
+                                                "name": 1,
+                                                "disable": "true"
+                                            },
+                                            {
+                                                "name": 2,
+                                                "metric": 5000
+                                            }
+                                        ],
+                                        "point-to-point": "true",
+                                        "family": []
+                                    },
+                                    {
+                                        "name": "lo0.0",
+                                        "level": [],
+                                        "passive": {},
+                                        "family": []
+                                    }
+                                ],
+                                "level": [
+                                    {
+                                        "name": 1,
+                                        "disable": "true"
+                                    },
+                                    {
+                                        "name": 2,
+                                        "wide-metrics-only": "true"
+                                    }
+                                ],
+                                "lsp-lifetime": 65535
+                            },
+                            "ldp": {
+                                "traffic-statistics": {
+                                    "file": {}
+                                },
+                                "transport-address": {},
+                                "interface": [
+                                    {
+                                        "name": "eth1",
+                                        "transport-address": {}
+                                    },
+                                    {
+                                        "name": "eth2",
+                                        "transport-address": {}
+                                    }
+                                ]
+                            },
+                            "mpls": {
+                                "interface": [
+                                    {
+                                        "name": "eth1",
+                                        "srlg": [],
+                                        "admin-group": [],
+                                        "admin-group-extended": [],
+                                        "static": {}
+                                    },
+                                    {
+                                        "name": "eth2",
+                                        "srlg": [],
+                                        "admin-group": [],
+                                        "admin-group-extended": [],
+                                        "static": {}
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "name": "STO-CORE-1",
+                "modset_id": "-2634619533265032106",
+                "config": {
+                    "configuration": {
+                        "system": {
+                            "host-name": "STO-CORE-1"
+                        },
+                        "interfaces": {
+                            "interface": [
+                                {
+                                    "name": "eth1",
+                                    "unit": [
+                                        {
+                                            "name": "0",
+                                            "description": "Link to AMS-CORE-1 [GigabitEthernet0/0/0/1]",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.0.20.2/30"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "eth2",
+                                    "unit": [
+                                        {
+                                            "name": "0",
+                                            "description": "Link to FRA-CORE-1 [GigabitEthernet0/0/0/1]",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.0.25.2/30"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "eth3",
+                                    "unit": [
+                                        {
+                                            "name": "0",
+                                            "description": "Link to LJU-CORE-1 [eth2]",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.0.31.1/30"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "eth4",
+                                    "description": "Customer VPN access SITE-3 [SNA-3-1] in VPN acme-65501",
+                                    "unit": [
+                                        {
+                                            "name": "100",
+                                            "description": "Customer VPN access SITE-3 [SNA-3-1] in VPN acme-65501",
+                                            "vlan-id": "100",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.203.1.1/30"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "encapsulation": "flexible-ethernet-services",
+                                    "flexible-vlan-tagging": "true"
+                                },
+                                {
+                                    "name": "lo0",
+                                    "unit": [
+                                        {
+                                            "name": "0",
+                                            "family": {
+                                                "inet": {
+                                                    "address": [
+                                                        {
+                                                            "name": "10.0.0.3/32"
+                                                        }
+                                                    ]
+                                                },
+                                                "iso": {
+                                                    "address": [
+                                                        {
+                                                            "name": "49.0001.0100.0000.0003.00"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "routing-instances": {
+                            "instance": [
+                                {
+                                    "name": "acme-65501",
+                                    "apply-groups": [],
+                                    "apply-groups-except": [],
+                                    "instance-type": "vrf",
+                                    "interface": [
+                                        {
+                                            "name": "eth4.100"
+                                        }
+                                    ],
+                                    "route-distinguisher": {
+                                        "rd-type": "65001:655013"
+                                    },
+                                    "vrf-target": {
+                                        "community": "target:65001:65501"
+                                    },
+                                    "vrf-table-label": {},
+                                    "protocols": {
+                                        "bgp": {
+                                            "group": [
+                                                {
+                                                    "name": "customer",
+                                                    "passive": "true",
+                                                    "import": [],
+                                                    "export": [],
+                                                    "neighbor": [
+                                                        {
+                                                            "name": "10.203.1.2",
+                                                            "description": "Customer eBGP SITE-3 [SNA-3-1] in VPN acme-65501 to 10.203.1.2",
+                                                            "peer-as": "65501",
+                                                            "authentication-key": "acme-65501",
+                                                            "as-override": "true"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "groups": [],
+                        "routing-options": {
+                            "autonomous-system": {
+                                "as-number": "65001"
+                            }
+                        },
+                        "protocols": {
+                            "bgp": {
+                                "path-selection": {},
+                                "group": [
+                                    {
+                                        "name": "IPV4-IBGP",
+                                        "type": "internal",
+                                        "local-address": "10.0.0.3",
+                                        "hold-time": 90,
+                                        "family": {
+                                            "inet-vpn": {
+                                                "unicast": {
+                                                    "prefix-limit": {},
+                                                    "accepted-prefix-limit": {},
+                                                    "rib-group": {},
+                                                    "add-path": {},
+                                                    "loops": {},
+                                                    "nexthop-resolution": {},
+                                                    "graceful-restart": {
+                                                        "long-lived": {
+                                                            "restarter": {},
+                                                            "extended-route-retention": {
+                                                                "retention-policy": []
+                                                            }
+                                                        }
+                                                    },
+                                                    "output-queue-priority": {},
+                                                    "route-refresh-priority": {},
+                                                    "withdraw-priority": {}
+                                                }
+                                            },
+                                            "inet6-vpn": {
+                                                "unicast": {
+                                                    "prefix-limit": {},
+                                                    "accepted-prefix-limit": {},
+                                                    "rib-group": {},
+                                                    "add-path": {},
+                                                    "loops": {},
+                                                    "nexthop-resolution": {},
+                                                    "graceful-restart": {
+                                                        "long-lived": {
+                                                            "restarter": {},
+                                                            "extended-route-retention": {
+                                                                "retention-policy": []
+                                                            }
+                                                        }
+                                                    },
+                                                    "output-queue-priority": {},
+                                                    "route-refresh-priority": {},
+                                                    "withdraw-priority": {}
+                                                }
+                                            },
+                                            "evpn": {},
+                                            "route-target": {}
+                                        },
+                                        "authentication-key": "ibgp-authentication-key",
+                                        "export": [],
+                                        "neighbor": [
+                                            {
+                                                "name": "10.0.0.1",
+                                                "description": "AMS-CORE-1"
+                                            },
+                                            {
+                                                "name": "10.0.0.2",
+                                                "description": "FRA-CORE-1"
+                                            },
+                                            {
+                                                "name": "10.0.0.4",
+                                                "description": "LJU-CORE-1"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "log-updown": "true"
+                            },
+                            "isis": {
+                                "interface": [
+                                    {
+                                        "name": "eth1",
+                                        "level": [
+                                            {
+                                                "name": 1,
+                                                "disable": "true"
+                                            },
+                                            {
+                                                "name": 2,
+                                                "metric": 5000
+                                            }
+                                        ],
+                                        "point-to-point": "true",
+                                        "family": []
+                                    },
+                                    {
+                                        "name": "eth2",
+                                        "level": [
+                                            {
+                                                "name": 1,
+                                                "disable": "true"
+                                            },
+                                            {
+                                                "name": 2,
+                                                "metric": 5000
+                                            }
+                                        ],
+                                        "point-to-point": "true",
+                                        "family": []
+                                    },
+                                    {
+                                        "name": "eth3",
+                                        "level": [
+                                            {
+                                                "name": 1,
+                                                "disable": "true"
+                                            },
+                                            {
+                                                "name": 2,
+                                                "metric": 5000
+                                            }
+                                        ],
+                                        "point-to-point": "true",
+                                        "family": []
+                                    },
+                                    {
+                                        "name": "lo0.0",
+                                        "level": [],
+                                        "passive": {},
+                                        "family": []
+                                    }
+                                ],
+                                "level": [
+                                    {
+                                        "name": 1,
+                                        "disable": "true"
+                                    },
+                                    {
+                                        "name": 2,
+                                        "wide-metrics-only": "true"
+                                    }
+                                ],
+                                "lsp-lifetime": 65535
+                            },
+                            "ldp": {
+                                "traffic-statistics": {
+                                    "file": {}
+                                },
+                                "transport-address": {},
+                                "interface": [
+                                    {
+                                        "name": "eth1",
+                                        "transport-address": {}
+                                    },
+                                    {
+                                        "name": "eth2",
+                                        "transport-address": {}
+                                    },
+                                    {
+                                        "name": "eth3",
+                                        "transport-address": {}
+                                    }
+                                ]
+                            },
+                            "mpls": {
+                                "interface": [
+                                    {
+                                        "name": "eth1",
+                                        "srlg": [],
+                                        "admin-group": [],
+                                        "admin-group-extended": [],
+                                        "static": {}
+                                    },
+                                    {
+                                        "name": "eth2",
+                                        "srlg": [],
+                                        "admin-group": [],
+                                        "admin-group-extended": [],
+                                        "static": {}
+                                    },
+                                    {
+                                        "name": "eth3",
+                                        "srlg": [],
+                                        "admin-group": [],
+                                        "admin-group-extended": [],
+                                        "static": {}
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
The l3vpn test includes the complete network configuration. We track the results in all output formats: XML, JSON and gdata internal.

This is a safety measure to ensure the configuration output by the application remains consistent throughout refactoring the yang library.