### PR TITLE
Update acton-yang

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/8d2eebaf75f88318f24ba41c4646d302b84c362c.zip",
-            "hash": "1220eeb19eaf597e80718bb401ca2483118aba57f70ccef0b998ab6add429d824c12"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/2eb19858c2a0af90fac7abcd15a89f9ccceba237.zip",
+            "hash": "12202f470b458ebbdbf81bacd9be916b947b5905e3e37ac03b58666de46c4d3a8e0f"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/34cfdad95bdc6241b9e2bf54b43e880c73e93410.zip",
-            "hash": "1220106e9dd8b6c904a7f6e53ae6775da1b5d3fbe06f7ae1fcbd49bb86070372ef46"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/1944135ef3b83abeb7a7be751212799d13da4296.zip",
+            "hash": "12205b8649445660fe9e7c898c3eb1c52d20888bd1ceba92203c07858be9a06638d0"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/8d2eebaf75f88318f24ba41c4646d302b84c362c.zip",
-            "hash": "1220eeb19eaf597e80718bb401ca2483118aba57f70ccef0b998ab6add429d824c12"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/2eb19858c2a0af90fac7abcd15a89f9ccceba237.zip",
+            "hash": "12202f470b458ebbdbf81bacd9be916b947b5905e3e37ac03b58666de46c4d3a8e0f"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/34cfdad95bdc6241b9e2bf54b43e880c73e93410.zip",
-            "hash": "1220106e9dd8b6c904a7f6e53ae6775da1b5d3fbe06f7ae1fcbd49bb86070372ef46"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/1944135ef3b83abeb7a7be751212799d13da4296.zip",
+            "hash": "12205b8649445660fe9e7c898c3eb1c52d20888bd1ceba92203c07858be9a06638d0"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/src/respnet/layers/y_0.act
+++ b/src/respnet/layers/y_0.act
@@ -178,7 +178,7 @@ mut def from_json_netinfra__netinfra__router_element(jd: dict[str, ?value]) -> y
     child_mock = jd.get('mock')
     if child_mock is not None:
         children['mock'] = from_json_netinfra__netinfra__router__mock(child_mock)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_netinfra__netinfra__router(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -351,7 +351,7 @@ mut def from_json_netinfra__netinfra__backbone_link_element(jd: dict[str, ?value
     child_right_interface = jd.get('right-interface')
     if child_right_interface is not None:
         children['right-interface'] = from_json_netinfra__netinfra__backbone_link__right_interface(child_right_interface)
-    return yang.gdata.Container(children, [str(child_left_router if child_left_router is not None else ''), str(child_left_interface if child_left_interface is not None else ''), str(child_right_router if child_right_router is not None else ''), str(child_right_interface if child_right_interface is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_left_router), yang.gdata.yang_str(child_left_interface), yang.gdata.yang_str(child_right_router), yang.gdata.yang_str(child_right_interface)])
 
 mut def from_json_netinfra__netinfra__backbone_link(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -541,7 +541,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier__id(child_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -669,7 +669,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier__id(child_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -797,7 +797,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier__id(child_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -925,7 +925,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier__id(child_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1359,7 +1359,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_ac
     child_address_translation = jd.get('address-translation')
     if child_address_translation is not None and isinstance(child_address_translation, dict):
         children['address-translation'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(child_address_translation)
-    return yang.gdata.Container(children, [str(child_cloud_identifier if child_cloud_identifier is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_cloud_identifier)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1716,7 +1716,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
     child_group_end = jd.get('group-end')
     if child_group_end is not None:
         children['group-end'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_end(child_group_end)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1922,7 +1922,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
     child_groups = jd.get('groups')
     if child_groups is not None and isinstance(child_groups, dict):
         children['groups'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(child_groups)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2366,7 +2366,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet
     child_local_sites_role = jd.get('local-sites-role')
     if child_local_sites_role is not None:
         children['local-sites-role'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__local_sites_role(child_local_sites_role)
-    return yang.gdata.Container(children, [str(child_vpn_id if child_vpn_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2602,7 +2602,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(j
     child_extranet_vpns = jd.get('extranet-vpns')
     if child_extranet_vpns is not None and isinstance(child_extranet_vpns, dict):
         children['extranet-vpns'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(child_extranet_vpns)
-    return yang.gdata.Container(children, [str(child_vpn_id if child_vpn_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2855,7 +2855,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_el
     child_country_code = jd.get('country-code')
     if child_country_code is not None:
         children['country-code'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__country_code(child_country_code)
-    return yang.gdata.Container(children, [str(child_location_id if child_location_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_location_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3123,7 +3123,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_elemen
     child_management = jd.get('management')
     if child_management is not None and isinstance(child_management, dict):
         children['management'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(child_management)
-    return yang.gdata.Container(children, [str(child_device_id if child_device_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_device_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3302,7 +3302,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups
     child_group_id = jd.get('group-id')
     if child_group_id is not None:
         children['group-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group__group_id(child_group_id)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3624,7 +3624,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
     child_ipv6_lan_prefix = jd.get('ipv6-lan-prefix')
     if child_ipv6_lan_prefix is not None and isinstance(child_ipv6_lan_prefix, list):
         children['ipv6-lan-prefix'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv6_lan_prefix(child_ipv6_lan_prefix)
-    return yang.gdata.Container(children, [str(child_type if child_type is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3816,7 +3816,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
     child_site_role = jd.get('site-role')
     if child_site_role is not None:
         children['site-role'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__site_role(child_site_role)
-    return yang.gdata.Container(children, [str(child_vpn_id if child_vpn_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3961,7 +3961,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
     child_vpn = jd.get('vpn')
     if child_vpn is not None and isinstance(child_vpn, list):
         children['vpn'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(child_vpn)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -4096,7 +4096,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
     child_entries = jd.get('entries')
     if child_entries is not None and isinstance(child_entries, list):
         children['entries'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(child_entries)
-    return yang.gdata.Container(children, [str(child_vpn_policy_id if child_vpn_policy_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_policy_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -4291,7 +4291,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__addres
     child_maximum_routes = jd.get('maximum-routes')
     if child_maximum_routes is not None:
         children['maximum-routes'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__maximum_routes(child_maximum_routes)
-    return yang.gdata.Container(children, [str(child_af if child_af is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -5087,7 +5087,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
     child_target_class_id = jd.get('target-class-id')
     if child_target_class_id is not None:
         children['target-class-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__target_class_id(child_target_class_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -5523,7 +5523,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_prof
     child_bandwidth = jd.get('bandwidth')
     if child_bandwidth is not None and isinstance(child_bandwidth, dict):
         children['bandwidth'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(child_bandwidth)
-    return yang.gdata.Container(children, [str(child_class_id if child_class_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_class_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -6172,7 +6172,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     child_metric = jd.get('metric')
     if child_metric is not None:
         children['metric'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(child_metric)
-    return yang.gdata.Container(children, [str(child_target_site if child_target_site is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_target_site)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -6522,7 +6522,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     child_lan_tag = jd.get('lan-tag')
     if child_lan_tag is not None:
         children['lan-tag'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(child_lan_tag)
-    return yang.gdata.Container(children, [str(child_lan if child_lan is not None else ''), str(child_next_hop if child_next_hop is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -6678,7 +6678,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     child_lan_tag = jd.get('lan-tag')
     if child_lan_tag is not None:
         children['lan-tag'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(child_lan_tag)
-    return yang.gdata.Container(children, [str(child_lan if child_lan is not None else ''), str(child_next_hop if child_next_hop is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -7093,7 +7093,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     child_vrrp = jd.get('vrrp')
     if child_vrrp is not None and isinstance(child_vrrp, dict):
         children['vrrp'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(child_vrrp)
-    return yang.gdata.Container(children, [str(child_type if child_type is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -7284,7 +7284,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_group_id = jd.get('group-id')
     if child_group_id is not None:
         children['group-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group__group_id(child_group_id)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -7466,7 +7466,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_group_id = jd.get('group-id')
     if child_group_id is not None:
         children['group-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group__group_id(child_group_id)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -7678,7 +7678,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_target = jd.get('target')
     if child_target is not None and isinstance(child_target, dict):
         children['target'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(child_target)
-    return yang.gdata.Container(children, [str(child_constraint_type if child_constraint_type is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_constraint_type)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -8100,7 +8100,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_end_address = jd.get('end-address')
     if child_end_address is not None:
         children['end-address'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__end_address(child_end_address)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -8688,7 +8688,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_end_address = jd.get('end-address')
     if child_end_address is not None:
         children['end-address'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__end_address(child_end_address)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -10071,7 +10071,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_target_class_id = jd.get('target-class-id')
     if child_target_class_id is not None:
         children['target-class-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__target_class_id(child_target_class_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -10507,7 +10507,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_bandwidth = jd.get('bandwidth')
     if child_bandwidth is not None and isinstance(child_bandwidth, dict):
         children['bandwidth'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(child_bandwidth)
-    return yang.gdata.Container(children, [str(child_class_id if child_class_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_class_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -11133,7 +11133,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_metric = jd.get('metric')
     if child_metric is not None:
         children['metric'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(child_metric)
-    return yang.gdata.Container(children, [str(child_target_site if child_target_site is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_target_site)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -11483,7 +11483,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_lan_tag = jd.get('lan-tag')
     if child_lan_tag is not None:
         children['lan-tag'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(child_lan_tag)
-    return yang.gdata.Container(children, [str(child_lan if child_lan is not None else ''), str(child_next_hop if child_next_hop is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -11639,7 +11639,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_lan_tag = jd.get('lan-tag')
     if child_lan_tag is not None:
         children['lan-tag'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(child_lan_tag)
-    return yang.gdata.Container(children, [str(child_lan if child_lan is not None else ''), str(child_next_hop if child_next_hop is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -12054,7 +12054,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_vrrp = jd.get('vrrp')
     if child_vrrp is not None and isinstance(child_vrrp, dict):
         children['vrrp'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(child_vrrp)
-    return yang.gdata.Container(children, [str(child_type if child_type is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -12472,7 +12472,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_vpn_attachment = jd.get('vpn-attachment')
     if child_vpn_attachment is not None and isinstance(child_vpn_attachment, dict):
         children['vpn-attachment'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(child_vpn_attachment)
-    return yang.gdata.Container(children, [str(child_site_network_access_id if child_site_network_access_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_site_network_access_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -12788,7 +12788,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(jd: dict[str, ?
     child_site_network_accesses = jd.get('site-network-accesses')
     if child_site_network_accesses is not None and isinstance(child_site_network_accesses, dict):
         children['site-network-accesses'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(child_site_network_accesses)
-    return yang.gdata.Container(children, [str(child_site_id if child_site_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_site_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/src/respnet/layers/y_0_loose.act
+++ b/src/respnet/layers/y_0_loose.act
@@ -178,7 +178,7 @@ mut def from_json_netinfra__netinfra__router_element(jd: dict[str, ?value]) -> y
     child_mock = jd.get('mock')
     if child_mock is not None:
         children['mock'] = from_json_netinfra__netinfra__router__mock(child_mock)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_netinfra__netinfra__router(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -351,7 +351,7 @@ mut def from_json_netinfra__netinfra__backbone_link_element(jd: dict[str, ?value
     child_right_interface = jd.get('right-interface')
     if child_right_interface is not None:
         children['right-interface'] = from_json_netinfra__netinfra__backbone_link__right_interface(child_right_interface)
-    return yang.gdata.Container(children, [str(child_left_router if child_left_router is not None else ''), str(child_left_interface if child_left_interface is not None else ''), str(child_right_router if child_right_router is not None else ''), str(child_right_interface if child_right_interface is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_left_router), yang.gdata.yang_str(child_left_interface), yang.gdata.yang_str(child_right_router), yang.gdata.yang_str(child_right_interface)])
 
 mut def from_json_netinfra__netinfra__backbone_link(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -541,7 +541,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier__id(child_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -669,7 +669,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier__id(child_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -797,7 +797,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier__id(child_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -925,7 +925,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier__id(child_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1359,7 +1359,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_ac
     child_address_translation = jd.get('address-translation')
     if child_address_translation is not None and isinstance(child_address_translation, dict):
         children['address-translation'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(child_address_translation)
-    return yang.gdata.Container(children, [str(child_cloud_identifier if child_cloud_identifier is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_cloud_identifier)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1716,7 +1716,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
     child_group_end = jd.get('group-end')
     if child_group_end is not None:
         children['group-end'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_end(child_group_end)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1922,7 +1922,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
     child_groups = jd.get('groups')
     if child_groups is not None and isinstance(child_groups, dict):
         children['groups'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(child_groups)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2366,7 +2366,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet
     child_local_sites_role = jd.get('local-sites-role')
     if child_local_sites_role is not None:
         children['local-sites-role'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__local_sites_role(child_local_sites_role)
-    return yang.gdata.Container(children, [str(child_vpn_id if child_vpn_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2602,7 +2602,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(j
     child_extranet_vpns = jd.get('extranet-vpns')
     if child_extranet_vpns is not None and isinstance(child_extranet_vpns, dict):
         children['extranet-vpns'] = from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(child_extranet_vpns)
-    return yang.gdata.Container(children, [str(child_vpn_id if child_vpn_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2855,7 +2855,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_el
     child_country_code = jd.get('country-code')
     if child_country_code is not None:
         children['country-code'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__country_code(child_country_code)
-    return yang.gdata.Container(children, [str(child_location_id if child_location_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_location_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3123,7 +3123,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_elemen
     child_management = jd.get('management')
     if child_management is not None and isinstance(child_management, dict):
         children['management'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(child_management)
-    return yang.gdata.Container(children, [str(child_device_id if child_device_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_device_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3302,7 +3302,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups
     child_group_id = jd.get('group-id')
     if child_group_id is not None:
         children['group-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group__group_id(child_group_id)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3624,7 +3624,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
     child_ipv6_lan_prefix = jd.get('ipv6-lan-prefix')
     if child_ipv6_lan_prefix is not None and isinstance(child_ipv6_lan_prefix, list):
         children['ipv6-lan-prefix'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv6_lan_prefix(child_ipv6_lan_prefix)
-    return yang.gdata.Container(children, [str(child_type if child_type is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3816,7 +3816,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
     child_site_role = jd.get('site-role')
     if child_site_role is not None:
         children['site-role'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__site_role(child_site_role)
-    return yang.gdata.Container(children, [str(child_vpn_id if child_vpn_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -3961,7 +3961,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
     child_vpn = jd.get('vpn')
     if child_vpn is not None and isinstance(child_vpn, list):
         children['vpn'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(child_vpn)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -4096,7 +4096,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
     child_entries = jd.get('entries')
     if child_entries is not None and isinstance(child_entries, list):
         children['entries'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(child_entries)
-    return yang.gdata.Container(children, [str(child_vpn_policy_id if child_vpn_policy_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_policy_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -4291,7 +4291,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__addres
     child_maximum_routes = jd.get('maximum-routes')
     if child_maximum_routes is not None:
         children['maximum-routes'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__maximum_routes(child_maximum_routes)
-    return yang.gdata.Container(children, [str(child_af if child_af is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -5087,7 +5087,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
     child_target_class_id = jd.get('target-class-id')
     if child_target_class_id is not None:
         children['target-class-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__target_class_id(child_target_class_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -5523,7 +5523,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_prof
     child_bandwidth = jd.get('bandwidth')
     if child_bandwidth is not None and isinstance(child_bandwidth, dict):
         children['bandwidth'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(child_bandwidth)
-    return yang.gdata.Container(children, [str(child_class_id if child_class_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_class_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -6172,7 +6172,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     child_metric = jd.get('metric')
     if child_metric is not None:
         children['metric'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(child_metric)
-    return yang.gdata.Container(children, [str(child_target_site if child_target_site is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_target_site)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -6522,7 +6522,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     child_lan_tag = jd.get('lan-tag')
     if child_lan_tag is not None:
         children['lan-tag'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(child_lan_tag)
-    return yang.gdata.Container(children, [str(child_lan if child_lan is not None else ''), str(child_next_hop if child_next_hop is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -6678,7 +6678,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     child_lan_tag = jd.get('lan-tag')
     if child_lan_tag is not None:
         children['lan-tag'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(child_lan_tag)
-    return yang.gdata.Container(children, [str(child_lan if child_lan is not None else ''), str(child_next_hop if child_next_hop is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -7093,7 +7093,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     child_vrrp = jd.get('vrrp')
     if child_vrrp is not None and isinstance(child_vrrp, dict):
         children['vrrp'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(child_vrrp)
-    return yang.gdata.Container(children, [str(child_type if child_type is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -7284,7 +7284,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_group_id = jd.get('group-id')
     if child_group_id is not None:
         children['group-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group__group_id(child_group_id)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -7466,7 +7466,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_group_id = jd.get('group-id')
     if child_group_id is not None:
         children['group-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group__group_id(child_group_id)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -7678,7 +7678,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_target = jd.get('target')
     if child_target is not None and isinstance(child_target, dict):
         children['target'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(child_target)
-    return yang.gdata.Container(children, [str(child_constraint_type if child_constraint_type is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_constraint_type)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -8100,7 +8100,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_end_address = jd.get('end-address')
     if child_end_address is not None:
         children['end-address'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__end_address(child_end_address)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -8688,7 +8688,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_end_address = jd.get('end-address')
     if child_end_address is not None:
         children['end-address'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__end_address(child_end_address)
-    return yang.gdata.Container(children, [str(child_group_id if child_group_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -10071,7 +10071,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_target_class_id = jd.get('target-class-id')
     if child_target_class_id is not None:
         children['target-class-id'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__target_class_id(child_target_class_id)
-    return yang.gdata.Container(children, [str(child_id if child_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -10507,7 +10507,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_bandwidth = jd.get('bandwidth')
     if child_bandwidth is not None and isinstance(child_bandwidth, dict):
         children['bandwidth'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(child_bandwidth)
-    return yang.gdata.Container(children, [str(child_class_id if child_class_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_class_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -11133,7 +11133,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_metric = jd.get('metric')
     if child_metric is not None:
         children['metric'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(child_metric)
-    return yang.gdata.Container(children, [str(child_target_site if child_target_site is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_target_site)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -11483,7 +11483,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_lan_tag = jd.get('lan-tag')
     if child_lan_tag is not None:
         children['lan-tag'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(child_lan_tag)
-    return yang.gdata.Container(children, [str(child_lan if child_lan is not None else ''), str(child_next_hop if child_next_hop is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -11639,7 +11639,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_lan_tag = jd.get('lan-tag')
     if child_lan_tag is not None:
         children['lan-tag'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(child_lan_tag)
-    return yang.gdata.Container(children, [str(child_lan if child_lan is not None else ''), str(child_next_hop if child_next_hop is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -12054,7 +12054,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_vrrp = jd.get('vrrp')
     if child_vrrp is not None and isinstance(child_vrrp, dict):
         children['vrrp'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(child_vrrp)
-    return yang.gdata.Container(children, [str(child_type if child_type is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -12472,7 +12472,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     child_vpn_attachment = jd.get('vpn-attachment')
     if child_vpn_attachment is not None and isinstance(child_vpn_attachment, dict):
         children['vpn-attachment'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(child_vpn_attachment)
-    return yang.gdata.Container(children, [str(child_site_network_access_id if child_site_network_access_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_site_network_access_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -12788,7 +12788,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(jd: dict[str, ?
     child_site_network_accesses = jd.get('site-network-accesses')
     if child_site_network_accesses is not None and isinstance(child_site_network_accesses, dict):
         children['site-network-accesses'] = from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(child_site_network_accesses)
-    return yang.gdata.Container(children, [str(child_site_id if child_site_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_site_id)])
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/src/respnet/layers/y_1.act
+++ b/src/respnet/layers/y_1.act
@@ -228,7 +228,7 @@ mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf_element(jd: dict[s
     child_ebgp_customer_address = jd.get('ebgp-customer-address')
     if child_ebgp_customer_address is not None and isinstance(child_ebgp_customer_address, list):
         children['ebgp-customer-address'] = from_json_netinfra_inter__netinfra__router__l3vpn_vrf__ebgp_customer_address(child_ebgp_customer_address)
-    return yang.gdata.Container(children, [str(child_vpn_id if child_vpn_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
 
 mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -403,7 +403,7 @@ mut def from_json_netinfra_inter__netinfra__router_element(jd: dict[str, ?value]
     child_l3vpn_vrf = jd.get('l3vpn-vrf')
     if child_l3vpn_vrf is not None and isinstance(child_l3vpn_vrf, list):
         children['l3vpn-vrf'] = from_json_netinfra_inter__netinfra__router__l3vpn_vrf(child_l3vpn_vrf)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_netinfra_inter__netinfra__router(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -576,7 +576,7 @@ mut def from_json_netinfra_inter__netinfra__backbone_link_element(jd: dict[str, 
     child_right_interface = jd.get('right-interface')
     if child_right_interface is not None:
         children['right-interface'] = from_json_netinfra_inter__netinfra__backbone_link__right_interface(child_right_interface)
-    return yang.gdata.Container(children, [str(child_left_router if child_left_router is not None else ''), str(child_left_interface if child_left_interface is not None else ''), str(child_right_router if child_right_router is not None else ''), str(child_right_interface if child_right_interface is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_left_router), yang.gdata.yang_str(child_left_interface), yang.gdata.yang_str(child_right_router), yang.gdata.yang_str(child_right_interface)])
 
 mut def from_json_netinfra_inter__netinfra__backbone_link(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -723,7 +723,7 @@ mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__router_element(jd: di
     child_ipv4_address = jd.get('ipv4-address')
     if child_ipv4_address is not None:
         children['ipv4-address'] = from_json_netinfra_inter__netinfra__ibgp_fullmesh__router__ipv4_address(child_ipv4_address)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__router(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -868,7 +868,7 @@ mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh_element(jd: dict[str, 
     child_router = jd.get('router')
     if child_router is not None and isinstance(child_router, list):
         children['router'] = from_json_netinfra_inter__netinfra__ibgp_fullmesh__router(child_router)
-    return yang.gdata.Container(children, [str(child_asn if child_asn is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_asn)])
 
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1223,7 +1223,7 @@ mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint_element(jd: dict[str, ?va
     child_bgp = jd.get('bgp')
     if child_bgp is not None and isinstance(child_bgp, dict):
         children['bgp'] = from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(child_bgp)
-    return yang.gdata.Container(children, [str(child_device if child_device is not None else ''), str(child_interface if child_interface is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_device), yang.gdata.yang_str(child_interface)])
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1368,7 +1368,7 @@ mut def from_json_l3vpn_inter__l3vpns__l3vpn_element(jd: dict[str, ?value]) -> y
     child_endpoint = jd.get('endpoint')
     if child_endpoint is not None and isinstance(child_endpoint, list):
         children['endpoint'] = from_json_l3vpn_inter__l3vpns__l3vpn__endpoint(child_endpoint)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/src/respnet/layers/y_1_loose.act
+++ b/src/respnet/layers/y_1_loose.act
@@ -228,7 +228,7 @@ mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf_element(jd: dict[s
     child_ebgp_customer_address = jd.get('ebgp-customer-address')
     if child_ebgp_customer_address is not None and isinstance(child_ebgp_customer_address, list):
         children['ebgp-customer-address'] = from_json_netinfra_inter__netinfra__router__l3vpn_vrf__ebgp_customer_address(child_ebgp_customer_address)
-    return yang.gdata.Container(children, [str(child_vpn_id if child_vpn_id is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
 
 mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -403,7 +403,7 @@ mut def from_json_netinfra_inter__netinfra__router_element(jd: dict[str, ?value]
     child_l3vpn_vrf = jd.get('l3vpn-vrf')
     if child_l3vpn_vrf is not None and isinstance(child_l3vpn_vrf, list):
         children['l3vpn-vrf'] = from_json_netinfra_inter__netinfra__router__l3vpn_vrf(child_l3vpn_vrf)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_netinfra_inter__netinfra__router(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -576,7 +576,7 @@ mut def from_json_netinfra_inter__netinfra__backbone_link_element(jd: dict[str, 
     child_right_interface = jd.get('right-interface')
     if child_right_interface is not None:
         children['right-interface'] = from_json_netinfra_inter__netinfra__backbone_link__right_interface(child_right_interface)
-    return yang.gdata.Container(children, [str(child_left_router if child_left_router is not None else ''), str(child_left_interface if child_left_interface is not None else ''), str(child_right_router if child_right_router is not None else ''), str(child_right_interface if child_right_interface is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_left_router), yang.gdata.yang_str(child_left_interface), yang.gdata.yang_str(child_right_router), yang.gdata.yang_str(child_right_interface)])
 
 mut def from_json_netinfra_inter__netinfra__backbone_link(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -723,7 +723,7 @@ mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__router_element(jd: di
     child_ipv4_address = jd.get('ipv4-address')
     if child_ipv4_address is not None:
         children['ipv4-address'] = from_json_netinfra_inter__netinfra__ibgp_fullmesh__router__ipv4_address(child_ipv4_address)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__router(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -868,7 +868,7 @@ mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh_element(jd: dict[str, 
     child_router = jd.get('router')
     if child_router is not None and isinstance(child_router, list):
         children['router'] = from_json_netinfra_inter__netinfra__ibgp_fullmesh__router(child_router)
-    return yang.gdata.Container(children, [str(child_asn if child_asn is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_asn)])
 
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1223,7 +1223,7 @@ mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint_element(jd: dict[str, ?va
     child_bgp = jd.get('bgp')
     if child_bgp is not None and isinstance(child_bgp, dict):
         children['bgp'] = from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(child_bgp)
-    return yang.gdata.Container(children, [str(child_device if child_device is not None else ''), str(child_interface if child_interface is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_device), yang.gdata.yang_str(child_interface)])
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1368,7 +1368,7 @@ mut def from_json_l3vpn_inter__l3vpns__l3vpn_element(jd: dict[str, ?value]) -> y
     child_endpoint = jd.get('endpoint')
     if child_endpoint is not None and isinstance(child_endpoint, list):
         children['endpoint'] = from_json_l3vpn_inter__l3vpns__l3vpn__endpoint(child_endpoint)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/src/respnet/layers/y_2.act
+++ b/src/respnet/layers/y_2.act
@@ -174,7 +174,7 @@ mut def from_json_orchestron_rfs__device__address__initial_credentials_element(j
     child_key = jd.get('key')
     if child_key is not None:
         children['key'] = from_json_orchestron_rfs__device__address__initial_credentials__key(child_key)
-    return yang.gdata.Container(children, [str(child_username if child_username is not None else ''), str(child_password if child_password is not None else ''), str(child_key if child_key is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_username), yang.gdata.yang_str(child_password), yang.gdata.yang_str(child_key)])
 
 mut def from_json_orchestron_rfs__device__address__initial_credentials(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -329,7 +329,7 @@ mut def from_json_orchestron_rfs__device__address_element(jd: dict[str, ?value])
     child_initial_credentials = jd.get('initial-credentials')
     if child_initial_credentials is not None and isinstance(child_initial_credentials, list):
         children['initial-credentials'] = from_json_orchestron_rfs__device__address__initial_credentials(child_initial_credentials)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__device__address(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -476,7 +476,7 @@ mut def from_json_orchestron_rfs__device__credentials__key_element(jd: dict[str,
     child_private_key = jd.get('private-key')
     if child_private_key is not None:
         children['private-key'] = from_json_orchestron_rfs__device__credentials__key__private_key(child_private_key)
-    return yang.gdata.Container(children, [str(child_key if child_key is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key)])
 
 mut def from_json_orchestron_rfs__device__credentials__key(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -705,7 +705,7 @@ mut def from_json_orchestron_rfs__device__initial_credentials_element(jd: dict[s
     child_key = jd.get('key')
     if child_key is not None:
         children['key'] = from_json_orchestron_rfs__device__initial_credentials__key(child_key)
-    return yang.gdata.Container(children, [str(child_username if child_username is not None else ''), str(child_password if child_password is not None else ''), str(child_key if child_key is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_username), yang.gdata.yang_str(child_password), yang.gdata.yang_str(child_key)])
 
 mut def from_json_orchestron_rfs__device__initial_credentials(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -873,7 +873,7 @@ mut def from_json_orchestron_rfs__device__mock__module_element(jd: dict[str, ?va
     child_feature = jd.get('feature')
     if child_feature is not None and isinstance(child_feature, list):
         children['feature'] = from_json_orchestron_rfs__device__mock__module__feature(child_feature)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__device__mock__module(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1117,7 +1117,7 @@ mut def from_json_orchestron_rfs__device_element(jd: dict[str, ?value]) -> yang.
     child_mock = jd.get('mock')
     if child_mock is not None and isinstance(child_mock, dict):
         children['mock'] = from_json_orchestron_rfs__device__mock(child_mock)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__device(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1300,7 +1300,7 @@ mut def from_json_orchestron_rfs__rfs__base_config_element(jd: dict[str, ?value]
     child_ibgp_authentication_key = jd.get('ibgp-authentication-key')
     if child_ibgp_authentication_key is not None:
         children['ibgp-authentication-key'] = from_json_orchestron_rfs__rfs__base_config__ibgp_authentication_key(child_ibgp_authentication_key)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs__base_config(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1556,7 +1556,7 @@ mut def from_json_orchestron_rfs__rfs__backbone_interface_element(jd: dict[str, 
     child_remote = jd.get('remote')
     if child_remote is not None and isinstance(child_remote, dict):
         children['remote'] = from_json_orchestron_rfs__rfs__backbone_interface__remote(child_remote)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs__backbone_interface(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1710,7 +1710,7 @@ mut def from_json_orchestron_rfs__rfs__ibgp_neighbor_element(jd: dict[str, ?valu
     child_description = jd.get('description')
     if child_description is not None:
         children['description'] = from_json_orchestron_rfs__rfs__ibgp_neighbor__description(child_description)
-    return yang.gdata.Container(children, [str(child_address if child_address is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_address)])
 
 mut def from_json_orchestron_rfs__rfs__ibgp_neighbor(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1890,7 +1890,7 @@ mut def from_json_orchestron_rfs__rfs__vrf_element(jd: dict[str, ?value]) -> yan
     child_asn = jd.get('asn')
     if child_asn is not None:
         children['asn'] = from_json_orchestron_rfs__rfs__vrf__asn(child_asn)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs__vrf(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2070,7 +2070,7 @@ mut def from_json_orchestron_rfs__rfs__vrf_interface_element(jd: dict[str, ?valu
     child_ipv4_prefix_length = jd.get('ipv4-prefix-length')
     if child_ipv4_prefix_length is not None:
         children['ipv4-prefix-length'] = from_json_orchestron_rfs__rfs__vrf_interface__ipv4_prefix_length(child_ipv4_prefix_length)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs__vrf_interface(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2265,7 +2265,7 @@ mut def from_json_orchestron_rfs__rfs__ebgp_customer_element(jd: dict[str, ?valu
     child_authentication_key = jd.get('authentication-key')
     if child_authentication_key is not None:
         children['authentication-key'] = from_json_orchestron_rfs__rfs__ebgp_customer__authentication_key(child_authentication_key)
-    return yang.gdata.Container(children, [str(child_vrf if child_vrf is not None else ''), str(child_address if child_address is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vrf), yang.gdata.yang_str(child_address)])
 
 mut def from_json_orchestron_rfs__rfs__ebgp_customer(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2450,7 +2450,7 @@ mut def from_json_orchestron_rfs__rfs_element(jd: dict[str, ?value]) -> yang.gda
     child_ebgp_customer = jd.get('respnet-rfs:ebgp-customer')
     if child_ebgp_customer is not None and isinstance(child_ebgp_customer, list):
         children['ebgp-customer'] = from_json_orchestron_rfs__rfs__ebgp_customer(child_ebgp_customer)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/src/respnet/layers/y_2_loose.act
+++ b/src/respnet/layers/y_2_loose.act
@@ -174,7 +174,7 @@ mut def from_json_orchestron_rfs__device__address__initial_credentials_element(j
     child_key = jd.get('key')
     if child_key is not None:
         children['key'] = from_json_orchestron_rfs__device__address__initial_credentials__key(child_key)
-    return yang.gdata.Container(children, [str(child_username if child_username is not None else ''), str(child_password if child_password is not None else ''), str(child_key if child_key is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_username), yang.gdata.yang_str(child_password), yang.gdata.yang_str(child_key)])
 
 mut def from_json_orchestron_rfs__device__address__initial_credentials(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -329,7 +329,7 @@ mut def from_json_orchestron_rfs__device__address_element(jd: dict[str, ?value])
     child_initial_credentials = jd.get('initial-credentials')
     if child_initial_credentials is not None and isinstance(child_initial_credentials, list):
         children['initial-credentials'] = from_json_orchestron_rfs__device__address__initial_credentials(child_initial_credentials)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__device__address(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -476,7 +476,7 @@ mut def from_json_orchestron_rfs__device__credentials__key_element(jd: dict[str,
     child_private_key = jd.get('private-key')
     if child_private_key is not None:
         children['private-key'] = from_json_orchestron_rfs__device__credentials__key__private_key(child_private_key)
-    return yang.gdata.Container(children, [str(child_key if child_key is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key)])
 
 mut def from_json_orchestron_rfs__device__credentials__key(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -705,7 +705,7 @@ mut def from_json_orchestron_rfs__device__initial_credentials_element(jd: dict[s
     child_key = jd.get('key')
     if child_key is not None:
         children['key'] = from_json_orchestron_rfs__device__initial_credentials__key(child_key)
-    return yang.gdata.Container(children, [str(child_username if child_username is not None else ''), str(child_password if child_password is not None else ''), str(child_key if child_key is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_username), yang.gdata.yang_str(child_password), yang.gdata.yang_str(child_key)])
 
 mut def from_json_orchestron_rfs__device__initial_credentials(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -873,7 +873,7 @@ mut def from_json_orchestron_rfs__device__mock__module_element(jd: dict[str, ?va
     child_feature = jd.get('feature')
     if child_feature is not None and isinstance(child_feature, list):
         children['feature'] = from_json_orchestron_rfs__device__mock__module__feature(child_feature)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__device__mock__module(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1117,7 +1117,7 @@ mut def from_json_orchestron_rfs__device_element(jd: dict[str, ?value]) -> yang.
     child_mock = jd.get('mock')
     if child_mock is not None and isinstance(child_mock, dict):
         children['mock'] = from_json_orchestron_rfs__device__mock(child_mock)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__device(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1300,7 +1300,7 @@ mut def from_json_orchestron_rfs__rfs__base_config_element(jd: dict[str, ?value]
     child_ibgp_authentication_key = jd.get('ibgp-authentication-key')
     if child_ibgp_authentication_key is not None:
         children['ibgp-authentication-key'] = from_json_orchestron_rfs__rfs__base_config__ibgp_authentication_key(child_ibgp_authentication_key)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs__base_config(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1556,7 +1556,7 @@ mut def from_json_orchestron_rfs__rfs__backbone_interface_element(jd: dict[str, 
     child_remote = jd.get('remote')
     if child_remote is not None and isinstance(child_remote, dict):
         children['remote'] = from_json_orchestron_rfs__rfs__backbone_interface__remote(child_remote)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs__backbone_interface(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1710,7 +1710,7 @@ mut def from_json_orchestron_rfs__rfs__ibgp_neighbor_element(jd: dict[str, ?valu
     child_description = jd.get('description')
     if child_description is not None:
         children['description'] = from_json_orchestron_rfs__rfs__ibgp_neighbor__description(child_description)
-    return yang.gdata.Container(children, [str(child_address if child_address is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_address)])
 
 mut def from_json_orchestron_rfs__rfs__ibgp_neighbor(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1890,7 +1890,7 @@ mut def from_json_orchestron_rfs__rfs__vrf_element(jd: dict[str, ?value]) -> yan
     child_asn = jd.get('asn')
     if child_asn is not None:
         children['asn'] = from_json_orchestron_rfs__rfs__vrf__asn(child_asn)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs__vrf(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2070,7 +2070,7 @@ mut def from_json_orchestron_rfs__rfs__vrf_interface_element(jd: dict[str, ?valu
     child_ipv4_prefix_length = jd.get('ipv4-prefix-length')
     if child_ipv4_prefix_length is not None:
         children['ipv4-prefix-length'] = from_json_orchestron_rfs__rfs__vrf_interface__ipv4_prefix_length(child_ipv4_prefix_length)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs__vrf_interface(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2265,7 +2265,7 @@ mut def from_json_orchestron_rfs__rfs__ebgp_customer_element(jd: dict[str, ?valu
     child_authentication_key = jd.get('authentication-key')
     if child_authentication_key is not None:
         children['authentication-key'] = from_json_orchestron_rfs__rfs__ebgp_customer__authentication_key(child_authentication_key)
-    return yang.gdata.Container(children, [str(child_vrf if child_vrf is not None else ''), str(child_address if child_address is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vrf), yang.gdata.yang_str(child_address)])
 
 mut def from_json_orchestron_rfs__rfs__ebgp_customer(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -2450,7 +2450,7 @@ mut def from_json_orchestron_rfs__rfs_element(jd: dict[str, ?value]) -> yang.gda
     child_ebgp_customer = jd.get('respnet-rfs:ebgp-customer')
     if child_ebgp_customer is not None and isinstance(child_ebgp_customer, list):
         children['ebgp-customer'] = from_json_orchestron_rfs__rfs__ebgp_customer(child_ebgp_customer)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_rfs__rfs(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/src/respnet/layers/y_3.act
+++ b/src/respnet/layers/y_3.act
@@ -139,7 +139,7 @@ mut def from_json_orchestron_device__devices__device_element(jd: dict[str, ?valu
     child_modset_id = jd.get('modset_id')
     if child_modset_id is not None:
         children['modset_id'] = from_json_orchestron_device__devices__device__modset_id(child_modset_id)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_device__devices__device(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/src/respnet/layers/y_3_loose.act
+++ b/src/respnet/layers/y_3_loose.act
@@ -139,7 +139,7 @@ mut def from_json_orchestron_device__devices__device_element(jd: dict[str, ?valu
     child_modset_id = jd.get('modset_id')
     if child_modset_id is not None:
         children['modset_id'] = from_json_orchestron_device__devices__device__modset_id(child_modset_id)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_orchestron_device__devices__device(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []


### PR DESCRIPTION
Fixes list key access when node names are not unique.

Stores the list entry keys in a "YANG-compliant" string - bytes are b64-encoded, booleans are lower case.