### PR TITLE
Parse XML directly to gdata

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/61fd0e08b0a547a902e6e4bb726c9b70079540ea.zip",
-            "hash": "12208b6565c6a3e4e329167cc7878dbfa5cdd55d107f08db4905977c7b254c4f7b54"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/757f1fcb37620bb894e1cd510fce6e1f108c0e86.zip",
+            "hash": "1220adbae7c863d031794727e4285dbef597fa304898539fbb0a0810aba1209ba7c8"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/940eb3782f7b8f0796e2dae7c9aeac76dc87735f.zip",
-            "hash": "1220ec299c75d0c79cf97eb64fd3f92b37b978c4d74ef2f6bc1aeb562b7d62ebdc5e"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5f2eaa66c7d2f3f73b7b1afdfa498f9600203b0c.zip",
+            "hash": "1220523fe28df55992304b469a8b3845b6b857c9b1cbdf0ff6828ac6dede987b03ba"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/gen/build.act.json
+++ b/gen/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "orchestron": {
             "repo_url": "https://github.com/orchestron-orchestrator/orchestron",
-            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/61fd0e08b0a547a902e6e4bb726c9b70079540ea.zip",
-            "hash": "12208b6565c6a3e4e329167cc7878dbfa5cdd55d107f08db4905977c7b254c4f7b54"
+            "url": "https://github.com/orchestron-orchestrator/orchestron/archive/757f1fcb37620bb894e1cd510fce6e1f108c0e86.zip",
+            "hash": "1220adbae7c863d031794727e4285dbef597fa304898539fbb0a0810aba1209ba7c8"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/940eb3782f7b8f0796e2dae7c9aeac76dc87735f.zip",
-            "hash": "1220ec299c75d0c79cf97eb64fd3f92b37b978c4d74ef2f6bc1aeb562b7d62ebdc5e"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5f2eaa66c7d2f3f73b7b1afdfa498f9600203b0c.zip",
+            "hash": "1220523fe28df55992304b469a8b3845b6b857c9b1cbdf0ff6828ac6dede987b03ba"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",

--- a/src/respnet.act
+++ b/src/respnet.act
@@ -16,7 +16,7 @@ import tmf.tmf641
 import respnet.tmf
 
 import respnet.layers
-from respnet.layers.y_0_loose import root as cfs_root
+import respnet.layers.y_0_loose as cfs_layer
 import respnet.layers.y_0
 import respnet.layers.y_1
 import respnet.layers.y_2
@@ -185,7 +185,7 @@ actor main(env):
                 elif request.headers.get("content-type") == "application/yang-data+xml":
                     try:
                         xml_in = xml.decode(request.body.decode())
-                        input_config = cfs_root.from_xml(xml_in).to_gdata()
+                        input_config = cfs_layer.from_xml(xml_in)
                         session = cfs.newsession()
                         session.edit_config(input_config, config_done)
                         return
@@ -223,7 +223,7 @@ actor main(env):
         print("Applying config file..")
         try:
             xml_in = configs.pop(0)
-            input_config = cfs_root.from_xml(xml_in).to_gdata()
+            input_config = cfs_layer.from_xml(xml_in)
             session.edit_config(input_config, _conf_file_done)
         except IndexError:
             print("All config files applied")

--- a/src/respnet/devices/CiscoIosXr_24_1_ncs55a1.act
+++ b/src/respnet/devices/CiscoIosXr_24_1_ncs55a1.act
@@ -23,13 +23,13 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology__topology_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry(yang.adata.MNode):
     topology_name: str
@@ -48,10 +48,6 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topo
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry:
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry(topology_name=n.get_str('topology-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry(topology_name=yang.gdata.from_xml_str(n, 'topology-name'))
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry]
@@ -89,13 +85,18 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topo
                 res.append(Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_topology_name = yang.gdata.from_xml_str(node, 'topology-name')
+    yang.gdata.maybe_add(children, 'topology-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology__topology_name, child_topology_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_topology_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology_element(e))
+    return yang.gdata.List(keys=['topology-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(yang.adata.MNode):
     topology: Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology
@@ -117,12 +118,12 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(yang.
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(topology=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology.from_gdata(n.get_opt_list('topology')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(topology=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology.from_xml(yang.gdata.get_xml_children(n, 'topology')))
-        return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_topology = yang.gdata.from_xml_opt_list(node, 'topology')
+    yang.gdata.maybe_add(children, 'topology', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies__topology, child_topology)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(yang.adata.MNode):
     topologies: Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies
@@ -144,12 +145,12 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(yang.adata.MNode)
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(topologies=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies.from_gdata(n.get_opt_container('topologies')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(topologies=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies.from_xml(yang.gdata.get_xml_opt_child(n, 'topologies')))
-        return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_topologies = yang.gdata.from_xml_opt_cnt(node, 'topologies')
+    yang.gdata.maybe_add(children, 'topologies', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast__topologies, child_topologies)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(yang.adata.MNode):
     unicast: ?Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast
@@ -181,12 +182,14 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(unicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast.from_gdata(n.get_opt_container('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast.from_gdata(n.get_opt_container('multicast')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(unicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast.from_xml(yang.gdata.get_xml_opt_child(n, 'unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')))
-        return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_unicast = yang.gdata.from_xml_opt_cnt(node, 'unicast')
+    yang.gdata.maybe_add(children, 'unicast', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__unicast, child_unicast)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4__multicast, child_multicast)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast(yang.adata.MNode):
 
@@ -204,13 +207,13 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology__topology_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry(yang.adata.MNode):
     topology_name: str
@@ -229,10 +232,6 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topo
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry:
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry(topology_name=n.get_str('topology-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry(topology_name=yang.gdata.from_xml_str(n, 'topology-name'))
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry]
@@ -270,13 +269,18 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topo
                 res.append(Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_topology_name = yang.gdata.from_xml_str(node, 'topology-name')
+    yang.gdata.maybe_add(children, 'topology-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology__topology_name, child_topology_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_topology_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology_element(e))
+    return yang.gdata.List(keys=['topology-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(yang.adata.MNode):
     topology: Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology
@@ -298,12 +302,12 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(yang.
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(topology=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology.from_gdata(n.get_opt_list('topology')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(topology=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology.from_xml(yang.gdata.get_xml_children(n, 'topology')))
-        return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_topology = yang.gdata.from_xml_opt_list(node, 'topology')
+    yang.gdata.maybe_add(children, 'topology', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies__topology, child_topology)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(yang.adata.MNode):
     topologies: Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies
@@ -325,12 +329,12 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(yang.adata.MNode)
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(topologies=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies.from_gdata(n.get_opt_container('topologies')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(topologies=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies.from_xml(yang.gdata.get_xml_opt_child(n, 'topologies')))
-        return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_topologies = yang.gdata.from_xml_opt_cnt(node, 'topologies')
+    yang.gdata.maybe_add(children, 'topologies', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast__topologies, child_topologies)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(yang.adata.MNode):
     unicast: ?Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast
@@ -362,12 +366,14 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(unicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast.from_gdata(n.get_opt_container('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast.from_gdata(n.get_opt_container('multicast')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(unicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast.from_xml(yang.gdata.get_xml_opt_child(n, 'unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')))
-        return Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_unicast = yang.gdata.from_xml_opt_cnt(node, 'unicast')
+    yang.gdata.maybe_add(children, 'unicast', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__unicast, child_unicast)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6__multicast, child_multicast)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__address_family(yang.adata.MNode):
     ipv4: Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4
@@ -394,16 +400,26 @@ class Cisco_IOS_XR_um_vrf_cfg__address_family(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__address_family(ipv4=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6.from_gdata(n.get_opt_container('ipv6')))
         return Cisco_IOS_XR_um_vrf_cfg__address_family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__address_family:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__address_family(ipv4=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv4')), ipv6=Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv6')))
-        return Cisco_IOS_XR_um_vrf_cfg__address_family()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_cnt(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_cnt(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family__ipv6, child_ipv6)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg', module='Cisco-IOS-XR-um-vrf-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vrf_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__stitching(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry(yang.adata.MNode):
     as_number: int
@@ -432,10 +448,6 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=n.get_int('as-number'), index=n.get_int('index'), stitching=n.get_bool('stitching'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=yang.gdata.from_xml_int(n, 'as-number'), index=yang.gdata.from_xml_int(n, 'index'), stitching=yang.gdata.from_xml_bool(n, 'stitching'))
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry]
@@ -479,13 +491,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
                 res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_as_number = yang.gdata.from_xml_int(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__as_number, child_as_number)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__index, child_index)
+    child_stitching = yang.gdata.from_xml_bool(node, 'stitching')
+    yang.gdata.maybe_add(children, 'stitching', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__stitching, child_stitching)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_as_number), yang.gdata.yang_str(child_index), yang.gdata.yang_str(child_stitching)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_element(e))
+    return yang.gdata.List(keys=['as-number', 'index', 'stitching'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts(yang.adata.MNode):
     two_byte_as_rt: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt
@@ -507,12 +528,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt.from_xml(yang.gdata.get_xml_children(n, 'two-byte-as-rt')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as_rt = yang.gdata.from_xml_opt_list(node, 'two-byte-as-rt')
+    yang.gdata.maybe_add(children, 'two-byte-as-rt', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt, child_two_byte_as_rt)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target(yang.adata.MNode):
     two_byte_as_rts: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts
@@ -534,12 +555,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts.from_gdata(n.get_opt_container('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts.from_xml(yang.gdata.get_xml_opt_child(n, 'two-byte-as-rts')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as_rts = yang.gdata.from_xml_opt_cnt(node, 'two-byte-as-rts')
+    yang.gdata.maybe_add(children, 'two-byte-as-rts', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target__two_byte_as_rts, child_two_byte_as_rts)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(yang.adata.MNode):
     route_target: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target
@@ -561,15 +582,21 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target.from_gdata(n.get_opt_container('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target.from_xml(yang.gdata.get_xml_opt_child(n, 'route-target')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_target = yang.gdata.from_xml_opt_cnt(node, 'route-target')
+    yang.gdata.maybe_add(children, 'route-target', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import__route_target, child_route_target)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg', module='Cisco-IOS-XR-um-router-bgp-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__stitching(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry(yang.adata.MNode):
     as_number: int
@@ -598,10 +625,6 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=n.get_int('as-number'), index=n.get_int('index'), stitching=n.get_bool('stitching'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=yang.gdata.from_xml_int(n, 'as-number'), index=yang.gdata.from_xml_int(n, 'index'), stitching=yang.gdata.from_xml_bool(n, 'stitching'))
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry]
@@ -645,13 +668,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
                 res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_as_number = yang.gdata.from_xml_int(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__as_number, child_as_number)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__index, child_index)
+    child_stitching = yang.gdata.from_xml_bool(node, 'stitching')
+    yang.gdata.maybe_add(children, 'stitching', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__stitching, child_stitching)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_as_number), yang.gdata.yang_str(child_index), yang.gdata.yang_str(child_stitching)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_element(e))
+    return yang.gdata.List(keys=['as-number', 'index', 'stitching'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts(yang.adata.MNode):
     two_byte_as_rt: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt
@@ -673,12 +705,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt.from_xml(yang.gdata.get_xml_children(n, 'two-byte-as-rt')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as_rt = yang.gdata.from_xml_opt_list(node, 'two-byte-as-rt')
+    yang.gdata.maybe_add(children, 'two-byte-as-rt', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt, child_two_byte_as_rt)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target(yang.adata.MNode):
     two_byte_as_rts: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts
@@ -700,12 +732,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts.from_gdata(n.get_opt_container('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts.from_xml(yang.gdata.get_xml_opt_child(n, 'two-byte-as-rts')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as_rts = yang.gdata.from_xml_opt_cnt(node, 'two-byte-as-rts')
+    yang.gdata.maybe_add(children, 'two-byte-as-rts', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target__two_byte_as_rts, child_two_byte_as_rts)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(yang.adata.MNode):
     route_target: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target
@@ -727,12 +759,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target.from_gdata(n.get_opt_container('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target.from_xml(yang.gdata.get_xml_opt_child(n, 'route-target')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_target = yang.gdata.from_xml_opt_cnt(node, 'route-target')
+    yang.gdata.maybe_add(children, 'route-target', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export__route_target, child_route_target)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg', module='Cisco-IOS-XR-um-router-bgp-cfg')
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(yang.adata.MNode):
     import_: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import
@@ -759,12 +791,14 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(yang.ada
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(import_=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import.from_gdata(n.get_opt_container('import')), export=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export.from_gdata(n.get_opt_container('export')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(import_=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import.from_xml(yang.gdata.get_xml_opt_child(n, 'import', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')), export=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export.from_xml(yang.gdata.get_xml_opt_child(n, 'export', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_import_ = yang.gdata.from_xml_opt_cnt(node, 'import', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')
+    yang.gdata.maybe_add(children, 'import', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__import, child_import_)
+    child_export = yang.gdata.from_xml_opt_cnt(node, 'export', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')
+    yang.gdata.maybe_add(children, 'export', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast__export, child_export)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast(yang.adata.MNode):
 
@@ -782,12 +816,10 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast(yang.a
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec(yang.adata.MNode):
 
@@ -805,12 +837,10 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec(yang.ad
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(yang.adata.MNode):
     unicast: ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast
@@ -857,15 +887,25 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(yang.adata.MNode)
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(unicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast.from_gdata(n.get_opt_container('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast.from_gdata(n.get_opt_container('multicast')), flowspec=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec.from_gdata(n.get_opt_container('flowspec')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(unicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast.from_xml(yang.gdata.get_xml_opt_child(n, 'unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')), flowspec=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec.from_xml(yang.gdata.get_xml_opt_child(n, 'flowspec')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_unicast = yang.gdata.from_xml_opt_cnt(node, 'unicast')
+    yang.gdata.maybe_add(children, 'unicast', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__unicast, child_unicast)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__multicast, child_multicast)
+    child_flowspec = yang.gdata.from_xml_opt_cnt(node, 'flowspec')
+    yang.gdata.maybe_add(children, 'flowspec', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4__flowspec, child_flowspec)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__stitching(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry(yang.adata.MNode):
     as_number: int
@@ -894,10 +934,6 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=n.get_int('as-number'), index=n.get_int('index'), stitching=n.get_bool('stitching'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=yang.gdata.from_xml_int(n, 'as-number'), index=yang.gdata.from_xml_int(n, 'index'), stitching=yang.gdata.from_xml_bool(n, 'stitching'))
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry]
@@ -941,13 +977,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
                 res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_as_number = yang.gdata.from_xml_int(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__as_number, child_as_number)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__index, child_index)
+    child_stitching = yang.gdata.from_xml_bool(node, 'stitching')
+    yang.gdata.maybe_add(children, 'stitching', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt__stitching, child_stitching)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_as_number), yang.gdata.yang_str(child_index), yang.gdata.yang_str(child_stitching)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt_element(e))
+    return yang.gdata.List(keys=['as-number', 'index', 'stitching'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts(yang.adata.MNode):
     two_byte_as_rt: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt
@@ -969,12 +1014,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt.from_xml(yang.gdata.get_xml_children(n, 'two-byte-as-rt')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as_rt = yang.gdata.from_xml_opt_list(node, 'two-byte-as-rt')
+    yang.gdata.maybe_add(children, 'two-byte-as-rt', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts__two_byte_as_rt, child_two_byte_as_rt)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target(yang.adata.MNode):
     two_byte_as_rts: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts
@@ -996,12 +1041,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts.from_gdata(n.get_opt_container('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts.from_xml(yang.gdata.get_xml_opt_child(n, 'two-byte-as-rts')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as_rts = yang.gdata.from_xml_opt_cnt(node, 'two-byte-as-rts')
+    yang.gdata.maybe_add(children, 'two-byte-as-rts', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target__two_byte_as_rts, child_two_byte_as_rts)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(yang.adata.MNode):
     route_target: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target
@@ -1023,15 +1068,21 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target.from_gdata(n.get_opt_container('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target.from_xml(yang.gdata.get_xml_opt_child(n, 'route-target')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_target = yang.gdata.from_xml_opt_cnt(node, 'route-target')
+    yang.gdata.maybe_add(children, 'route-target', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import__route_target, child_route_target)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg', module='Cisco-IOS-XR-um-router-bgp-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__stitching(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry(yang.adata.MNode):
     as_number: int
@@ -1060,10 +1111,6 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=n.get_int('as-number'), index=n.get_int('index'), stitching=n.get_bool('stitching'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry(as_number=yang.gdata.from_xml_int(n, 'as-number'), index=yang.gdata.from_xml_int(n, 'index'), stitching=yang.gdata.from_xml_bool(n, 'stitching'))
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry]
@@ -1107,13 +1154,22 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
                 res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_as_number = yang.gdata.from_xml_int(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__as_number, child_as_number)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__index, child_index)
+    child_stitching = yang.gdata.from_xml_bool(node, 'stitching')
+    yang.gdata.maybe_add(children, 'stitching', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt__stitching, child_stitching)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_as_number), yang.gdata.yang_str(child_index), yang.gdata.yang_str(child_stitching)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt_element(e))
+    return yang.gdata.List(keys=['as-number', 'index', 'stitching'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts(yang.adata.MNode):
     two_byte_as_rt: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt
@@ -1135,12 +1191,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt.from_gdata(n.get_opt_list('two-byte-as-rt')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts(two_byte_as_rt=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt.from_xml(yang.gdata.get_xml_children(n, 'two-byte-as-rt')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as_rt = yang.gdata.from_xml_opt_list(node, 'two-byte-as-rt')
+    yang.gdata.maybe_add(children, 'two-byte-as-rt', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts__two_byte_as_rt, child_two_byte_as_rt)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target(yang.adata.MNode):
     two_byte_as_rts: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts
@@ -1162,12 +1218,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export_
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts.from_gdata(n.get_opt_container('two-byte-as-rts')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target(two_byte_as_rts=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts.from_xml(yang.gdata.get_xml_opt_child(n, 'two-byte-as-rts')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as_rts = yang.gdata.from_xml_opt_cnt(node, 'two-byte-as-rts')
+    yang.gdata.maybe_add(children, 'two-byte-as-rts', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target__two_byte_as_rts, child_two_byte_as_rts)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(yang.adata.MNode):
     route_target: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target
@@ -1189,12 +1245,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target.from_gdata(n.get_opt_container('route-target')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(route_target=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target.from_xml(yang.gdata.get_xml_opt_child(n, 'route-target')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_target = yang.gdata.from_xml_opt_cnt(node, 'route-target')
+    yang.gdata.maybe_add(children, 'route-target', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export__route_target, child_route_target)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg', module='Cisco-IOS-XR-um-router-bgp-cfg')
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(yang.adata.MNode):
     import_: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import
@@ -1221,12 +1277,14 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(yang.ada
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(import_=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import.from_gdata(n.get_opt_container('import')), export=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export.from_gdata(n.get_opt_container('export')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(import_=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import.from_xml(yang.gdata.get_xml_opt_child(n, 'import', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')), export=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export.from_xml(yang.gdata.get_xml_opt_child(n, 'export', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_import_ = yang.gdata.from_xml_opt_cnt(node, 'import', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')
+    yang.gdata.maybe_add(children, 'import', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__import, child_import_)
+    child_export = yang.gdata.from_xml_opt_cnt(node, 'export', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')
+    yang.gdata.maybe_add(children, 'export', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast__export, child_export)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast(yang.adata.MNode):
 
@@ -1244,12 +1302,10 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast(yang.a
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec(yang.adata.MNode):
 
@@ -1267,12 +1323,10 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec(yang.ad
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(yang.adata.MNode):
     unicast: ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast
@@ -1319,12 +1373,16 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(yang.adata.MNode)
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(unicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast.from_gdata(n.get_opt_container('unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast.from_gdata(n.get_opt_container('multicast')), flowspec=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec.from_gdata(n.get_opt_container('flowspec')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(unicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast.from_xml(yang.gdata.get_xml_opt_child(n, 'unicast')), multicast=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')), flowspec=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec.from_xml(yang.gdata.get_xml_opt_child(n, 'flowspec')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_unicast = yang.gdata.from_xml_opt_cnt(node, 'unicast')
+    yang.gdata.maybe_add(children, 'unicast', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__unicast, child_unicast)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__multicast, child_multicast)
+    child_flowspec = yang.gdata.from_xml_opt_cnt(node, 'flowspec')
+    yang.gdata.maybe_add(children, 'flowspec', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6__flowspec, child_flowspec)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(yang.adata.MNode):
     ipv4: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4
@@ -1351,12 +1409,14 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(ipv4=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6.from_gdata(n.get_opt_container('ipv6')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(ipv4=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv4')), ipv6=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv6')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_cnt(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_cnt(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family__ipv6, child_ipv6)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big(yang.adata.MNode):
 
@@ -1374,12 +1434,10 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(yang.adata.MNode):
     big: ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big
@@ -1406,13 +1464,15 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(big=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big.from_gdata(n.get_opt_container('big')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(big=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big.from_xml(yang.gdata.get_xml_opt_child(n, 'big')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_big = yang.gdata.from_xml_opt_cnt(node, 'big')
+    yang.gdata.maybe_add(children, 'big', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode__big, child_big)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(yang.adata.MNode):
     id: ?str
@@ -1434,13 +1494,15 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(id=n.get_opt_str('id'))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(id=yang.gdata.from_xml_opt_str(n, 'id'))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_id = yang.gdata.from_xml_opt_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn__id, child_id)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable(yang.adata.MNode):
 
@@ -1458,12 +1520,10 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable(yang.a
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(yang.adata.MNode):
     disable: ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable
@@ -1490,15 +1550,21 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(yang.adata.MNod
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(disable=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable.from_gdata(n.get_opt_container('disable')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(disable=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable.from_xml(yang.gdata.get_xml_opt_child(n, 'disable')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_cnt(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering__disable, child_disable)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__fallback_vrf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(yang.adata.MNode):
     as_number: ?str
@@ -1525,14 +1591,20 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(as_number=yang.gdata.from_xml_opt_str(n, 'as-number'), index=yang.gdata.from_xml_opt_int(n, 'index'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_number = yang.gdata.from_xml_str(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as__as_number, child_as_number)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as__index, child_index)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(yang.adata.MNode):
     as_number: ?str
@@ -1559,14 +1631,20 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(as_number=yang.gdata.from_xml_opt_str(n, 'as-number'), index=yang.gdata.from_xml_opt_int(n, 'index'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_number = yang.gdata.from_xml_str(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as__as_number, child_as_number)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as__index, child_index)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(yang.adata.MNode):
     ipv4_address: ?str
@@ -1593,12 +1671,14 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(ipv4_address=n.get_opt_str('ipv4-address'), index=n.get_opt_int('index'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'), index=yang.gdata.from_xml_opt_int(n, 'index'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4_address = yang.gdata.from_xml_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address__ipv4_address, child_ipv4_address)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address__index, child_index)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(yang.adata.MNode):
     two_byte_as: ?Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as
@@ -1645,12 +1725,16 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(two_byte_as=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as.from_gdata(n.get_opt_container('two-byte-as')), four_byte_as=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as.from_gdata(n.get_opt_container('four-byte-as')), ip_address=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address.from_gdata(n.get_opt_container('ip-address')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(two_byte_as=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as.from_xml(yang.gdata.get_xml_opt_child(n, 'two-byte-as')), four_byte_as=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as.from_xml(yang.gdata.get_xml_opt_child(n, 'four-byte-as')), ip_address=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address.from_xml(yang.gdata.get_xml_opt_child(n, 'ip-address')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_two_byte_as = yang.gdata.from_xml_opt_cnt(node, 'two-byte-as')
+    yang.gdata.maybe_add(children, 'two-byte-as', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__two_byte_as, child_two_byte_as)
+    child_four_byte_as = yang.gdata.from_xml_opt_cnt(node, 'four-byte-as')
+    yang.gdata.maybe_add(children, 'four-byte-as', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__four_byte_as, child_four_byte_as)
+    child_ip_address = yang.gdata.from_xml_opt_cnt(node, 'ip-address')
+    yang.gdata.maybe_add(children, 'ip-address', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd__ip_address, child_ip_address)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg', module='Cisco-IOS-XR-um-router-bgp-cfg')
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry(yang.adata.MNode):
     vrf_name: str
@@ -1705,10 +1789,6 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry(vrf_name=n.get_str('vrf-name'), address_family=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family.from_gdata(n.get_opt_container('address-family')), mode=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode.from_gdata(n.get_opt_container('mode')), vpn=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn.from_gdata(n.get_opt_container('vpn')), description=n.get_opt_str('description'), remote_route_filtering=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering.from_gdata(n.get_opt_container('remote-route-filtering')), fallback_vrf=n.get_opt_str('fallback-vrf'), rd=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd.from_gdata(n.get_opt_container('rd')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry(vrf_name=yang.gdata.from_xml_str(n, 'vrf-name'), address_family=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family.from_xml(yang.gdata.get_xml_opt_child(n, 'address-family')), mode=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode.from_xml(yang.gdata.get_xml_opt_child(n, 'mode')), vpn=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn')), description=yang.gdata.from_xml_opt_str(n, 'description'), remote_route_filtering=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering.from_xml(yang.gdata.get_xml_opt_child(n, 'remote-route-filtering')), fallback_vrf=yang.gdata.from_xml_opt_str(n, 'fallback-vrf'), rd=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd.from_xml(yang.gdata.get_xml_opt_child(n, 'rd', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')))
-
 class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry]
     mut def __init__(self, elements=[]):
@@ -1745,13 +1825,32 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf(yang.adata.MNode):
                 res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vrf_name = yang.gdata.from_xml_str(node, 'vrf-name')
+    yang.gdata.maybe_add(children, 'vrf-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vrf_name, child_vrf_name)
+    child_address_family = yang.gdata.from_xml_opt_cnt(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__address_family, child_address_family)
+    child_mode = yang.gdata.from_xml_opt_cnt(node, 'mode')
+    yang.gdata.maybe_add(children, 'mode', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__mode, child_mode)
+    child_vpn = yang.gdata.from_xml_opt_cnt(node, 'vpn')
+    yang.gdata.maybe_add(children, 'vpn', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__vpn, child_vpn)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__description, child_description)
+    child_remote_route_filtering = yang.gdata.from_xml_opt_cnt(node, 'remote-route-filtering')
+    yang.gdata.maybe_add(children, 'remote-route-filtering', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__remote_route_filtering, child_remote_route_filtering)
+    child_fallback_vrf = yang.gdata.from_xml_opt_str(node, 'fallback-vrf')
+    yang.gdata.maybe_add(children, 'fallback-vrf', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__fallback_vrf, child_fallback_vrf)
+    child_rd = yang.gdata.from_xml_opt_cnt(node, 'rd', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')
+    yang.gdata.maybe_add(children, 'rd', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf__rd, child_rd)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vrf_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf_element(e))
+    return yang.gdata.List(keys=['vrf-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrfs(yang.adata.MNode):
     vrf: Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf
@@ -1773,12 +1872,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrfs(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrfs(vrf=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_vrf_cfg__vrfs()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrfs:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrfs(vrf=Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf.from_xml(yang.gdata.get_xml_children(n, 'vrf')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrfs()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vrf = yang.gdata.from_xml_opt_list(node, 'vrf')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs__vrf, child_vrf)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg', module='Cisco-IOS-XR-um-vrf-cfg')
 
 class Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable(yang.adata.MNode):
 
@@ -1796,12 +1895,10 @@ class Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable(yang.adata.MNode)
             return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(yang.adata.MNode):
     disable: ?Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable
@@ -1828,15 +1925,21 @@ class Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(disable=Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable.from_gdata(n.get_opt_container('disable')))
         return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(disable=Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable.from_xml(yang.gdata.get_xml_opt_child(n, 'disable')))
-        return Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_cnt(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download__disable, child_disable)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg', module='Cisco-IOS-XR-um-vrf-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name__srlg_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name__value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry(yang.adata.MNode):
     srlg_name: str
@@ -1865,10 +1968,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry(srlg_name=n.get_str('srlg-name'), value=n.get_opt_int('value'), description=n.get_opt_str('description'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry(srlg_name=yang.gdata.from_xml_str(n, 'srlg-name'), value=yang.gdata.from_xml_opt_int(n, 'value'), description=yang.gdata.from_xml_opt_str(n, 'description'))
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__names__name(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry]
@@ -1906,13 +2005,22 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__names__name(yang.adata.MNode):
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_srlg_name = yang.gdata.from_xml_str(node, 'srlg-name')
+    yang.gdata.maybe_add(children, 'srlg-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name__srlg_name, child_srlg_name)
+    child_value = yang.gdata.from_xml_opt_int(node, 'value')
+    yang.gdata.maybe_add(children, 'value', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name__value, child_value)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name__description, child_description)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_srlg_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name_element(e))
+    return yang.gdata.List(keys=['srlg-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__names(yang.adata.MNode):
     name: Cisco_IOS_XR_um_vrf_cfg__srlg__names__name
@@ -1934,14 +2042,18 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__names(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__names(name=Cisco_IOS_XR_um_vrf_cfg__srlg__names__name.from_gdata(n.get_opt_list('name')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__names()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__names:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__names(name=Cisco_IOS_XR_um_vrf_cfg__srlg__names__name.from_xml(yang.gdata.get_xml_children(n, 'name')))
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__names()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_name = yang.gdata.from_xml_opt_list(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names__name, child_name)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__interface_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(yang.adata.MNode):
     priority: ?str
@@ -1963,15 +2075,21 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(yang
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(priority=n.get_opt_str('priority'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(priority=yang.gdata.from_xml_opt_str(n, 'priority'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_priority = yang.gdata.from_xml_opt_str(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical__priority, child_priority)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index__index_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index__value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry(yang.adata.MNode):
     index_number: int
@@ -2000,10 +2118,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry(index_number=n.get_int('index-number'), value=n.get_opt_int('value'), priority=n.get_opt_str('priority'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry(index_number=yang.gdata.from_xml_int(n, 'index-number'), value=yang.gdata.from_xml_opt_int(n, 'value'), priority=yang.gdata.from_xml_opt_str(n, 'priority'))
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry]
@@ -2041,13 +2155,22 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index(yang.
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_index_number = yang.gdata.from_xml_int(node, 'index-number')
+    yang.gdata.maybe_add(children, 'index-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index__index_number, child_index_number)
+    child_value = yang.gdata.from_xml_int(node, 'value')
+    yang.gdata.maybe_add(children, 'value', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index__value, child_value)
+    child_priority = yang.gdata.from_xml_str(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index__priority, child_priority)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_index_number)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index_element(e))
+    return yang.gdata.List(keys=['index-number'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(yang.adata.MNode):
     index: Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index
@@ -2069,13 +2192,15 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(yang.adata.M
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index.from_xml(yang.gdata.get_xml_children(n, 'index')))
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_index = yang.gdata.from_xml_opt_list(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes__index, child_index)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name__srlg_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry(yang.adata.MNode):
     srlg_name: str
@@ -2094,10 +2219,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry(ya
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry(srlg_name=n.get_str('srlg-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry(srlg_name=yang.gdata.from_xml_str(n, 'srlg-name'))
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry]
@@ -2135,13 +2256,18 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name(yang.ada
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_srlg_name = yang.gdata.from_xml_str(node, 'srlg-name')
+    yang.gdata.maybe_add(children, 'srlg-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name__srlg_name, child_srlg_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_srlg_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name_element(e))
+    return yang.gdata.List(keys=['srlg-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(yang.adata.MNode):
     name: Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name
@@ -2163,14 +2289,18 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(yang.adata.MNo
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(name=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name.from_gdata(n.get_opt_list('name')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(name=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name.from_xml(yang.gdata.get_xml_children(n, 'name')))
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_name = yang.gdata.from_xml_opt_list(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names__name, child_name)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group__index_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group__group_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry(yang.adata.MNode):
     index_number: int
@@ -2194,10 +2324,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry(
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry(index_number=n.get_int('index-number'), group_name=n.get_opt_str('group-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry(index_number=yang.gdata.from_xml_int(n, 'index-number'), group_name=yang.gdata.from_xml_opt_str(n, 'group-name'))
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry]
@@ -2235,13 +2361,20 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group(yang.a
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_index_number = yang.gdata.from_xml_int(node, 'index-number')
+    yang.gdata.maybe_add(children, 'index-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group__index_number, child_index_number)
+    child_group_name = yang.gdata.from_xml_str(node, 'group-name')
+    yang.gdata.maybe_add(children, 'group-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group__group_name, child_group_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_index_number)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group_element(e))
+    return yang.gdata.List(keys=['index-number'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(yang.adata.MNode):
     group: Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group
@@ -2263,12 +2396,12 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(yang.adata.MN
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(group=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group.from_gdata(n.get_opt_list('group')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(group=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups__group, child_group)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry(yang.adata.MNode):
     interface_name: str
@@ -2318,10 +2451,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry(yang.adata.MNod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry(interface_name=n.get_str('interface-name'), include_optical=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical.from_gdata(n.get_opt_container('include-optical')), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes.from_gdata(n.get_opt_container('indexes')), names=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names.from_gdata(n.get_opt_container('names')), groups=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups.from_gdata(n.get_opt_container('groups')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry(interface_name=yang.gdata.from_xml_str(n, 'interface-name'), include_optical=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical.from_xml(yang.gdata.get_xml_opt_child(n, 'include-optical')), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes.from_xml(yang.gdata.get_xml_opt_child(n, 'indexes')), names=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names.from_xml(yang.gdata.get_xml_opt_child(n, 'names')), groups=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups.from_xml(yang.gdata.get_xml_opt_child(n, 'groups')))
-
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -2358,13 +2487,26 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface(yang.adata.MNode):
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_interface_name = yang.gdata.from_xml_str(node, 'interface-name')
+    yang.gdata.maybe_add(children, 'interface-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__interface_name, child_interface_name)
+    child_include_optical = yang.gdata.from_xml_opt_cnt(node, 'include-optical')
+    yang.gdata.maybe_add(children, 'include-optical', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__include_optical, child_include_optical)
+    child_indexes = yang.gdata.from_xml_opt_cnt(node, 'indexes')
+    yang.gdata.maybe_add(children, 'indexes', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__indexes, child_indexes)
+    child_names = yang.gdata.from_xml_opt_cnt(node, 'names')
+    yang.gdata.maybe_add(children, 'names', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__names, child_names)
+    child_groups = yang.gdata.from_xml_opt_cnt(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface__groups, child_groups)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_interface_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface_element(e))
+    return yang.gdata.List(keys=['interface-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(yang.adata.MNode):
     interface: Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface
@@ -2386,16 +2528,24 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(interface=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(interface=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')))
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces__interface, child_interface)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__group_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index__index_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index__value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry(yang.adata.MNode):
     index_number: int
@@ -2424,10 +2574,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry(yang.ad
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry(index_number=n.get_int('index-number'), value=n.get_opt_int('value'), priority=n.get_opt_str('priority'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry(index_number=yang.gdata.from_xml_int(n, 'index-number'), value=yang.gdata.from_xml_opt_int(n, 'value'), priority=yang.gdata.from_xml_opt_str(n, 'priority'))
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry]
@@ -2465,13 +2611,22 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index(yang.adata.MN
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_index_number = yang.gdata.from_xml_int(node, 'index-number')
+    yang.gdata.maybe_add(children, 'index-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index__index_number, child_index_number)
+    child_value = yang.gdata.from_xml_int(node, 'value')
+    yang.gdata.maybe_add(children, 'value', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index__value, child_value)
+    child_priority = yang.gdata.from_xml_str(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index__priority, child_priority)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_index_number)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index_element(e))
+    return yang.gdata.List(keys=['index-number'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(yang.adata.MNode):
     index: Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index
@@ -2493,12 +2648,12 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index.from_xml(yang.gdata.get_xml_children(n, 'index')))
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_index = yang.gdata.from_xml_opt_list(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes__index, child_index)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry(yang.adata.MNode):
     group_name: str
@@ -2522,10 +2677,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry(group_name=n.get_str('group-name'), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes.from_gdata(n.get_opt_container('indexes')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry(group_name=yang.gdata.from_xml_str(n, 'group-name'), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes.from_xml(yang.gdata.get_xml_opt_child(n, 'indexes')))
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry]
@@ -2563,13 +2714,20 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group(yang.adata.MNode):
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_name = yang.gdata.from_xml_str(node, 'group-name')
+    yang.gdata.maybe_add(children, 'group-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__group_name, child_group_name)
+    child_indexes = yang.gdata.from_xml_opt_cnt(node, 'indexes')
+    yang.gdata.maybe_add(children, 'indexes', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group__indexes, child_indexes)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group_element(e))
+    return yang.gdata.List(keys=['group-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__groups(yang.adata.MNode):
     group: Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group
@@ -2591,16 +2749,24 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__groups(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__groups(group=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group.from_gdata(n.get_opt_list('group')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__groups:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__groups(group=Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__groups()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups__group, child_group)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__location_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index__index_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index__value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry(yang.adata.MNode):
     index_number: int
@@ -2629,10 +2795,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexe
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry(index_number=n.get_int('index-number'), value=n.get_opt_int('value'), priority=n.get_opt_str('priority'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry(index_number=yang.gdata.from_xml_int(n, 'index-number'), value=yang.gdata.from_xml_opt_int(n, 'value'), priority=yang.gdata.from_xml_opt_str(n, 'priority'))
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry]
@@ -2670,13 +2832,22 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexe
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_index_number = yang.gdata.from_xml_int(node, 'index-number')
+    yang.gdata.maybe_add(children, 'index-number', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index__index_number, child_index_number)
+    child_value = yang.gdata.from_xml_int(node, 'value')
+    yang.gdata.maybe_add(children, 'value', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index__value, child_value)
+    child_priority = yang.gdata.from_xml_str(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index__priority, child_priority)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_index_number)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index_element(e))
+    return yang.gdata.List(keys=['index-number'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes(yang.adata.MNode):
     index: Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index
@@ -2698,12 +2869,12 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexe
             return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index.from_gdata(n.get_opt_list('index')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes(index=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index.from_xml(yang.gdata.get_xml_children(n, 'index')))
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_index = yang.gdata.from_xml_opt_list(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes__index, child_index)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry(yang.adata.MNode):
     location_name: str
@@ -2727,10 +2898,6 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry(y
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry:
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry(location_name=n.get_str('location-name'), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes.from_gdata(n.get_opt_container('indexes')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry(location_name=yang.gdata.from_xml_str(n, 'location-name'), indexes=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes.from_xml(yang.gdata.get_xml_opt_child(n, 'indexes')))
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry]
@@ -2768,13 +2935,20 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location(yang.ad
                 res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_location_name = yang.gdata.from_xml_str(node, 'location-name')
+    yang.gdata.maybe_add(children, 'location-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__location_name, child_location_name)
+    child_indexes = yang.gdata.from_xml_opt_cnt(node, 'indexes')
+    yang.gdata.maybe_add(children, 'indexes', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location__indexes, child_indexes)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_location_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location_element(e))
+    return yang.gdata.List(keys=['location-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(yang.adata.MNode):
     inherit_location: Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location
@@ -2796,12 +2970,12 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(inherit_location=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location.from_gdata(n.get_opt_list('inherit-location')))
         return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(inherit_location=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location.from_xml(yang.gdata.get_xml_children(n, 'inherit-location')))
-        return Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_inherit_location = yang.gdata.from_xml_opt_list(node, 'inherit-location')
+    yang.gdata.maybe_add(children, 'inherit-location', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations__inherit_location, child_inherit_location)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__srlg(yang.adata.MNode):
     names: Cisco_IOS_XR_um_vrf_cfg__srlg__names
@@ -2838,14 +3012,24 @@ class Cisco_IOS_XR_um_vrf_cfg__srlg(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__srlg(names=Cisco_IOS_XR_um_vrf_cfg__srlg__names.from_gdata(n.get_opt_container('names')), interfaces=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces.from_gdata(n.get_opt_container('interfaces')), groups=Cisco_IOS_XR_um_vrf_cfg__srlg__groups.from_gdata(n.get_opt_container('groups')), inherit_locations=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations.from_gdata(n.get_opt_container('inherit-locations')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_vrf_cfg__srlg:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__srlg(names=Cisco_IOS_XR_um_vrf_cfg__srlg__names.from_xml(yang.gdata.get_xml_opt_child(n, 'names')), interfaces=Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces.from_xml(yang.gdata.get_xml_opt_child(n, 'interfaces')), groups=Cisco_IOS_XR_um_vrf_cfg__srlg__groups.from_xml(yang.gdata.get_xml_opt_child(n, 'groups')), inherit_locations=Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations.from_xml(yang.gdata.get_xml_opt_child(n, 'inherit-locations')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_names = yang.gdata.from_xml_opt_cnt(node, 'names')
+    yang.gdata.maybe_add(children, 'names', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__names, child_names)
+    child_interfaces = yang.gdata.from_xml_opt_cnt(node, 'interfaces')
+    yang.gdata.maybe_add(children, 'interfaces', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__interfaces, child_interfaces)
+    child_groups = yang.gdata.from_xml_opt_cnt(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__groups, child_groups)
+    child_inherit_locations = yang.gdata.from_xml_opt_cnt(node, 'inherit-locations')
+    yang.gdata.maybe_add(children, 'inherit-locations', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg__inherit_locations, child_inherit_locations)
+    return yang.gdata.Container(children, presence=True, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg', module='Cisco-IOS-XR-um-vrf-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__group_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf__vrf_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry(yang.adata.MNode):
     vrf_name: str
@@ -2864,10 +3048,6 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry(yang.adata
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry(vrf_name=n.get_str('vrf-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry(vrf_name=yang.gdata.from_xml_str(n, 'vrf-name'))
 
 class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry]
@@ -2905,13 +3085,18 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf(yang.adata.MNode
                 res.append(Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vrf_name = yang.gdata.from_xml_str(node, 'vrf-name')
+    yang.gdata.maybe_add(children, 'vrf-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf__vrf_name, child_vrf_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vrf_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf_element(e))
+    return yang.gdata.List(keys=['vrf-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(yang.adata.MNode):
     vrf: Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf
@@ -2933,12 +3118,12 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(vrf=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(vrf=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf.from_xml(yang.gdata.get_xml_children(n, 'vrf')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vrf = yang.gdata.from_xml_opt_list(node, 'vrf')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs__vrf, child_vrf)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry(yang.adata.MNode):
     group_name: str
@@ -2962,10 +3147,6 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry:
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry(group_name=n.get_str('group-name'), vrfs=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs.from_gdata(n.get_opt_container('vrfs')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry:
-        return Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry(group_name=yang.gdata.from_xml_str(n, 'group-name'), vrfs=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs.from_xml(yang.gdata.get_xml_opt_child(n, 'vrfs')))
 
 class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry]
@@ -3003,13 +3184,20 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group(yang.adata.MNode):
                 res.append(Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_name = yang.gdata.from_xml_str(node, 'group-name')
+    yang.gdata.maybe_add(children, 'group-name', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__group_name, child_group_name)
+    child_vrfs = yang.gdata.from_xml_opt_cnt(node, 'vrfs')
+    yang.gdata.maybe_add(children, 'vrfs', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group__vrfs, child_vrfs)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group_element(e))
+    return yang.gdata.List(keys=['group-name'], elements=elements)
 
 class Cisco_IOS_XR_um_vrf_cfg__vrf_groups(yang.adata.MNode):
     vrf_group: Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group
@@ -3031,15 +3219,21 @@ class Cisco_IOS_XR_um_vrf_cfg__vrf_groups(yang.adata.MNode):
             return Cisco_IOS_XR_um_vrf_cfg__vrf_groups(vrf_group=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group.from_gdata(n.get_opt_list('vrf-group')))
         return Cisco_IOS_XR_um_vrf_cfg__vrf_groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_vrf_cfg__vrf_groups:
-        if n != None:
-            return Cisco_IOS_XR_um_vrf_cfg__vrf_groups(vrf_group=Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group.from_xml(yang.gdata.get_xml_children(n, 'vrf-group')))
-        return Cisco_IOS_XR_um_vrf_cfg__vrf_groups()
 
+mut def from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vrf_group = yang.gdata.from_xml_opt_list(node, 'vrf-group')
+    yang.gdata.maybe_add(children, 'vrf-group', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups__vrf_group, child_vrf_group)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg', module='Cisco-IOS-XR-um-vrf-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__process_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__is_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net__net_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry(yang.adata.MNode):
     net_id: str
@@ -3058,10 +3252,6 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__n
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry(net_id=n.get_str('net-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry:
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry(net_id=yang.gdata.from_xml_str(n, 'net-id'))
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry]
@@ -3099,13 +3289,18 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__n
                 res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_net_id = yang.gdata.from_xml_str(node, 'net-id')
+    yang.gdata.maybe_add(children, 'net-id', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net__net_id, child_net_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_net_id)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net_element(e))
+    return yang.gdata.List(keys=['net-id'], elements=elements)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(yang.adata.MNode):
     net: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net
@@ -3127,15 +3322,21 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(ya
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(net=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net.from_gdata(n.get_opt_list('net')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(net=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net.from_xml(yang.gdata.get_xml_children(n, 'net')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_net = yang.gdata.from_xml_opt_list(node, 'net')
+    yang.gdata.maybe_add(children, 'net', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets__net, child_net)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__af_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__saf_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls__sr_prefer(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls(yang.adata.MNode):
     sr_prefer: ?bool
@@ -3157,12 +3358,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls(sr_prefer=n.get_opt_bool('sr-prefer'))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls(sr_prefer=yang.gdata.from_xml_opt_bool(n, 'sr-prefer'))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sr_prefer = yang.gdata.from_xml_opt_bool(node, 'sr-prefer')
+    yang.gdata.maybe_add(children, 'sr-prefer', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls__sr_prefer, child_sr_prefer)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing(yang.adata.MNode):
     mpls: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls
@@ -3184,12 +3385,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing(mpls=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls.from_gdata(n.get_opt_container('mpls')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing(mpls=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls.from_xml(yang.gdata.get_xml_opt_child(n, 'mpls')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_mpls = yang.gdata.from_xml_opt_cnt(node, 'mpls')
+    yang.gdata.maybe_add(children, 'mpls', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing__mpls, child_mpls)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow(yang.adata.MNode):
 
@@ -3207,12 +3408,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide(yang.adata.MNode):
 
@@ -3230,12 +3429,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition(yang.adata.MNode):
 
@@ -3253,13 +3450,13 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__level_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow(yang.adata.MNode):
 
@@ -3277,12 +3474,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide(yang.adata.MNode):
 
@@ -3300,12 +3495,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition(yang.adata.MNode):
 
@@ -3323,12 +3516,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry(yang.adata.MNode):
     level_id: int
@@ -3378,10 +3569,6 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry(level_id=n.get_int('level-id'), narrow=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow.from_gdata(n.get_opt_container('narrow')), wide=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide.from_gdata(n.get_opt_container('wide')), transition=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition.from_gdata(n.get_opt_container('transition')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry:
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry(level_id=yang.gdata.from_xml_int(n, 'level-id'), narrow=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow.from_xml(yang.gdata.get_xml_opt_child(n, 'narrow')), wide=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide.from_xml(yang.gdata.get_xml_opt_child(n, 'wide')), transition=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition.from_xml(yang.gdata.get_xml_opt_child(n, 'transition')))
-
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry]
     mut def __init__(self, elements=[]):
@@ -3418,13 +3605,24 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
                 res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_level_id = yang.gdata.from_xml_int(node, 'level-id')
+    yang.gdata.maybe_add(children, 'level-id', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__level_id, child_level_id)
+    child_narrow = yang.gdata.from_xml_opt_cnt(node, 'narrow')
+    yang.gdata.maybe_add(children, 'narrow', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__narrow, child_narrow)
+    child_wide = yang.gdata.from_xml_opt_cnt(node, 'wide')
+    yang.gdata.maybe_add(children, 'wide', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__wide, child_wide)
+    child_transition = yang.gdata.from_xml_opt_cnt(node, 'transition')
+    yang.gdata.maybe_add(children, 'transition', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level__transition, child_transition)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_level_id)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level_element(e))
+    return yang.gdata.List(keys=['level-id'], elements=elements)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels(yang.adata.MNode):
     level: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level
@@ -3446,12 +3644,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels(level=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level.from_gdata(n.get_opt_list('level')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels(level=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level.from_xml(yang.gdata.get_xml_children(n, 'level')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_level = yang.gdata.from_xml_opt_list(node, 'level')
+    yang.gdata.maybe_add(children, 'level', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels__level, child_level)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style(yang.adata.MNode):
     narrow: ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow
@@ -3503,12 +3701,18 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style(narrow=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow.from_gdata(n.get_opt_container('narrow')), wide=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide.from_gdata(n.get_opt_container('wide')), transition=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition.from_gdata(n.get_opt_container('transition')), levels=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels.from_gdata(n.get_opt_container('levels')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style(narrow=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow.from_xml(yang.gdata.get_xml_opt_child(n, 'narrow')), wide=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide.from_xml(yang.gdata.get_xml_opt_child(n, 'wide')), transition=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition.from_xml(yang.gdata.get_xml_opt_child(n, 'transition')), levels=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels.from_xml(yang.gdata.get_xml_opt_child(n, 'levels')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_narrow = yang.gdata.from_xml_opt_cnt(node, 'narrow')
+    yang.gdata.maybe_add(children, 'narrow', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__narrow, child_narrow)
+    child_wide = yang.gdata.from_xml_opt_cnt(node, 'wide')
+    yang.gdata.maybe_add(children, 'wide', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__wide, child_wide)
+    child_transition = yang.gdata.from_xml_opt_cnt(node, 'transition')
+    yang.gdata.maybe_add(children, 'transition', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__transition, child_transition)
+    child_levels = yang.gdata.from_xml_opt_cnt(node, 'levels')
+    yang.gdata.maybe_add(children, 'levels', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style__levels, child_levels)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry(yang.adata.MNode):
     af_name: str
@@ -3542,10 +3746,6 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry(af_name=n.get_str('af-name'), saf_name=n.get_str('saf-name'), segment_routing=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing.from_gdata(n.get_opt_container('segment-routing')), metric_style=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style.from_gdata(n.get_opt_container('metric-style')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry:
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry(af_name=yang.gdata.from_xml_str(n, 'af-name'), saf_name=yang.gdata.from_xml_str(n, 'saf-name'), segment_routing=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing.from_xml(yang.gdata.get_xml_opt_child(n, 'segment-routing')), metric_style=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style.from_xml(yang.gdata.get_xml_opt_child(n, 'metric-style')))
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry]
@@ -3586,13 +3786,24 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
                 res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af_name = yang.gdata.from_xml_str(node, 'af-name')
+    yang.gdata.maybe_add(children, 'af-name', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__af_name, child_af_name)
+    child_saf_name = yang.gdata.from_xml_str(node, 'saf-name')
+    yang.gdata.maybe_add(children, 'saf-name', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__saf_name, child_saf_name)
+    child_segment_routing = yang.gdata.from_xml_opt_cnt(node, 'segment-routing')
+    yang.gdata.maybe_add(children, 'segment-routing', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__segment_routing, child_segment_routing)
+    child_metric_style = yang.gdata.from_xml_opt_cnt(node, 'metric-style')
+    yang.gdata.maybe_add(children, 'metric-style', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family__metric_style, child_metric_style)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af_name), yang.gdata.yang_str(child_saf_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family_element(e))
+    return yang.gdata.List(keys=['af-name', 'saf-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families(yang.adata.MNode):
     address_family: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family
@@ -3614,14 +3825,18 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families(address_family=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families(address_family=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__interface_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__circuit_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point(yang.adata.MNode):
 
@@ -3639,12 +3854,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4(yang.adata.MNode):
 
@@ -3662,12 +3875,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6(yang.adata.MNode):
 
@@ -3685,12 +3896,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect(yang.adata.MNode):
     ipv4: ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4
@@ -3727,14 +3936,20 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect(ipv4=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6.from_gdata(n.get_opt_container('ipv6')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect(ipv4=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv4')), ipv6=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv6')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_cnt(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_cnt(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect__ipv6, child_ipv6)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__minimum_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__multiplier(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd(yang.adata.MNode):
     fast_detect: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect
@@ -3766,12 +3981,16 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd(fast_detect=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect.from_gdata(n.get_opt_container('fast-detect')), minimum_interval=n.get_opt_int('minimum-interval'), multiplier=n.get_opt_int('multiplier'))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd(fast_detect=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect.from_xml(yang.gdata.get_xml_opt_child(n, 'fast-detect')), minimum_interval=yang.gdata.from_xml_opt_int(n, 'minimum-interval'), multiplier=yang.gdata.from_xml_opt_int(n, 'multiplier'))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_fast_detect = yang.gdata.from_xml_opt_cnt(node, 'fast-detect')
+    yang.gdata.maybe_add(children, 'fast-detect', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__fast_detect, child_fast_detect)
+    child_minimum_interval = yang.gdata.from_xml_opt_int(node, 'minimum-interval')
+    yang.gdata.maybe_add(children, 'minimum-interval', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__minimum_interval, child_minimum_interval)
+    child_multiplier = yang.gdata.from_xml_opt_int(node, 'multiplier')
+    yang.gdata.maybe_add(children, 'multiplier', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd__multiplier, child_multiplier)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive(yang.adata.MNode):
 
@@ -3789,15 +4008,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__af_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__saf_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__default_metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum(yang.adata.MNode):
 
@@ -3815,14 +4038,16 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__level_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__default_metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum(yang.adata.MNode):
 
@@ -3840,12 +4065,10 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry(yang.adata.MNode):
     level_id: int
@@ -3879,10 +4102,6 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry(level_id=n.get_int('level-id'), default_metric=n.get_opt_int('default-metric'), maximum=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum.from_gdata(n.get_opt_container('maximum')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry:
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry(level_id=yang.gdata.from_xml_int(n, 'level-id'), default_metric=yang.gdata.from_xml_opt_int(n, 'default-metric'), maximum=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum.from_xml(yang.gdata.get_xml_opt_child(n, 'maximum')))
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry]
@@ -3920,13 +4139,22 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
                 res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_level_id = yang.gdata.from_xml_int(node, 'level-id')
+    yang.gdata.maybe_add(children, 'level-id', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__level_id, child_level_id)
+    child_default_metric = yang.gdata.from_xml_opt_int(node, 'default-metric')
+    yang.gdata.maybe_add(children, 'default-metric', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__default_metric, child_default_metric)
+    child_maximum = yang.gdata.from_xml_opt_cnt(node, 'maximum')
+    yang.gdata.maybe_add(children, 'maximum', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level__maximum, child_maximum)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_level_id)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level_element(e))
+    return yang.gdata.List(keys=['level-id'], elements=elements)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels(yang.adata.MNode):
     level: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level
@@ -3948,12 +4176,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels(level=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level.from_gdata(n.get_opt_list('level')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels(level=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level.from_xml(yang.gdata.get_xml_children(n, 'level')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_level = yang.gdata.from_xml_opt_list(node, 'level')
+    yang.gdata.maybe_add(children, 'level', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels__level, child_level)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric(yang.adata.MNode):
     default_metric: ?int
@@ -3990,13 +4218,19 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric(default_metric=n.get_opt_int('default-metric'), maximum=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum.from_gdata(n.get_opt_container('maximum')), levels=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels.from_gdata(n.get_opt_container('levels')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric(default_metric=yang.gdata.from_xml_opt_int(n, 'default-metric'), maximum=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum.from_xml(yang.gdata.get_xml_opt_child(n, 'maximum')), levels=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels.from_xml(yang.gdata.get_xml_opt_child(n, 'levels')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_default_metric = yang.gdata.from_xml_opt_int(node, 'default-metric')
+    yang.gdata.maybe_add(children, 'default-metric', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__default_metric, child_default_metric)
+    child_maximum = yang.gdata.from_xml_opt_cnt(node, 'maximum')
+    yang.gdata.maybe_add(children, 'maximum', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__maximum, child_maximum)
+    child_levels = yang.gdata.from_xml_opt_cnt(node, 'levels')
+    yang.gdata.maybe_add(children, 'levels', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric__levels, child_levels)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index__sid_index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index(yang.adata.MNode):
     sid_index: ?int
@@ -4018,12 +4252,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index(sid_index=n.get_opt_int('sid-index'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index(sid_index=yang.gdata.from_xml_opt_int(n, 'sid-index'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sid_index = yang.gdata.from_xml_int(node, 'sid-index')
+    yang.gdata.maybe_add(children, 'sid-index', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index__sid_index, child_sid_index)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid(yang.adata.MNode):
     index: ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index
@@ -4050,12 +4284,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid(index=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index.from_gdata(n.get_opt_container('index')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid(index=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index.from_xml(yang.gdata.get_xml_opt_child(n, 'index')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_index = yang.gdata.from_xml_opt_cnt(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid__index, child_index)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid(yang.adata.MNode):
     sid: ?Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid
@@ -4082,12 +4316,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid(sid=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid.from_gdata(n.get_opt_container('sid')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid(sid=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid.from_xml(yang.gdata.get_xml_opt_child(n, 'sid')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sid = yang.gdata.from_xml_opt_cnt(node, 'sid')
+    yang.gdata.maybe_add(children, 'sid', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid__sid, child_sid)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry(yang.adata.MNode):
     af_name: str
@@ -4121,10 +4355,6 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry(af_name=n.get_str('af-name'), saf_name=n.get_str('saf-name'), metric=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric.from_gdata(n.get_opt_container('metric')), prefix_sid=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid.from_gdata(n.get_opt_container('prefix-sid')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry:
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry(af_name=yang.gdata.from_xml_str(n, 'af-name'), saf_name=yang.gdata.from_xml_str(n, 'saf-name'), metric=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric.from_xml(yang.gdata.get_xml_opt_child(n, 'metric')), prefix_sid=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid.from_xml(yang.gdata.get_xml_opt_child(n, 'prefix-sid')))
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry]
@@ -4165,13 +4395,24 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
                 res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af_name = yang.gdata.from_xml_str(node, 'af-name')
+    yang.gdata.maybe_add(children, 'af-name', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__af_name, child_af_name)
+    child_saf_name = yang.gdata.from_xml_str(node, 'saf-name')
+    yang.gdata.maybe_add(children, 'saf-name', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__saf_name, child_saf_name)
+    child_metric = yang.gdata.from_xml_opt_cnt(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__metric, child_metric)
+    child_prefix_sid = yang.gdata.from_xml_opt_cnt(node, 'prefix-sid')
+    yang.gdata.maybe_add(children, 'prefix-sid', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family__prefix_sid, child_prefix_sid)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af_name), yang.gdata.yang_str(child_saf_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family_element(e))
+    return yang.gdata.List(keys=['af-name', 'saf-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families(yang.adata.MNode):
     address_family: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family
@@ -4193,12 +4434,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families(address_family=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families(address_family=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry(yang.adata.MNode):
     interface_name: str
@@ -4253,10 +4494,6 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry(interface_name=n.get_str('interface-name'), circuit_type=n.get_opt_str('circuit-type'), point_to_point=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point.from_gdata(n.get_opt_container('point-to-point')), bfd=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd.from_gdata(n.get_opt_container('bfd')), passive=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive.from_gdata(n.get_opt_container('passive')), address_families=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families.from_gdata(n.get_opt_container('address-families')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry:
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry(interface_name=yang.gdata.from_xml_str(n, 'interface-name'), circuit_type=yang.gdata.from_xml_opt_str(n, 'circuit-type'), point_to_point=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point.from_xml(yang.gdata.get_xml_opt_child(n, 'point-to-point')), bfd=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd.from_xml(yang.gdata.get_xml_opt_child(n, 'bfd')), passive=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive.from_xml(yang.gdata.get_xml_opt_child(n, 'passive')), address_families=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families.from_xml(yang.gdata.get_xml_opt_child(n, 'address-families')))
-
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -4293,13 +4530,28 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
                 res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_interface_name = yang.gdata.from_xml_str(node, 'interface-name')
+    yang.gdata.maybe_add(children, 'interface-name', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__interface_name, child_interface_name)
+    child_circuit_type = yang.gdata.from_xml_opt_str(node, 'circuit-type')
+    yang.gdata.maybe_add(children, 'circuit-type', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__circuit_type, child_circuit_type)
+    child_point_to_point = yang.gdata.from_xml_opt_cnt(node, 'point-to-point')
+    yang.gdata.maybe_add(children, 'point-to-point', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__point_to_point, child_point_to_point)
+    child_bfd = yang.gdata.from_xml_opt_cnt(node, 'bfd')
+    yang.gdata.maybe_add(children, 'bfd', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__bfd, child_bfd)
+    child_passive = yang.gdata.from_xml_opt_cnt(node, 'passive')
+    yang.gdata.maybe_add(children, 'passive', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__passive, child_passive)
+    child_address_families = yang.gdata.from_xml_opt_cnt(node, 'address-families')
+    yang.gdata.maybe_add(children, 'address-families', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface__address_families, child_address_families)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_interface_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface_element(e))
+    return yang.gdata.List(keys=['interface-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces(yang.adata.MNode):
     interface: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface
@@ -4321,12 +4573,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfa
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces(interface=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces(interface=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces__interface, child_interface)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry(yang.adata.MNode):
     process_id: str
@@ -4366,10 +4618,6 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry(ya
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry:
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry(process_id=n.get_str('process-id'), is_type=n.get_opt_str('is-type'), nets=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets.from_gdata(n.get_opt_container('nets')), address_families=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families.from_gdata(n.get_opt_container('address-families')), interfaces=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces.from_gdata(n.get_opt_container('interfaces')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry:
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry(process_id=yang.gdata.from_xml_str(n, 'process-id'), is_type=yang.gdata.from_xml_opt_str(n, 'is-type'), nets=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets.from_xml(yang.gdata.get_xml_opt_child(n, 'nets')), address_families=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families.from_xml(yang.gdata.get_xml_opt_child(n, 'address-families')), interfaces=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces.from_xml(yang.gdata.get_xml_opt_child(n, 'interfaces')))
-
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry]
     mut def __init__(self, elements=[]):
@@ -4406,13 +4654,26 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process(yang.ada
                 res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_process_id = yang.gdata.from_xml_str(node, 'process-id')
+    yang.gdata.maybe_add(children, 'process-id', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__process_id, child_process_id)
+    child_is_type = yang.gdata.from_xml_opt_str(node, 'is-type')
+    yang.gdata.maybe_add(children, 'is-type', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__is_type, child_is_type)
+    child_nets = yang.gdata.from_xml_opt_cnt(node, 'nets')
+    yang.gdata.maybe_add(children, 'nets', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__nets, child_nets)
+    child_address_families = yang.gdata.from_xml_opt_cnt(node, 'address-families')
+    yang.gdata.maybe_add(children, 'address-families', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__address_families, child_address_families)
+    child_interfaces = yang.gdata.from_xml_opt_cnt(node, 'interfaces')
+    yang.gdata.maybe_add(children, 'interfaces', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process__interfaces, child_interfaces)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_process_id)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process_element(e))
+    return yang.gdata.List(keys=['process-id'], elements=elements)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(yang.adata.MNode):
     process: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process
@@ -4434,12 +4695,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(yang.adata.MNode)
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(process=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process.from_gdata(n.get_opt_list('process')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(process=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process.from_xml(yang.gdata.get_xml_children(n, 'process')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_process = yang.gdata.from_xml_opt_list(node, 'process')
+    yang.gdata.maybe_add(children, 'process', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes__process, child_process)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router__isis(yang.adata.MNode):
     processes: Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes
@@ -4461,12 +4722,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router__isis(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_isis_cfg__router__isis(processes=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes.from_gdata(n.get_opt_container('processes')))
         return Cisco_IOS_XR_um_router_isis_cfg__router__isis()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router__isis:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router__isis(processes=Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes.from_xml(yang.gdata.get_xml_opt_child(n, 'processes')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router__isis()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_processes = yang.gdata.from_xml_opt_cnt(node, 'processes')
+    yang.gdata.maybe_add(children, 'processes', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis__processes, child_processes)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_isis_cfg__router(yang.adata.MNode):
     isis: Cisco_IOS_XR_um_router_isis_cfg__router__isis
@@ -4488,12 +4749,12 @@ class Cisco_IOS_XR_um_router_isis_cfg__router(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_isis_cfg__router(isis=Cisco_IOS_XR_um_router_isis_cfg__router__isis.from_gdata(n.get_opt_container('isis')))
         return Cisco_IOS_XR_um_router_isis_cfg__router()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_isis_cfg__router:
-        if n != None:
-            return Cisco_IOS_XR_um_router_isis_cfg__router(isis=Cisco_IOS_XR_um_router_isis_cfg__router__isis.from_xml(yang.gdata.get_xml_opt_child(n, 'isis')))
-        return Cisco_IOS_XR_um_router_isis_cfg__router()
 
+mut def from_xml_Cisco_IOS_XR_um_router_isis_cfg__router(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_isis = yang.gdata.from_xml_opt_cnt(node, 'isis')
+    yang.gdata.maybe_add(children, 'isis', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router__isis, child_isis)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-isis-cfg', module='Cisco-IOS-XR-um-router-isis-cfg')
 
 class Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot(yang.adata.MNode):
 
@@ -4511,12 +4772,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain(yang.adata.MNode):
 
@@ -4534,12 +4793,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__as_format(yang.adata.MNode):
     asdot: ?Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot
@@ -4576,13 +4833,17 @@ class Cisco_IOS_XR_um_router_bgp_cfg__as_format(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__as_format(asdot=Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot.from_gdata(n.get_opt_container('asdot')), asplain=Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain.from_gdata(n.get_opt_container('asplain')))
         return Cisco_IOS_XR_um_router_bgp_cfg__as_format()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__as_format:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__as_format(asdot=Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot.from_xml(yang.gdata.get_xml_opt_child(n, 'asdot')), asplain=Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain.from_xml(yang.gdata.get_xml_opt_child(n, 'asplain')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__as_format()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_asdot = yang.gdata.from_xml_opt_cnt(node, 'asdot')
+    yang.gdata.maybe_add(children, 'asdot', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format__asdot, child_asdot)
+    child_asplain = yang.gdata.from_xml_opt_cnt(node, 'asplain')
+    yang.gdata.maybe_add(children, 'asplain', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format__asplain, child_asplain)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg', module='Cisco-IOS-XR-um-router-bgp-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__bmp_server_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown(yang.adata.MNode):
 
@@ -4600,14 +4861,16 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown(yang.adata.
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host__host_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host__port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(yang.adata.MNode):
     host_name: ?str
@@ -4634,17 +4897,29 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(yang.adata.MNod
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(host_name=n.get_opt_str('host-name'), port=n.get_opt_int('port'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(host_name=yang.gdata.from_xml_opt_str(n, 'host-name'), port=yang.gdata.from_xml_opt_int(n, 'port'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_host_name = yang.gdata.from_xml_str(node, 'host-name')
+    yang.gdata.maybe_add(children, 'host-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host__host_name, child_host_name)
+    child_port = yang.gdata.from_xml_opt_int(node, 'port')
+    yang.gdata.maybe_add(children, 'port', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host__port, child_port)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_delay(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__flapping_delay(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__max_buffer_size(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay__initial_delay(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay__spread(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay(yang.adata.MNode):
     initial_delay: ?int
@@ -4671,12 +4946,14 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__del
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay(initial_delay=n.get_opt_int('initial-delay'), spread=n.get_opt_int('spread'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay(initial_delay=yang.gdata.from_xml_opt_int(n, 'initial-delay'), spread=yang.gdata.from_xml_opt_int(n, 'spread'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_initial_delay = yang.gdata.from_xml_int(node, 'initial-delay')
+    yang.gdata.maybe_add(children, 'initial-delay', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay__initial_delay, child_initial_delay)
+    child_spread = yang.gdata.from_xml_opt_int(node, 'spread')
+    yang.gdata.maybe_add(children, 'spread', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay__spread, child_spread)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip(yang.adata.MNode):
 
@@ -4694,12 +4971,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__ski
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(yang.adata.MNode):
     delay: ?Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay
@@ -4736,20 +5011,38 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(yang
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(delay=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay.from_gdata(n.get_opt_container('delay')), skip=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip.from_gdata(n.get_opt_container('skip')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(delay=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay.from_xml(yang.gdata.get_xml_opt_child(n, 'delay')), skip=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip.from_xml(yang.gdata.get_xml_opt_child(n, 'skip')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_delay = yang.gdata.from_xml_opt_cnt(node, 'delay')
+    yang.gdata.maybe_add(children, 'delay', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__delay, child_delay)
+    child_skip = yang.gdata.from_xml_opt_cnt(node, 'skip')
+    yang.gdata.maybe_add(children, 'skip', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh__skip, child_skip)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__stats_reporting_period(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__dscp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__precedence(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__update_source(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__vrf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp__keep_alive(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp__mss(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(yang.adata.MNode):
     keep_alive: ?int
@@ -4776,12 +5069,14 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(yang.adata.MNode
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(keep_alive=n.get_opt_int('keep-alive'), mss=n.get_opt_int('mss'))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(keep_alive=yang.gdata.from_xml_opt_int(n, 'keep-alive'), mss=yang.gdata.from_xml_opt_int(n, 'mss'))
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_keep_alive = yang.gdata.from_xml_opt_int(node, 'keep-alive')
+    yang.gdata.maybe_add(children, 'keep-alive', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp__keep_alive, child_keep_alive)
+    child_mss = yang.gdata.from_xml_opt_int(node, 'mss')
+    yang.gdata.maybe_add(children, 'mss', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp__mss, child_mss)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry(yang.adata.MNode):
     bmp_server_id: int
@@ -4876,10 +5171,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry(yang.adata.MNod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry(bmp_server_id=n.get_int('bmp-server-id'), shutdown=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown.from_gdata(n.get_opt_container('shutdown')), host=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host.from_gdata(n.get_opt_container('host')), initial_delay=n.get_opt_int('initial-delay'), flapping_delay=n.get_opt_int('flapping-delay'), max_buffer_size=n.get_opt_int('max-buffer-size'), initial_refresh=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh.from_gdata(n.get_opt_container('initial-refresh')), stats_reporting_period=n.get_opt_int('stats-reporting-period'), description=n.get_opt_str('description'), dscp=n.get_opt_str('dscp'), precedence=n.get_opt_str('precedence'), update_source=n.get_opt_str('update-source'), vrf=n.get_opt_str('vrf'), tcp=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp.from_gdata(n.get_opt_container('tcp')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry(bmp_server_id=yang.gdata.from_xml_int(n, 'bmp-server-id'), shutdown=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown.from_xml(yang.gdata.get_xml_opt_child(n, 'shutdown')), host=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host.from_xml(yang.gdata.get_xml_opt_child(n, 'host')), initial_delay=yang.gdata.from_xml_opt_int(n, 'initial-delay'), flapping_delay=yang.gdata.from_xml_opt_int(n, 'flapping-delay'), max_buffer_size=yang.gdata.from_xml_opt_int(n, 'max-buffer-size'), initial_refresh=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh.from_xml(yang.gdata.get_xml_opt_child(n, 'initial-refresh')), stats_reporting_period=yang.gdata.from_xml_opt_int(n, 'stats-reporting-period'), description=yang.gdata.from_xml_opt_str(n, 'description'), dscp=yang.gdata.from_xml_opt_str(n, 'dscp'), precedence=yang.gdata.from_xml_opt_str(n, 'precedence'), update_source=yang.gdata.from_xml_opt_str(n, 'update-source'), vrf=yang.gdata.from_xml_opt_str(n, 'vrf'), tcp=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp.from_xml(yang.gdata.get_xml_opt_child(n, 'tcp')))
-
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry]
     mut def __init__(self, elements=[]):
@@ -4916,17 +5207,56 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server(yang.adata.MNode):
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_bmp_server_id = yang.gdata.from_xml_int(node, 'bmp-server-id')
+    yang.gdata.maybe_add(children, 'bmp-server-id', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__bmp_server_id, child_bmp_server_id)
+    child_shutdown = yang.gdata.from_xml_opt_cnt(node, 'shutdown')
+    yang.gdata.maybe_add(children, 'shutdown', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__shutdown, child_shutdown)
+    child_host = yang.gdata.from_xml_opt_cnt(node, 'host')
+    yang.gdata.maybe_add(children, 'host', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__host, child_host)
+    child_initial_delay = yang.gdata.from_xml_opt_int(node, 'initial-delay')
+    yang.gdata.maybe_add(children, 'initial-delay', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_delay, child_initial_delay)
+    child_flapping_delay = yang.gdata.from_xml_opt_int(node, 'flapping-delay')
+    yang.gdata.maybe_add(children, 'flapping-delay', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__flapping_delay, child_flapping_delay)
+    child_max_buffer_size = yang.gdata.from_xml_opt_int(node, 'max-buffer-size')
+    yang.gdata.maybe_add(children, 'max-buffer-size', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__max_buffer_size, child_max_buffer_size)
+    child_initial_refresh = yang.gdata.from_xml_opt_cnt(node, 'initial-refresh')
+    yang.gdata.maybe_add(children, 'initial-refresh', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__initial_refresh, child_initial_refresh)
+    child_stats_reporting_period = yang.gdata.from_xml_opt_int(node, 'stats-reporting-period')
+    yang.gdata.maybe_add(children, 'stats-reporting-period', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__stats_reporting_period, child_stats_reporting_period)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__description, child_description)
+    child_dscp = yang.gdata.from_xml_opt_str(node, 'dscp')
+    yang.gdata.maybe_add(children, 'dscp', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__dscp, child_dscp)
+    child_precedence = yang.gdata.from_xml_opt_str(node, 'precedence')
+    yang.gdata.maybe_add(children, 'precedence', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__precedence, child_precedence)
+    child_update_source = yang.gdata.from_xml_opt_str(node, 'update-source')
+    yang.gdata.maybe_add(children, 'update-source', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__update_source, child_update_source)
+    child_vrf = yang.gdata.from_xml_opt_str(node, 'vrf')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__vrf, child_vrf)
+    child_tcp = yang.gdata.from_xml_opt_cnt(node, 'tcp')
+    yang.gdata.maybe_add(children, 'tcp', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server__tcp, child_tcp)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_bmp_server_id)])
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server_element(e))
+    return yang.gdata.List(keys=['bmp-server-id'], elements=elements)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__max_buffer_size(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode__mode_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode__advertisement_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode__scan_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry(yang.adata.MNode):
     mode_name: str
@@ -4955,10 +5285,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_m
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry(mode_name=n.get_str('mode-name'), advertisement_interval=n.get_opt_int('advertisement-interval'), scan_time=n.get_opt_int('scan-time'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry(mode_name=yang.gdata.from_xml_str(n, 'mode-name'), advertisement_interval=yang.gdata.from_xml_opt_int(n, 'advertisement-interval'), scan_time=yang.gdata.from_xml_opt_int(n, 'scan-time'))
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry]
@@ -4996,13 +5322,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_m
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_mode_name = yang.gdata.from_xml_str(node, 'mode-name')
+    yang.gdata.maybe_add(children, 'mode-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode__mode_name, child_mode_name)
+    child_advertisement_interval = yang.gdata.from_xml_opt_int(node, 'advertisement-interval')
+    yang.gdata.maybe_add(children, 'advertisement-interval', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode__advertisement_interval, child_advertisement_interval)
+    child_scan_time = yang.gdata.from_xml_opt_int(node, 'scan-time')
+    yang.gdata.maybe_add(children, 'scan-time', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode__scan_time, child_scan_time)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_mode_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode_element(e))
+    return yang.gdata.List(keys=['mode-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes(yang.adata.MNode):
     bmp_mode: Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode
@@ -5024,12 +5359,12 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_m
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes(bmp_mode=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode.from_gdata(n.get_opt_list('bmp-mode')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes(bmp_mode=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode.from_xml(yang.gdata.get_xml_children(n, 'bmp-mode')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bmp_mode = yang.gdata.from_xml_opt_list(node, 'bmp-mode')
+    yang.gdata.maybe_add(children, 'bmp-mode', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes__bmp_mode, child_bmp_mode)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(yang.adata.MNode):
     bmp_modes: Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes
@@ -5051,12 +5386,12 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(yang.a
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(bmp_modes=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes.from_gdata(n.get_opt_container('bmp-modes')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(bmp_modes=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes.from_xml(yang.gdata.get_xml_opt_child(n, 'bmp-modes')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bmp_modes = yang.gdata.from_xml_opt_cnt(node, 'bmp-modes')
+    yang.gdata.maybe_add(children, 'bmp-modes', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring__bmp_modes, child_bmp_modes)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(yang.adata.MNode):
     max_buffer_size: ?int
@@ -5083,12 +5418,14 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(max_buffer_size=n.get_opt_int('max-buffer-size'), route_monitoring=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring.from_gdata(n.get_opt_container('route-monitoring')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(max_buffer_size=yang.gdata.from_xml_opt_int(n, 'max-buffer-size'), route_monitoring=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring.from_xml(yang.gdata.get_xml_opt_child(n, 'route-monitoring')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_max_buffer_size = yang.gdata.from_xml_opt_int(node, 'max-buffer-size')
+    yang.gdata.maybe_add(children, 'max-buffer-size', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__max_buffer_size, child_max_buffer_size)
+    child_route_monitoring = yang.gdata.from_xml_opt_cnt(node, 'route-monitoring')
+    yang.gdata.maybe_add(children, 'route-monitoring', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all__route_monitoring, child_route_monitoring)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(yang.adata.MNode):
     server: Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server
@@ -5115,12 +5452,14 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(server=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server.from_gdata(n.get_opt_list('server')), all=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all.from_gdata(n.get_opt_container('all')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(server=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server.from_xml(yang.gdata.get_xml_children(n, 'server')), all=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all.from_xml(yang.gdata.get_xml_opt_child(n, 'all')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_server = yang.gdata.from_xml_opt_list(node, 'server')
+    yang.gdata.maybe_add(children, 'server', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__server, child_server)
+    child_all = yang.gdata.from_xml_opt_cnt(node, 'all')
+    yang.gdata.maybe_add(children, 'all', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers__all, child_all)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__bmp(yang.adata.MNode):
     servers: Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers
@@ -5142,15 +5481,21 @@ class Cisco_IOS_XR_um_router_bgp_cfg__bmp(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__bmp(servers=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers.from_gdata(n.get_opt_container('servers')))
         return Cisco_IOS_XR_um_router_bgp_cfg__bmp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__bmp:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__bmp(servers=Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers.from_xml(yang.gdata.get_xml_opt_child(n, 'servers')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__bmp()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_servers = yang.gdata.from_xml_opt_cnt(node, 'servers')
+    yang.gdata.maybe_add(children, 'servers', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp__servers, child_servers)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg', module='Cisco-IOS-XR-um-router-bgp-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__server_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface__interface_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface(yang.adata.MNode):
     interface_name: ?str
@@ -5172,12 +5517,12 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bi
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface(interface_name=n.get_opt_str('interface-name'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface(interface_name=yang.gdata.from_xml_opt_str(n, 'interface-name'))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface_name = yang.gdata.from_xml_opt_str(node, 'interface-name')
+    yang.gdata.maybe_add(children, 'interface-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface__interface_name, child_interface_name)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source(yang.adata.MNode):
     interface: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface
@@ -5199,14 +5544,18 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bi
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source(interface=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface.from_gdata(n.get_opt_container('interface')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source(interface=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface.from_xml(yang.gdata.get_xml_opt_child(n, 'interface')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface = yang.gdata.from_xml_opt_cnt(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source__interface, child_interface)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__preference(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__refresh_time_value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off(yang.adata.MNode):
 
@@ -5224,12 +5573,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time(yang.adata.MNode):
     refresh_time_value: ?int
@@ -5261,13 +5608,17 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time(refresh_time_value=n.get_opt_int('refresh-time-value'), off=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off.from_gdata(n.get_opt_container('off')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time(refresh_time_value=yang.gdata.from_xml_opt_int(n, 'refresh-time-value'), off=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off.from_xml(yang.gdata.get_xml_opt_child(n, 'off')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_refresh_time_value = yang.gdata.from_xml_opt_int(node, 'refresh-time-value')
+    yang.gdata.maybe_add(children, 'refresh-time-value', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__refresh_time_value, child_refresh_time_value)
+    child_off = yang.gdata.from_xml_opt_cnt(node, 'off')
+    yang.gdata.maybe_add(children, 'off', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time__off, child_off)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__response_time_value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off(yang.adata.MNode):
 
@@ -5285,12 +5636,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time(yang.adata.MNode):
     response_time_value: ?int
@@ -5322,16 +5671,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__re
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time(response_time_value=n.get_opt_int('response-time-value'), off=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off.from_gdata(n.get_opt_container('off')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time(response_time_value=yang.gdata.from_xml_opt_int(n, 'response-time-value'), off=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off.from_xml(yang.gdata.get_xml_opt_child(n, 'off')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_response_time_value = yang.gdata.from_xml_opt_int(node, 'response-time-value')
+    yang.gdata.maybe_add(children, 'response-time-value', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__response_time_value, child_response_time_value)
+    child_off = yang.gdata.from_xml_opt_cnt(node, 'off')
+    yang.gdata.maybe_add(children, 'off', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time__off, child_off)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__purge_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__username(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__password(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp__port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp(yang.adata.MNode):
     port: ?int
@@ -5353,13 +5712,15 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp(port=n.get_opt_int('port'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp(port=yang.gdata.from_xml_opt_int(n, 'port'))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_port = yang.gdata.from_xml_opt_int(node, 'port')
+    yang.gdata.maybe_add(children, 'port', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp__port, child_port)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh__port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh(yang.adata.MNode):
     port: ?int
@@ -5381,12 +5742,12 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh(port=n.get_opt_int('port'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh(port=yang.gdata.from_xml_opt_int(n, 'port'))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_port = yang.gdata.from_xml_opt_int(node, 'port')
+    yang.gdata.maybe_add(children, 'port', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh__port, child_port)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport(yang.adata.MNode):
     tcp: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp
@@ -5413,12 +5774,14 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__tr
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport(tcp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp.from_gdata(n.get_opt_container('tcp')), ssh=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh.from_gdata(n.get_opt_container('ssh')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport(tcp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp.from_xml(yang.gdata.get_xml_opt_child(n, 'tcp')), ssh=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh.from_xml(yang.gdata.get_xml_opt_child(n, 'ssh')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_tcp = yang.gdata.from_xml_opt_cnt(node, 'tcp')
+    yang.gdata.maybe_add(children, 'tcp', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__tcp, child_tcp)
+    child_ssh = yang.gdata.from_xml_opt_cnt(node, 'ssh')
+    yang.gdata.maybe_add(children, 'ssh', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport__ssh, child_ssh)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown(yang.adata.MNode):
 
@@ -5436,12 +5799,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__sh
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry(yang.adata.MNode):
     server_id: str
@@ -5511,10 +5872,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_ent
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry(server_id=n.get_str('server-id'), bind_source=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source.from_gdata(n.get_opt_container('bind-source')), preference=n.get_opt_int('preference'), refresh_time=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time.from_gdata(n.get_opt_container('refresh-time')), response_time=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time.from_gdata(n.get_opt_container('response-time')), purge_time=n.get_opt_int('purge-time'), username=n.get_opt_str('username'), password=n.get_opt_str('password'), transport=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport.from_gdata(n.get_opt_container('transport')), shutdown=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown.from_gdata(n.get_opt_container('shutdown')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry(server_id=yang.gdata.from_xml_str(n, 'server-id'), bind_source=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source.from_xml(yang.gdata.get_xml_opt_child(n, 'bind-source')), preference=yang.gdata.from_xml_opt_int(n, 'preference'), refresh_time=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time.from_xml(yang.gdata.get_xml_opt_child(n, 'refresh-time')), response_time=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time.from_xml(yang.gdata.get_xml_opt_child(n, 'response-time')), purge_time=yang.gdata.from_xml_opt_int(n, 'purge-time'), username=yang.gdata.from_xml_opt_str(n, 'username'), password=yang.gdata.from_xml_opt_str(n, 'password'), transport=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport.from_xml(yang.gdata.get_xml_opt_child(n, 'transport')), shutdown=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown.from_xml(yang.gdata.get_xml_opt_child(n, 'shutdown')))
-
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry]
     mut def __init__(self, elements=[]):
@@ -5551,13 +5908,36 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server(yan
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_server_id = yang.gdata.from_xml_str(node, 'server-id')
+    yang.gdata.maybe_add(children, 'server-id', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__server_id, child_server_id)
+    child_bind_source = yang.gdata.from_xml_opt_cnt(node, 'bind-source')
+    yang.gdata.maybe_add(children, 'bind-source', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__bind_source, child_bind_source)
+    child_preference = yang.gdata.from_xml_opt_int(node, 'preference')
+    yang.gdata.maybe_add(children, 'preference', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__preference, child_preference)
+    child_refresh_time = yang.gdata.from_xml_opt_cnt(node, 'refresh-time')
+    yang.gdata.maybe_add(children, 'refresh-time', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__refresh_time, child_refresh_time)
+    child_response_time = yang.gdata.from_xml_opt_cnt(node, 'response-time')
+    yang.gdata.maybe_add(children, 'response-time', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__response_time, child_response_time)
+    child_purge_time = yang.gdata.from_xml_opt_int(node, 'purge-time')
+    yang.gdata.maybe_add(children, 'purge-time', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__purge_time, child_purge_time)
+    child_username = yang.gdata.from_xml_opt_str(node, 'username')
+    yang.gdata.maybe_add(children, 'username', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__username, child_username)
+    child_password = yang.gdata.from_xml_opt_str(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__password, child_password)
+    child_transport = yang.gdata.from_xml_opt_cnt(node, 'transport')
+    yang.gdata.maybe_add(children, 'transport', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__transport, child_transport)
+    child_shutdown = yang.gdata.from_xml_opt_cnt(node, 'shutdown')
+    yang.gdata.maybe_add(children, 'shutdown', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server__shutdown, child_shutdown)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_server_id)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server_element(e))
+    return yang.gdata.List(keys=['server-id'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(yang.adata.MNode):
     server: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server
@@ -5579,16 +5959,24 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(yang.adata.
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(server=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server.from_gdata(n.get_opt_list('server')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(server=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server.from_xml(yang.gdata.get_xml_children(n, 'server')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_server = yang.gdata.from_xml_opt_list(node, 'server')
+    yang.gdata.maybe_add(children, 'server', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers__server, child_server)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route__minimum_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route__maximum_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route__origin_as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry(yang.adata.MNode):
     address: str
@@ -5622,10 +6010,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry(address=n.get_str('address'), minimum_prefix_length=n.get_int('minimum-prefix-length'), maximum_prefix_length=n.get_int('maximum-prefix-length'), origin_as_number=n.get_int('origin-as-number'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry(address=yang.gdata.from_xml_str(n, 'address'), minimum_prefix_length=yang.gdata.from_xml_int(n, 'minimum-prefix-length'), maximum_prefix_length=yang.gdata.from_xml_int(n, 'maximum-prefix-length'), origin_as_number=yang.gdata.from_xml_int(n, 'origin-as-number'))
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry]
@@ -5672,13 +6056,24 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route(yang.
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route__address, child_address)
+    child_minimum_prefix_length = yang.gdata.from_xml_int(node, 'minimum-prefix-length')
+    yang.gdata.maybe_add(children, 'minimum-prefix-length', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route__minimum_prefix_length, child_minimum_prefix_length)
+    child_maximum_prefix_length = yang.gdata.from_xml_int(node, 'maximum-prefix-length')
+    yang.gdata.maybe_add(children, 'maximum-prefix-length', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route__maximum_prefix_length, child_maximum_prefix_length)
+    child_origin_as_number = yang.gdata.from_xml_int(node, 'origin-as-number')
+    yang.gdata.maybe_add(children, 'origin-as-number', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route__origin_as_number, child_origin_as_number)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_address), yang.gdata.yang_str(child_minimum_prefix_length), yang.gdata.yang_str(child_maximum_prefix_length), yang.gdata.yang_str(child_origin_as_number)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route_element(e))
+    return yang.gdata.List(keys=['address', 'minimum-prefix-length', 'maximum-prefix-length', 'origin-as-number'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(yang.adata.MNode):
     route: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route
@@ -5700,13 +6095,15 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(yang.adata.M
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(route=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route.from_gdata(n.get_opt_list('route')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(route=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route.from_xml(yang.gdata.get_xml_children(n, 'route')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route = yang.gdata.from_xml_opt_list(node, 'route')
+    yang.gdata.maybe_add(children, 'route', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes__route, child_route)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__datafile(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(yang.adata.MNode):
     servers: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers
@@ -5738,13 +6135,19 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(servers=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers.from_gdata(n.get_opt_container('servers')), routes=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes.from_gdata(n.get_opt_container('routes')), datafile=n.get_opt_str('datafile'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(servers=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers.from_xml(yang.gdata.get_xml_opt_child(n, 'servers')), routes=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes.from_xml(yang.gdata.get_xml_opt_child(n, 'routes')), datafile=yang.gdata.from_xml_opt_str(n, 'datafile'))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_servers = yang.gdata.from_xml_opt_cnt(node, 'servers')
+    yang.gdata.maybe_add(children, 'servers', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__servers, child_servers)
+    child_routes = yang.gdata.from_xml_opt_cnt(node, 'routes')
+    yang.gdata.maybe_add(children, 'routes', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__routes, child_routes)
+    child_datafile = yang.gdata.from_xml_opt_str(node, 'datafile')
+    yang.gdata.maybe_add(children, 'datafile', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki__datafile, child_datafile)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family__af_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry(yang.adata.MNode):
     af_name: str
@@ -5763,10 +6166,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry(af_name=n.get_str('af-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry(af_name=yang.gdata.from_xml_str(n, 'af-name'))
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry]
@@ -5804,13 +6203,18 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af_name = yang.gdata.from_xml_str(node, 'af-name')
+    yang.gdata.maybe_add(children, 'af-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family__af_name, child_af_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family_element(e))
+    return yang.gdata.List(keys=['af-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(yang.adata.MNode):
     address_family: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family
@@ -5832,15 +6236,21 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(yang.ada
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__neighbor_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use__session_group(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use__neighbor_group(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(yang.adata.MNode):
     session_group: ?str
@@ -5867,13 +6277,17 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(session_group=n.get_opt_str('session-group'), neighbor_group=n.get_opt_str('neighbor-group'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(session_group=yang.gdata.from_xml_opt_str(n, 'session-group'), neighbor_group=yang.gdata.from_xml_opt_str(n, 'neighbor-group'))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_session_group = yang.gdata.from_xml_opt_str(node, 'session-group')
+    yang.gdata.maybe_add(children, 'session-group', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use__session_group, child_session_group)
+    child_neighbor_group = yang.gdata.from_xml_opt_str(node, 'neighbor-group')
+    yang.gdata.maybe_add(children, 'neighbor-group', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use__neighbor_group, child_neighbor_group)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry(yang.adata.MNode):
     neighbor_address: str
@@ -5902,10 +6316,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry(neighbor_address=n.get_str('neighbor-address'), use=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use.from_gdata(n.get_opt_container('use')), description=n.get_opt_str('description'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry(neighbor_address=yang.gdata.from_xml_str(n, 'neighbor-address'), use=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use.from_xml(yang.gdata.get_xml_opt_child(n, 'use')), description=yang.gdata.from_xml_opt_str(n, 'description'))
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry]
@@ -5943,13 +6353,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor(yang.
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_neighbor_address = yang.gdata.from_xml_str(node, 'neighbor-address')
+    yang.gdata.maybe_add(children, 'neighbor-address', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__neighbor_address, child_neighbor_address)
+    child_use = yang.gdata.from_xml_opt_cnt(node, 'use')
+    yang.gdata.maybe_add(children, 'use', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__use, child_use)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor__description, child_description)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_neighbor_address)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor_element(e))
+    return yang.gdata.List(keys=['neighbor-address'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(yang.adata.MNode):
     neighbor: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor
@@ -5971,14 +6390,18 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(yang.adata.MNod
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(neighbor=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor.from_gdata(n.get_opt_list('neighbor')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(neighbor=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor.from_xml(yang.gdata.get_xml_children(n, 'neighbor')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_neighbor = yang.gdata.from_xml_opt_list(node, 'neighbor')
+    yang.gdata.maybe_add(children, 'neighbor', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors__neighbor, child_neighbor)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__neighbor_group_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family__af_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry(yang.adata.MNode):
     af_name: str
@@ -5997,10 +6420,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry(af_name=n.get_str('af-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry(af_name=yang.gdata.from_xml_str(n, 'af-name'))
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry]
@@ -6038,13 +6457,18 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af_name = yang.gdata.from_xml_str(node, 'af-name')
+    yang.gdata.maybe_add(children, 'af-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family__af_name, child_af_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family_element(e))
+    return yang.gdata.List(keys=['af-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families(yang.adata.MNode):
     address_family: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family
@@ -6066,15 +6490,21 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__remote_as(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__encrypted(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable(yang.adata.MNode):
 
@@ -6092,12 +6522,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password(yang.adata.MNode):
     encrypted: ?str
@@ -6129,13 +6557,17 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password(encrypted=n.get_opt_str('encrypted'), inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable.from_gdata(n.get_opt_container('inheritance-disable')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password(encrypted=yang.gdata.from_xml_opt_str(n, 'encrypted'), inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable.from_xml(yang.gdata.get_xml_opt_child(n, 'inheritance-disable')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_encrypted = yang.gdata.from_xml_opt_str(node, 'encrypted')
+    yang.gdata.maybe_add(children, 'encrypted', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__encrypted, child_encrypted)
+    child_inheritance_disable = yang.gdata.from_xml_opt_cnt(node, 'inheritance-disable')
+    yang.gdata.maybe_add(children, 'inheritance-disable', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password__inheritance_disable, child_inheritance_disable)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__update_source(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry(yang.adata.MNode):
     neighbor_group_name: str
@@ -6185,10 +6617,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry(neighbor_group_name=n.get_str('neighbor-group-name'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families.from_gdata(n.get_opt_container('address-families')), remote_as=n.get_opt_str('remote-as'), description=n.get_opt_str('description'), password=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password.from_gdata(n.get_opt_container('password')), update_source=n.get_opt_str('update-source'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry(neighbor_group_name=yang.gdata.from_xml_str(n, 'neighbor-group-name'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families.from_xml(yang.gdata.get_xml_opt_child(n, 'address-families')), remote_as=yang.gdata.from_xml_opt_str(n, 'remote-as'), description=yang.gdata.from_xml_opt_str(n, 'description'), password=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password.from_xml(yang.gdata.get_xml_opt_child(n, 'password')), update_source=yang.gdata.from_xml_opt_str(n, 'update-source'))
-
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry]
     mut def __init__(self, elements=[]):
@@ -6225,13 +6653,28 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_neighbor_group_name = yang.gdata.from_xml_str(node, 'neighbor-group-name')
+    yang.gdata.maybe_add(children, 'neighbor-group-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__neighbor_group_name, child_neighbor_group_name)
+    child_address_families = yang.gdata.from_xml_opt_cnt(node, 'address-families')
+    yang.gdata.maybe_add(children, 'address-families', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__address_families, child_address_families)
+    child_remote_as = yang.gdata.from_xml_opt_str(node, 'remote-as')
+    yang.gdata.maybe_add(children, 'remote-as', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__remote_as, child_remote_as)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__description, child_description)
+    child_password = yang.gdata.from_xml_opt_cnt(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__password, child_password)
+    child_update_source = yang.gdata.from_xml_opt_str(node, 'update-source')
+    yang.gdata.maybe_add(children, 'update-source', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group__update_source, child_update_source)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_neighbor_group_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group_element(e))
+    return yang.gdata.List(keys=['neighbor-group-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(yang.adata.MNode):
     neighbor_group: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group
@@ -6253,13 +6696,15 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(yang.adat
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(neighbor_group=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group.from_gdata(n.get_opt_list('neighbor-group')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(neighbor_group=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group.from_xml(yang.gdata.get_xml_children(n, 'neighbor-group')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_neighbor_group = yang.gdata.from_xml_opt_list(node, 'neighbor-group')
+    yang.gdata.maybe_add(children, 'neighbor-group', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups__neighbor_group, child_neighbor_group)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp__router_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(yang.adata.MNode):
     router_id: ?str
@@ -6281,14 +6726,18 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(router_id=n.get_opt_str('router-id'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(router_id=yang.gdata.from_xml_opt_str(n, 'router-id'))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_router_id = yang.gdata.from_xml_opt_str(node, 'router-id')
+    yang.gdata.maybe_add(children, 'router-id', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp__router_id, child_router_id)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__vrf_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family__af_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry(yang.adata.MNode):
     af_name: str
@@ -6307,10 +6756,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_famili
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry(af_name=n.get_str('af-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry(af_name=yang.gdata.from_xml_str(n, 'af-name'))
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry]
@@ -6348,13 +6793,18 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_famili
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af_name = yang.gdata.from_xml_str(node, 'af-name')
+    yang.gdata.maybe_add(children, 'af-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family__af_name, child_af_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family_element(e))
+    return yang.gdata.List(keys=['af-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families(yang.adata.MNode):
     address_family: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family
@@ -6376,18 +6826,30 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_famili
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__neighbor_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__af_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__in(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__out(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention__route_policy_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention__retention_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention(yang.adata.MNode):
     route_policy_name: ?str
@@ -6414,12 +6876,14 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention(route_policy_name=n.get_opt_str('route-policy-name'), retention_time=n.get_opt_int('retention-time'))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention(route_policy_name=yang.gdata.from_xml_opt_str(n, 'route-policy-name'), retention_time=yang.gdata.from_xml_opt_int(n, 'retention-time'))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_policy_name = yang.gdata.from_xml_opt_str(node, 'route-policy-name')
+    yang.gdata.maybe_add(children, 'route-policy-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention__route_policy_name, child_route_policy_name)
+    child_retention_time = yang.gdata.from_xml_opt_int(node, 'retention-time')
+    yang.gdata.maybe_add(children, 'retention-time', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention__retention_time, child_retention_time)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy(yang.adata.MNode):
     in_: ?str
@@ -6451,12 +6915,16 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy(in_=n.get_opt_str('in'), out=n.get_opt_str('out'), retention=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention.from_gdata(n.get_opt_container('retention')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy(in_=yang.gdata.from_xml_opt_str(n, 'in'), out=yang.gdata.from_xml_opt_str(n, 'out'), retention=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention.from_xml(yang.gdata.get_xml_opt_child(n, 'retention')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_in_ = yang.gdata.from_xml_opt_str(node, 'in')
+    yang.gdata.maybe_add(children, 'in', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__in, child_in_)
+    child_out = yang.gdata.from_xml_opt_str(node, 'out')
+    yang.gdata.maybe_add(children, 'out', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__out, child_out)
+    child_retention = yang.gdata.from_xml_opt_cnt(node, 'retention')
+    yang.gdata.maybe_add(children, 'retention', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy__retention, child_retention)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable(yang.adata.MNode):
 
@@ -6474,12 +6942,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override(yang.adata.MNode):
     inheritance_disable: ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable
@@ -6506,12 +6972,12 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override(inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable.from_gdata(n.get_opt_container('inheritance-disable')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override(inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable.from_xml(yang.gdata.get_xml_opt_child(n, 'inheritance-disable')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_inheritance_disable = yang.gdata.from_xml_opt_cnt(node, 'inheritance-disable')
+    yang.gdata.maybe_add(children, 'inheritance-disable', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override__inheritance_disable, child_inheritance_disable)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry(yang.adata.MNode):
     af_name: str
@@ -6545,10 +7011,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry(af_name=n.get_str('af-name'), route_policy=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy.from_gdata(n.get_opt_container('route-policy')), as_override=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override.from_gdata(n.get_opt_container('as-override')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry(af_name=yang.gdata.from_xml_str(n, 'af-name'), route_policy=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy.from_xml(yang.gdata.get_xml_opt_child(n, 'route-policy')), as_override=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override.from_xml(yang.gdata.get_xml_opt_child(n, 'as-override')))
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry]
@@ -6586,13 +7048,22 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af_name = yang.gdata.from_xml_str(node, 'af-name')
+    yang.gdata.maybe_add(children, 'af-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__af_name, child_af_name)
+    child_route_policy = yang.gdata.from_xml_opt_cnt(node, 'route-policy')
+    yang.gdata.maybe_add(children, 'route-policy', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__route_policy, child_route_policy)
+    child_as_override = yang.gdata.from_xml_opt_cnt(node, 'as-override')
+    yang.gdata.maybe_add(children, 'as-override', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family__as_override, child_as_override)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family_element(e))
+    return yang.gdata.List(keys=['af-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families(yang.adata.MNode):
     address_family: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family
@@ -6614,15 +7085,21 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families(address_family=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__remote_as(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__encrypted(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable(yang.adata.MNode):
 
@@ -6640,12 +7117,10 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password(yang.adata.MNode):
     encrypted: ?str
@@ -6677,12 +7152,14 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password(encrypted=n.get_opt_str('encrypted'), inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable.from_gdata(n.get_opt_container('inheritance-disable')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password(encrypted=yang.gdata.from_xml_opt_str(n, 'encrypted'), inheritance_disable=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable.from_xml(yang.gdata.get_xml_opt_child(n, 'inheritance-disable')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_encrypted = yang.gdata.from_xml_opt_str(node, 'encrypted')
+    yang.gdata.maybe_add(children, 'encrypted', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__encrypted, child_encrypted)
+    child_inheritance_disable = yang.gdata.from_xml_opt_cnt(node, 'inheritance-disable')
+    yang.gdata.maybe_add(children, 'inheritance-disable', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password__inheritance_disable, child_inheritance_disable)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry(yang.adata.MNode):
     neighbor_address: str
@@ -6727,10 +7204,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry(neighbor_address=n.get_str('neighbor-address'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families.from_gdata(n.get_opt_container('address-families')), remote_as=n.get_opt_str('remote-as'), description=n.get_opt_str('description'), password=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password.from_gdata(n.get_opt_container('password')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry(neighbor_address=yang.gdata.from_xml_str(n, 'neighbor-address'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families.from_xml(yang.gdata.get_xml_opt_child(n, 'address-families')), remote_as=yang.gdata.from_xml_opt_str(n, 'remote-as'), description=yang.gdata.from_xml_opt_str(n, 'description'), password=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password.from_xml(yang.gdata.get_xml_opt_child(n, 'password')))
-
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -6767,13 +7240,26 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__nei
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_neighbor_address = yang.gdata.from_xml_str(node, 'neighbor-address')
+    yang.gdata.maybe_add(children, 'neighbor-address', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__neighbor_address, child_neighbor_address)
+    child_address_families = yang.gdata.from_xml_opt_cnt(node, 'address-families')
+    yang.gdata.maybe_add(children, 'address-families', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__address_families, child_address_families)
+    child_remote_as = yang.gdata.from_xml_opt_str(node, 'remote-as')
+    yang.gdata.maybe_add(children, 'remote-as', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__remote_as, child_remote_as)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__description, child_description)
+    child_password = yang.gdata.from_xml_opt_cnt(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor__password, child_password)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_neighbor_address)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor_element(e))
+    return yang.gdata.List(keys=['neighbor-address'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(yang.adata.MNode):
     neighbor: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor
@@ -6795,12 +7281,12 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(yang
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(neighbor=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor.from_gdata(n.get_opt_list('neighbor')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(neighbor=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor.from_xml(yang.gdata.get_xml_children(n, 'neighbor')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_neighbor = yang.gdata.from_xml_opt_list(node, 'neighbor')
+    yang.gdata.maybe_add(children, 'neighbor', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors__neighbor, child_neighbor)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto(yang.adata.MNode):
 
@@ -6818,14 +7304,16 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto(yang.
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as(yang.adata.MNode):
     as_number: ?str
@@ -6852,14 +7340,20 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_a
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as(as_number=yang.gdata.from_xml_opt_str(n, 'as-number'), index=yang.gdata.from_xml_opt_int(n, 'index'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_number = yang.gdata.from_xml_str(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as__as_number, child_as_number)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as__index, child_index)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as(yang.adata.MNode):
     as_number: ?str
@@ -6886,14 +7380,20 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as(as_number=n.get_opt_str('as-number'), index=n.get_opt_int('index'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as(as_number=yang.gdata.from_xml_opt_str(n, 'as-number'), index=yang.gdata.from_xml_opt_int(n, 'index'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_number = yang.gdata.from_xml_str(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as__as_number, child_as_number)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as__index, child_index)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address__index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address(yang.adata.MNode):
     ipv4_address: ?str
@@ -6920,12 +7420,14 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address(ipv4_address=n.get_opt_str('ipv4-address'), index=n.get_opt_int('index'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address(ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'), index=yang.gdata.from_xml_opt_int(n, 'index'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4_address = yang.gdata.from_xml_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address__ipv4_address, child_ipv4_address)
+    child_index = yang.gdata.from_xml_int(node, 'index')
+    yang.gdata.maybe_add(children, 'index', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address__index, child_index)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(yang.adata.MNode):
     auto: ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto
@@ -6982,12 +7484,18 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(yang.adata.
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(auto=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto.from_gdata(n.get_opt_container('auto')), two_byte_as=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as.from_gdata(n.get_opt_container('two-byte-as')), four_byte_as=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as.from_gdata(n.get_opt_container('four-byte-as')), ip_address=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address.from_gdata(n.get_opt_container('ip-address')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(auto=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto.from_xml(yang.gdata.get_xml_opt_child(n, 'auto')), two_byte_as=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as.from_xml(yang.gdata.get_xml_opt_child(n, 'two-byte-as')), four_byte_as=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as.from_xml(yang.gdata.get_xml_opt_child(n, 'four-byte-as')), ip_address=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address.from_xml(yang.gdata.get_xml_opt_child(n, 'ip-address')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_auto = yang.gdata.from_xml_opt_cnt(node, 'auto')
+    yang.gdata.maybe_add(children, 'auto', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__auto, child_auto)
+    child_two_byte_as = yang.gdata.from_xml_opt_cnt(node, 'two-byte-as')
+    yang.gdata.maybe_add(children, 'two-byte-as', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__two_byte_as, child_two_byte_as)
+    child_four_byte_as = yang.gdata.from_xml_opt_cnt(node, 'four-byte-as')
+    yang.gdata.maybe_add(children, 'four-byte-as', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__four_byte_as, child_four_byte_as)
+    child_ip_address = yang.gdata.from_xml_opt_cnt(node, 'ip-address')
+    yang.gdata.maybe_add(children, 'ip-address', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd__ip_address, child_ip_address)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry(yang.adata.MNode):
     vrf_name: str
@@ -7027,10 +7535,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry(yang.adat
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry(vrf_name=n.get_str('vrf-name'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families.from_gdata(n.get_opt_container('address-families')), neighbors=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors.from_gdata(n.get_opt_container('neighbors')), rd=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd.from_gdata(n.get_opt_container('rd')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry(vrf_name=yang.gdata.from_xml_str(n, 'vrf-name'), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families.from_xml(yang.gdata.get_xml_opt_child(n, 'address-families')), neighbors=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors.from_xml(yang.gdata.get_xml_opt_child(n, 'neighbors')), rd=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd.from_xml(yang.gdata.get_xml_opt_child(n, 'rd')))
-
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry]
     mut def __init__(self, elements=[]):
@@ -7067,13 +7571,24 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf(yang.adata.MNod
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vrf_name = yang.gdata.from_xml_str(node, 'vrf-name')
+    yang.gdata.maybe_add(children, 'vrf-name', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__vrf_name, child_vrf_name)
+    child_address_families = yang.gdata.from_xml_opt_cnt(node, 'address-families')
+    yang.gdata.maybe_add(children, 'address-families', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__address_families, child_address_families)
+    child_neighbors = yang.gdata.from_xml_opt_cnt(node, 'neighbors')
+    yang.gdata.maybe_add(children, 'neighbors', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__neighbors, child_neighbors)
+    child_rd = yang.gdata.from_xml_opt_cnt(node, 'rd')
+    yang.gdata.maybe_add(children, 'rd', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf__rd, child_rd)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vrf_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf_element(e))
+    return yang.gdata.List(keys=['vrf-name'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(yang.adata.MNode):
     vrf: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf
@@ -7095,12 +7610,12 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(vrf=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf.from_gdata(n.get_opt_list('vrf')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(vrf=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf.from_xml(yang.gdata.get_xml_children(n, 'vrf')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vrf = yang.gdata.from_xml_opt_list(node, 'vrf')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs__vrf, child_vrf)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry(yang.adata.MNode):
     as_number: str
@@ -7150,10 +7665,6 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry:
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry(as_number=n.get_str('as-number'), rpki=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki.from_gdata(n.get_opt_container('rpki')), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families.from_gdata(n.get_opt_container('address-families')), neighbors=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors.from_gdata(n.get_opt_container('neighbors')), neighbor_groups=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups.from_gdata(n.get_opt_container('neighbor-groups')), bgp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp.from_gdata(n.get_opt_container('bgp')), vrfs=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs.from_gdata(n.get_opt_container('vrfs')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry:
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry(as_number=yang.gdata.from_xml_str(n, 'as-number'), rpki=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki.from_xml(yang.gdata.get_xml_opt_child(n, 'rpki')), address_families=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families.from_xml(yang.gdata.get_xml_opt_child(n, 'address-families')), neighbors=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors.from_xml(yang.gdata.get_xml_opt_child(n, 'neighbors')), neighbor_groups=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups.from_xml(yang.gdata.get_xml_opt_child(n, 'neighbor-groups')), bgp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')), vrfs=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs.from_xml(yang.gdata.get_xml_opt_child(n, 'vrfs')))
-
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry]
     mut def __init__(self, elements=[]):
@@ -7190,13 +7701,30 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as(yang.adata.MNode):
                 res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_as_number = yang.gdata.from_xml_str(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__as_number, child_as_number)
+    child_rpki = yang.gdata.from_xml_opt_cnt(node, 'rpki')
+    yang.gdata.maybe_add(children, 'rpki', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__rpki, child_rpki)
+    child_address_families = yang.gdata.from_xml_opt_cnt(node, 'address-families')
+    yang.gdata.maybe_add(children, 'address-families', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__address_families, child_address_families)
+    child_neighbors = yang.gdata.from_xml_opt_cnt(node, 'neighbors')
+    yang.gdata.maybe_add(children, 'neighbors', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbors, child_neighbors)
+    child_neighbor_groups = yang.gdata.from_xml_opt_cnt(node, 'neighbor-groups')
+    yang.gdata.maybe_add(children, 'neighbor-groups', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__neighbor_groups, child_neighbor_groups)
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__bgp, child_bgp)
+    child_vrfs = yang.gdata.from_xml_opt_cnt(node, 'vrfs')
+    yang.gdata.maybe_add(children, 'vrfs', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as__vrfs, child_vrfs)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_as_number)])
+
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as_element(e))
+    return yang.gdata.List(keys=['as-number'], elements=elements)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(yang.adata.MNode):
     as_: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as
@@ -7218,12 +7746,12 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(as_=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as.from_gdata(n.get_opt_list('as')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router__bgp:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(as_=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as.from_xml(yang.gdata.get_xml_children(n, 'as')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router__bgp()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_ = yang.gdata.from_xml_opt_list(node, 'as')
+    yang.gdata.maybe_add(children, 'as', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp__as, child_as_)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_router_bgp_cfg__router(yang.adata.MNode):
     bgp: Cisco_IOS_XR_um_router_bgp_cfg__router__bgp
@@ -7245,13 +7773,15 @@ class Cisco_IOS_XR_um_router_bgp_cfg__router(yang.adata.MNode):
             return Cisco_IOS_XR_um_router_bgp_cfg__router(bgp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp.from_gdata(n.get_opt_container('bgp')))
         return Cisco_IOS_XR_um_router_bgp_cfg__router()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_router_bgp_cfg__router:
-        if n != None:
-            return Cisco_IOS_XR_um_router_bgp_cfg__router(bgp=Cisco_IOS_XR_um_router_bgp_cfg__router__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')))
-        return Cisco_IOS_XR_um_router_bgp_cfg__router()
 
+mut def from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router__bgp, child_bgp)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg', module='Cisco-IOS-XR-um-router-bgp-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family__af_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry(yang.adata.MNode):
     af_name: str
@@ -7270,10 +7800,6 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry:
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry(af_name=n.get_str('af-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry:
-        return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry(af_name=yang.gdata.from_xml_str(n, 'af-name'))
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry]
@@ -7311,13 +7837,18 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family(
                 res.append(Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af_name = yang.gdata.from_xml_str(node, 'af-name')
+    yang.gdata.maybe_add(children, 'af-name', from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family__af_name, child_af_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family_element(e))
+    return yang.gdata.List(keys=['af-name'], elements=elements)
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(yang.adata.MNode):
     address_family: Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family
@@ -7339,13 +7870,15 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(yang.adata.MNode
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(address_family=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family.from_gdata(n.get_opt_list('address-family')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families:
-        if n != None:
-            return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(address_family=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families()
 
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface__interface_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry(yang.adata.MNode):
     interface_name: str
@@ -7364,10 +7897,6 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry(yang.
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry:
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry(interface_name=n.get_str('interface-name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry:
-        return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry(interface_name=yang.gdata.from_xml_str(n, 'interface-name'))
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry]
@@ -7405,13 +7934,18 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface(yang.adata.
                 res.append(Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_interface_name = yang.gdata.from_xml_str(node, 'interface-name')
+    yang.gdata.maybe_add(children, 'interface-name', from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface__interface_name, child_interface_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_interface_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface_element(e))
+    return yang.gdata.List(keys=['interface-name'], elements=elements)
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(yang.adata.MNode):
     interface: Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface
@@ -7433,12 +7967,12 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(yang.adata.MNode):
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(interface=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces:
-        if n != None:
-            return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(interface=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')))
-        return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces()
 
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces__interface, child_interface)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(yang.adata.MNode):
     address_families: Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families
@@ -7465,12 +7999,14 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(yang.adata.MNode):
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(address_families=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families.from_gdata(n.get_opt_container('address-families')), interfaces=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces.from_gdata(n.get_opt_container('interfaces')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp:
-        if n != None:
-            return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(address_families=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families.from_xml(yang.gdata.get_xml_opt_child(n, 'address-families')), interfaces=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces.from_xml(yang.gdata.get_xml_opt_child(n, 'interfaces')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_families = yang.gdata.from_xml_opt_cnt(node, 'address-families')
+    yang.gdata.maybe_add(children, 'address-families', from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__address_families, child_address_families)
+    child_interfaces = yang.gdata.from_xml_opt_cnt(node, 'interfaces')
+    yang.gdata.maybe_add(children, 'interfaces', from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp__interfaces, child_interfaces)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(yang.adata.MNode):
     ldp: ?Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp
@@ -7497,13 +8033,15 @@ class Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(yang.adata.MNode):
             return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(ldp=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp.from_gdata(n.get_opt_container('ldp')))
         return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_mpls_ldp_cfg__mpls:
-        if n != None:
-            return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(ldp=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp.from_xml(yang.gdata.get_xml_opt_child(n, 'ldp')))
-        return Cisco_IOS_XR_um_mpls_ldp_cfg__mpls()
 
+mut def from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ldp = yang.gdata.from_xml_opt_cnt(node, 'ldp')
+    yang.gdata.maybe_add(children, 'ldp', from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls__ldp, child_ldp)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-mpls-ldp-cfg', module='Cisco-IOS-XR-um-mpls-ldp-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__interface_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport(yang.adata.MNode):
 
@@ -7521,12 +8059,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point(yang.adata.MNode):
 
@@ -7544,12 +8080,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint(yang.adata.MNode):
 
@@ -7567,12 +8101,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(yang.adata.MNode):
     l2transport: ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport
@@ -7619,16 +8151,28 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(y
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(l2transport=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport.from_gdata(n.get_opt_container('l2transport')), point_to_point=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point.from_gdata(n.get_opt_container('point-to-point')), multipoint=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint.from_gdata(n.get_opt_container('multipoint')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(l2transport=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport.from_xml(yang.gdata.get_xml_opt_child(n, 'l2transport')), point_to_point=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point.from_xml(yang.gdata.get_xml_opt_child(n, 'point-to-point')), multipoint=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint.from_xml(yang.gdata.get_xml_opt_child(n, 'multipoint')))
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l2transport = yang.gdata.from_xml_opt_cnt(node, 'l2transport')
+    yang.gdata.maybe_add(children, 'l2transport', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__l2transport, child_l2transport)
+    child_point_to_point = yang.gdata.from_xml_opt_cnt(node, 'point-to-point')
+    yang.gdata.maybe_add(children, 'point-to-point', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__point_to_point, child_point_to_point)
+    child_multipoint = yang.gdata.from_xml_opt_cnt(node, 'multipoint')
+    yang.gdata.maybe_add(children, 'multipoint', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type__multipoint, child_multipoint)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address__netmask(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address__route_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address__algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address(yang.adata.MNode):
     address: ?str
@@ -7665,16 +8209,30 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__add
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address(address=n.get_opt_str('address'), netmask=n.get_opt_str('netmask'), route_tag=n.get_opt_int('route-tag'), algorithm=n.get_opt_int('algorithm'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address(address=yang.gdata.from_xml_opt_str(n, 'address'), netmask=yang.gdata.from_xml_opt_str(n, 'netmask'), route_tag=yang.gdata.from_xml_opt_int(n, 'route-tag'), algorithm=yang.gdata.from_xml_opt_int(n, 'algorithm'))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address__address, child_address)
+    child_netmask = yang.gdata.from_xml_str(node, 'netmask')
+    yang.gdata.maybe_add(children, 'netmask', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address__netmask, child_netmask)
+    child_route_tag = yang.gdata.from_xml_opt_int(node, 'route-tag')
+    yang.gdata.maybe_add(children, 'route-tag', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address__route_tag, child_route_tag)
+    child_algorithm = yang.gdata.from_xml_opt_int(node, 'algorithm')
+    yang.gdata.maybe_add(children, 'algorithm', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address__algorithm, child_algorithm)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary__netmask(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary__route_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary__algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry(yang.adata.MNode):
     address: str
@@ -7708,10 +8266,6 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__sec
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry:
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry(address=n.get_str('address'), netmask=n.get_opt_str('netmask'), route_tag=n.get_opt_int('route-tag'), algorithm=n.get_opt_int('algorithm'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry:
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry(address=yang.gdata.from_xml_str(n, 'address'), netmask=yang.gdata.from_xml_opt_str(n, 'netmask'), route_tag=yang.gdata.from_xml_opt_int(n, 'route-tag'), algorithm=yang.gdata.from_xml_opt_int(n, 'algorithm'))
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry]
@@ -7749,13 +8303,24 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__sec
                 res.append(Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary__address, child_address)
+    child_netmask = yang.gdata.from_xml_str(node, 'netmask')
+    yang.gdata.maybe_add(children, 'netmask', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary__netmask, child_netmask)
+    child_route_tag = yang.gdata.from_xml_opt_int(node, 'route-tag')
+    yang.gdata.maybe_add(children, 'route-tag', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary__route_tag, child_route_tag)
+    child_algorithm = yang.gdata.from_xml_opt_int(node, 'algorithm')
+    yang.gdata.maybe_add(children, 'algorithm', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary__algorithm, child_algorithm)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_address)])
+
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary_element(e))
+    return yang.gdata.List(keys=['address'], elements=elements)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries(yang.adata.MNode):
     secondary: Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary
@@ -7777,13 +8342,15 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__sec
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries(secondary=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary.from_gdata(n.get_opt_list('secondary')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries(secondary=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary.from_xml(yang.gdata.get_xml_children(n, 'secondary')))
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_secondary = yang.gdata.from_xml_opt_list(node, 'secondary')
+    yang.gdata.maybe_add(children, 'secondary', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries__secondary, child_secondary)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__unnumbered(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp(yang.adata.MNode):
 
@@ -7801,12 +8368,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(yang.adata.MNode):
     address: ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address
@@ -7853,12 +8418,18 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(yang
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(address=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address.from_gdata(n.get_opt_container('address')), secondaries=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries.from_gdata(n.get_opt_container('secondaries')), unnumbered=n.get_opt_str('unnumbered'), dhcp=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp.from_gdata(n.get_opt_container('dhcp')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(address=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address.from_xml(yang.gdata.get_xml_opt_child(n, 'address')), secondaries=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries.from_xml(yang.gdata.get_xml_opt_child(n, 'secondaries')), unnumbered=yang.gdata.from_xml_opt_str(n, 'unnumbered'), dhcp=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp.from_xml(yang.gdata.get_xml_opt_child(n, 'dhcp')))
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address = yang.gdata.from_xml_opt_cnt(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__address, child_address)
+    child_secondaries = yang.gdata.from_xml_opt_cnt(node, 'secondaries')
+    yang.gdata.maybe_add(children, 'secondaries', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__secondaries, child_secondaries)
+    child_unnumbered = yang.gdata.from_xml_opt_str(node, 'unnumbered')
+    yang.gdata.maybe_add(children, 'unnumbered', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__unnumbered, child_unnumbered)
+    child_dhcp = yang.gdata.from_xml_opt_cnt(node, 'dhcp')
+    yang.gdata.maybe_add(children, 'dhcp', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses__dhcp, child_dhcp)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ip-address-cfg', module='Cisco-IOS-XR-um-if-ip-address-cfg')
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(yang.adata.MNode):
     addresses: Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses
@@ -7880,12 +8451,12 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(yang.adata.MNod
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(addresses=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses.from_gdata(n.get_opt_container('addresses')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(addresses=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'addresses', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ip-address-cfg')))
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_addresses = yang.gdata.from_xml_opt_cnt(node, 'addresses', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ip-address-cfg')
+    yang.gdata.maybe_add(children, 'addresses', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4__addresses, child_addresses)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6(yang.adata.MNode):
 
@@ -7903,12 +8474,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6(yang.adata.MNod
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp(yang.adata.MNode):
 
@@ -7926,12 +8495,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc(yang.adata.MNode):
 
@@ -7949,12 +8516,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr(yang.adata.MNode):
 
@@ -7972,12 +8537,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF(yang.adata.MNode):
 
@@ -7995,12 +8558,10 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay(yang.adata.MNode):
     IETF: ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF
@@ -8027,12 +8588,12 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay(IETF=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF.from_gdata(n.get_opt_container('IETF')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay(IETF=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF.from_xml(yang.gdata.get_xml_opt_child(n, 'IETF')))
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_IETF = yang.gdata.from_xml_opt_cnt(node, 'IETF')
+    yang.gdata.maybe_add(children, 'IETF', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay__IETF, child_IETF)
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation(yang.adata.MNode):
     ppp: ?Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp
@@ -8089,18 +8650,36 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_enc
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation(ppp=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp.from_gdata(n.get_opt_container('ppp')), hdlc=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc.from_gdata(n.get_opt_container('hdlc')), mfr=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr.from_gdata(n.get_opt_container('mfr')), frame_relay=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay.from_gdata(n.get_opt_container('frame-relay')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation(ppp=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp.from_xml(yang.gdata.get_xml_opt_child(n, 'ppp')), hdlc=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc.from_xml(yang.gdata.get_xml_opt_child(n, 'hdlc')), mfr=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr.from_xml(yang.gdata.get_xml_opt_child(n, 'mfr')), frame_relay=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay.from_xml(yang.gdata.get_xml_opt_child(n, 'frame-relay')))
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ppp = yang.gdata.from_xml_opt_cnt(node, 'ppp')
+    yang.gdata.maybe_add(children, 'ppp', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__ppp, child_ppp)
+    child_hdlc = yang.gdata.from_xml_opt_cnt(node, 'hdlc')
+    yang.gdata.maybe_add(children, 'hdlc', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__hdlc, child_hdlc)
+    child_mfr = yang.gdata.from_xml_opt_cnt(node, 'mfr')
+    yang.gdata.maybe_add(children, 'mfr', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__mfr, child_mfr)
+    child_frame_relay = yang.gdata.from_xml_opt_cnt(node, 'frame-relay')
+    yang.gdata.maybe_add(children, 'frame-relay', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation__frame_relay, child_frame_relay)
+    return yang.gdata.Container(children)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__shutdown(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__mtu(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__vrf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-vrf-cfg', module='Cisco-IOS-XR-um-if-vrf-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q__vlan_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q__second_dot1q(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q(yang.adata.MNode):
     vlan_id: ?int
@@ -8127,12 +8706,14 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_e
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q(vlan_id=n.get_opt_int('vlan-id'), second_dot1q=n.get_opt_int('second-dot1q'))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q(vlan_id=yang.gdata.from_xml_opt_int(n, 'vlan-id'), second_dot1q=yang.gdata.from_xml_opt_int(n, 'second-dot1q'))
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vlan_id = yang.gdata.from_xml_opt_int(node, 'vlan-id')
+    yang.gdata.maybe_add(children, 'vlan-id', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q__vlan_id, child_vlan_id)
+    child_second_dot1q = yang.gdata.from_xml_opt_int(node, 'second-dot1q')
+    yang.gdata.maybe_add(children, 'second-dot1q', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q__second_dot1q, child_second_dot1q)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation(yang.adata.MNode):
     dot1q: Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q
@@ -8154,12 +8735,12 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_e
             return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation(dot1q=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q.from_gdata(n.get_opt_container('dot1q')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation(dot1q=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q.from_xml(yang.gdata.get_xml_opt_child(n, 'dot1q')))
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_dot1q = yang.gdata.from_xml_opt_cnt(node, 'dot1q')
+    yang.gdata.maybe_add(children, 'dot1q', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation__dot1q, child_dot1q)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-l2-ethernet-cfg', module='Cisco-IOS-XR-um-l2-ethernet-cfg')
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry(yang.adata.MNode):
     interface_name: str
@@ -8224,10 +8805,6 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry(yang.adata.MNod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry:
         return Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry(interface_name=n.get_str('interface-name'), sub_interface_type=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type.from_gdata(n.get_opt_container('sub-interface-type')), ipv4=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6.from_gdata(n.get_opt_container('ipv6')), um_interface_cfg_encapsulation=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation.from_gdata(n.get_opt_container('um-interface-cfg:encapsulation')), shutdown=n.get_opt_bool('shutdown'), mtu=n.get_opt_int('mtu'), description=n.get_opt_str('description'), vrf=n.get_opt_str('vrf'), um_l2_ethernet_cfg_encapsulation=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation.from_gdata(n.get_opt_container('um-l2-ethernet-cfg:encapsulation')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry:
-        return Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry(interface_name=yang.gdata.from_xml_str(n, 'interface-name'), sub_interface_type=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type.from_xml(yang.gdata.get_xml_opt_child(n, 'sub-interface-type')), ipv4=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv4')), ipv6=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv6')), um_interface_cfg_encapsulation=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation.from_xml(yang.gdata.get_xml_opt_child(n, 'encapsulation')), shutdown=yang.gdata.from_xml_opt_bool(n, 'shutdown'), mtu=yang.gdata.from_xml_opt_int(n, 'mtu'), description=yang.gdata.from_xml_opt_str(n, 'description'), vrf=yang.gdata.from_xml_opt_str(n, 'vrf', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-vrf-cfg'), um_l2_ethernet_cfg_encapsulation=Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation.from_xml(yang.gdata.get_xml_opt_child(n, 'encapsulation', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-l2-ethernet-cfg')))
-
 class Cisco_IOS_XR_um_interface_cfg__interfaces__interface(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -8264,13 +8841,36 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces__interface(yang.adata.MNode):
                 res.append(Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_um_interface_cfg__interfaces__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_interface_name = yang.gdata.from_xml_str(node, 'interface-name')
+    yang.gdata.maybe_add(children, 'interface-name', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__interface_name, child_interface_name)
+    child_sub_interface_type = yang.gdata.from_xml_opt_cnt(node, 'sub-interface-type')
+    yang.gdata.maybe_add(children, 'sub-interface-type', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__sub_interface_type, child_sub_interface_type)
+    child_ipv4 = yang.gdata.from_xml_opt_cnt(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_cnt(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__ipv6, child_ipv6)
+    child_um_interface_cfg_encapsulation = yang.gdata.from_xml_opt_cnt(node, 'encapsulation')
+    yang.gdata.maybe_add(children, 'um-interface-cfg:encapsulation', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_interface_cfg_encapsulation, child_um_interface_cfg_encapsulation)
+    child_shutdown = yang.gdata.from_xml_opt_bool(node, 'shutdown')
+    yang.gdata.maybe_add(children, 'shutdown', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__shutdown, child_shutdown)
+    child_mtu = yang.gdata.from_xml_opt_int(node, 'mtu')
+    yang.gdata.maybe_add(children, 'mtu', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__mtu, child_mtu)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__description, child_description)
+    child_vrf = yang.gdata.from_xml_opt_str(node, 'vrf', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-vrf-cfg')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__vrf, child_vrf)
+    child_um_l2_ethernet_cfg_encapsulation = yang.gdata.from_xml_opt_cnt(node, 'encapsulation', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-l2-ethernet-cfg')
+    yang.gdata.maybe_add(children, 'um-l2-ethernet-cfg:encapsulation', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface__um_l2_ethernet_cfg_encapsulation, child_um_l2_ethernet_cfg_encapsulation)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_interface_name)])
+
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface_element(e))
+    return yang.gdata.List(keys=['interface-name'], elements=elements)
 
 class Cisco_IOS_XR_um_interface_cfg__interfaces(yang.adata.MNode):
     interface: Cisco_IOS_XR_um_interface_cfg__interfaces__interface
@@ -8292,12 +8892,12 @@ class Cisco_IOS_XR_um_interface_cfg__interfaces(yang.adata.MNode):
             return Cisco_IOS_XR_um_interface_cfg__interfaces(interface=Cisco_IOS_XR_um_interface_cfg__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return Cisco_IOS_XR_um_interface_cfg__interfaces()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_interface_cfg__interfaces:
-        if n != None:
-            return Cisco_IOS_XR_um_interface_cfg__interfaces(interface=Cisco_IOS_XR_um_interface_cfg__interfaces__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')))
-        return Cisco_IOS_XR_um_interface_cfg__interfaces()
 
+mut def from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces__interface, child_interface)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg', module='Cisco-IOS-XR-um-interface-cfg')
 
 class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict(yang.adata.MNode):
 
@@ -8315,12 +8915,10 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict(yang.adat
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict:
-        if n != None:
-            return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict()
-        return None
 
+mut def from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(yang.adata.MNode):
     strict: ?Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict
@@ -8347,12 +8945,12 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(yang.adata.MNode)
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(strict=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict.from_gdata(n.get_opt_container('strict')))
         return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter:
-        if n != None:
-            return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(strict=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict.from_xml(yang.gdata.get_xml_opt_child(n, 'strict')))
-        return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter()
 
+mut def from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_strict = yang.gdata.from_xml_opt_cnt(node, 'strict')
+    yang.gdata.maybe_add(children, 'strict', from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter__strict, child_strict)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(yang.adata.MNode):
     egress_filter: Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter
@@ -8374,13 +8972,15 @@ class Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(yang.adata.MNode):
             return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(egress_filter=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter.from_gdata(n.get_opt_container('egress-filter')))
         return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet:
-        if n != None:
-            return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(egress_filter=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter.from_xml(yang.gdata.get_xml_opt_child(n, 'egress-filter')))
-        return Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet()
 
+mut def from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_egress_filter = yang.gdata.from_xml_opt_cnt(node, 'egress-filter')
+    yang.gdata.maybe_add(children, 'egress-filter', from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet__egress_filter, child_egress_filter)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-l2-ethernet-cfg', module='Cisco-IOS-XR-um-l2-ethernet-cfg')
 
+mut def from_xml_Cisco_IOS_XR_um_hostname_cfg__hostname__system_network_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_um_hostname_cfg__hostname(yang.adata.MNode):
     system_network_name: ?str
@@ -8402,14 +9002,18 @@ class Cisco_IOS_XR_um_hostname_cfg__hostname(yang.adata.MNode):
             return Cisco_IOS_XR_um_hostname_cfg__hostname(system_network_name=n.get_opt_str('system-network-name'))
         return Cisco_IOS_XR_um_hostname_cfg__hostname()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_um_hostname_cfg__hostname:
-        if n != None:
-            return Cisco_IOS_XR_um_hostname_cfg__hostname(system_network_name=yang.gdata.from_xml_opt_str(n, 'system-network-name'))
-        return Cisco_IOS_XR_um_hostname_cfg__hostname()
 
+mut def from_xml_Cisco_IOS_XR_um_hostname_cfg__hostname(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_system_network_name = yang.gdata.from_xml_opt_str(node, 'system-network-name')
+    yang.gdata.maybe_add(children, 'system-network-name', from_xml_Cisco_IOS_XR_um_hostname_cfg__hostname__system_network_name, child_system_network_name)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg', module='Cisco-IOS-XR-um-hostname-cfg')
 
+mut def from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy__route_policy_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy__rpl_route_policy(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry(yang.adata.MNode):
     route_policy_name: str
@@ -8433,10 +9037,6 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry:
         return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry(route_policy_name=n.get_str('route-policy-name'), rpl_route_policy=n.get_opt_str('rpl-route-policy'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry:
-        return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry(route_policy_name=yang.gdata.from_xml_str(n, 'route-policy-name'), rpl_route_policy=yang.gdata.from_xml_opt_str(n, 'rpl-route-policy'))
 
 class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy(yang.adata.MNode):
     elements: list[Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry]
@@ -8474,13 +9074,20 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_
                 res.append(Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry]:
-        res = []
-        for node in nodes:
-            res.append(Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_entry.from_xml(node))
-        return res
 
+mut def from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_route_policy_name = yang.gdata.from_xml_str(node, 'route-policy-name')
+    yang.gdata.maybe_add(children, 'route-policy-name', from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy__route_policy_name, child_route_policy_name)
+    child_rpl_route_policy = yang.gdata.from_xml_str(node, 'rpl-route-policy')
+    yang.gdata.maybe_add(children, 'rpl-route-policy', from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy__rpl_route_policy, child_rpl_route_policy)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_route_policy_name)])
+
+mut def from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy_element(e))
+    return yang.gdata.List(keys=['route-policy-name'], elements=elements)
 
 class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(yang.adata.MNode):
     route_policy: Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy
@@ -8502,12 +9109,12 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(yang.ad
             return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(route_policy=Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy.from_gdata(n.get_opt_list('route-policy')))
         return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies:
-        if n != None:
-            return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(route_policy=Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy.from_xml(yang.gdata.get_xml_children(n, 'route-policy')))
-        return Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies()
 
+mut def from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_policy = yang.gdata.from_xml_opt_list(node, 'route-policy')
+    yang.gdata.maybe_add(children, 'route-policy', from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies__route_policy, child_route_policy)
+    return yang.gdata.Container(children)
 
 class Cisco_IOS_XR_policy_repository_cfg__routing_policy(yang.adata.MNode):
     route_policies: Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies
@@ -8529,12 +9136,12 @@ class Cisco_IOS_XR_policy_repository_cfg__routing_policy(yang.adata.MNode):
             return Cisco_IOS_XR_policy_repository_cfg__routing_policy(route_policies=Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies.from_gdata(n.get_opt_container('route-policies')))
         return Cisco_IOS_XR_policy_repository_cfg__routing_policy()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> Cisco_IOS_XR_policy_repository_cfg__routing_policy:
-        if n != None:
-            return Cisco_IOS_XR_policy_repository_cfg__routing_policy(route_policies=Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies.from_xml(yang.gdata.get_xml_opt_child(n, 'route-policies')))
-        return Cisco_IOS_XR_policy_repository_cfg__routing_policy()
 
+mut def from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_policies = yang.gdata.from_xml_opt_cnt(node, 'route-policies')
+    yang.gdata.maybe_add(children, 'route-policies', from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy__route_policies, child_route_policies)
+    return yang.gdata.Container(children, ns='http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg', module='Cisco-IOS-XR-policy-repository-cfg')
 
 class root(yang.adata.MNode):
     address_family: Cisco_IOS_XR_um_vrf_cfg__address_family
@@ -8626,12 +9233,38 @@ class root(yang.adata.MNode):
             return root(address_family=Cisco_IOS_XR_um_vrf_cfg__address_family.from_gdata(n.get_opt_container('address-family')), vrfs=Cisco_IOS_XR_um_vrf_cfg__vrfs.from_gdata(n.get_opt_container('vrfs')), selective_vrf_download=Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download.from_gdata(n.get_opt_container('selective-vrf-download')), srlg=Cisco_IOS_XR_um_vrf_cfg__srlg.from_gdata(n.get_opt_container('srlg')), vrf_groups=Cisco_IOS_XR_um_vrf_cfg__vrf_groups.from_gdata(n.get_opt_container('vrf-groups')), um_router_isis_cfg_router=Cisco_IOS_XR_um_router_isis_cfg__router.from_gdata(n.get_opt_container('um-router-isis-cfg:router')), as_format=Cisco_IOS_XR_um_router_bgp_cfg__as_format.from_gdata(n.get_opt_container('as-format')), bmp=Cisco_IOS_XR_um_router_bgp_cfg__bmp.from_gdata(n.get_opt_container('bmp')), um_router_bgp_cfg_router=Cisco_IOS_XR_um_router_bgp_cfg__router.from_gdata(n.get_opt_container('um-router-bgp-cfg:router')), mpls=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls.from_gdata(n.get_opt_container('mpls')), interfaces=Cisco_IOS_XR_um_interface_cfg__interfaces.from_gdata(n.get_opt_container('interfaces')), ethernet=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet.from_gdata(n.get_opt_container('ethernet')), hostname=Cisco_IOS_XR_um_hostname_cfg__hostname.from_gdata(n.get_opt_container('hostname')), routing_policy=Cisco_IOS_XR_policy_repository_cfg__routing_policy.from_gdata(n.get_opt_container('routing-policy')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(address_family=Cisco_IOS_XR_um_vrf_cfg__address_family.from_xml(yang.gdata.get_xml_opt_child(n, 'address-family', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')), vrfs=Cisco_IOS_XR_um_vrf_cfg__vrfs.from_xml(yang.gdata.get_xml_opt_child(n, 'vrfs', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')), selective_vrf_download=Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download.from_xml(yang.gdata.get_xml_opt_child(n, 'selective-vrf-download', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')), srlg=Cisco_IOS_XR_um_vrf_cfg__srlg.from_xml(yang.gdata.get_xml_opt_child(n, 'srlg', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')), vrf_groups=Cisco_IOS_XR_um_vrf_cfg__vrf_groups.from_xml(yang.gdata.get_xml_opt_child(n, 'vrf-groups', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')), um_router_isis_cfg_router=Cisco_IOS_XR_um_router_isis_cfg__router.from_xml(yang.gdata.get_xml_opt_child(n, 'router', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-isis-cfg')), as_format=Cisco_IOS_XR_um_router_bgp_cfg__as_format.from_xml(yang.gdata.get_xml_opt_child(n, 'as-format', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')), bmp=Cisco_IOS_XR_um_router_bgp_cfg__bmp.from_xml(yang.gdata.get_xml_opt_child(n, 'bmp', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')), um_router_bgp_cfg_router=Cisco_IOS_XR_um_router_bgp_cfg__router.from_xml(yang.gdata.get_xml_opt_child(n, 'router', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')), mpls=Cisco_IOS_XR_um_mpls_ldp_cfg__mpls.from_xml(yang.gdata.get_xml_opt_child(n, 'mpls', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-mpls-ldp-cfg')), interfaces=Cisco_IOS_XR_um_interface_cfg__interfaces.from_xml(yang.gdata.get_xml_opt_child(n, 'interfaces', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg')), ethernet=Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet.from_xml(yang.gdata.get_xml_opt_child(n, 'ethernet', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-l2-ethernet-cfg')), hostname=Cisco_IOS_XR_um_hostname_cfg__hostname.from_xml(yang.gdata.get_xml_opt_child(n, 'hostname', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg')), routing_policy=Cisco_IOS_XR_policy_repository_cfg__routing_policy.from_xml(yang.gdata.get_xml_opt_child(n, 'routing-policy', 'http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_cnt(node, 'address-family', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_Cisco_IOS_XR_um_vrf_cfg__address_family, child_address_family)
+    child_vrfs = yang.gdata.from_xml_opt_cnt(node, 'vrfs', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')
+    yang.gdata.maybe_add(children, 'vrfs', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrfs, child_vrfs)
+    child_selective_vrf_download = yang.gdata.from_xml_opt_cnt(node, 'selective-vrf-download', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')
+    yang.gdata.maybe_add(children, 'selective-vrf-download', from_xml_Cisco_IOS_XR_um_vrf_cfg__selective_vrf_download, child_selective_vrf_download)
+    child_srlg = yang.gdata.from_xml_opt_cnt(node, 'srlg', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')
+    yang.gdata.maybe_add(children, 'srlg', from_xml_Cisco_IOS_XR_um_vrf_cfg__srlg, child_srlg)
+    child_vrf_groups = yang.gdata.from_xml_opt_cnt(node, 'vrf-groups', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg')
+    yang.gdata.maybe_add(children, 'vrf-groups', from_xml_Cisco_IOS_XR_um_vrf_cfg__vrf_groups, child_vrf_groups)
+    child_um_router_isis_cfg_router = yang.gdata.from_xml_opt_cnt(node, 'router', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-isis-cfg')
+    yang.gdata.maybe_add(children, 'um-router-isis-cfg:router', from_xml_Cisco_IOS_XR_um_router_isis_cfg__router, child_um_router_isis_cfg_router)
+    child_as_format = yang.gdata.from_xml_opt_cnt(node, 'as-format', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')
+    yang.gdata.maybe_add(children, 'as-format', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__as_format, child_as_format)
+    child_bmp = yang.gdata.from_xml_opt_cnt(node, 'bmp', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')
+    yang.gdata.maybe_add(children, 'bmp', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__bmp, child_bmp)
+    child_um_router_bgp_cfg_router = yang.gdata.from_xml_opt_cnt(node, 'router', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-router-bgp-cfg')
+    yang.gdata.maybe_add(children, 'um-router-bgp-cfg:router', from_xml_Cisco_IOS_XR_um_router_bgp_cfg__router, child_um_router_bgp_cfg_router)
+    child_mpls = yang.gdata.from_xml_opt_cnt(node, 'mpls', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-mpls-ldp-cfg')
+    yang.gdata.maybe_add(children, 'mpls', from_xml_Cisco_IOS_XR_um_mpls_ldp_cfg__mpls, child_mpls)
+    child_interfaces = yang.gdata.from_xml_opt_cnt(node, 'interfaces', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg')
+    yang.gdata.maybe_add(children, 'interfaces', from_xml_Cisco_IOS_XR_um_interface_cfg__interfaces, child_interfaces)
+    child_ethernet = yang.gdata.from_xml_opt_cnt(node, 'ethernet', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-l2-ethernet-cfg')
+    yang.gdata.maybe_add(children, 'ethernet', from_xml_Cisco_IOS_XR_um_l2_ethernet_cfg__ethernet, child_ethernet)
+    child_hostname = yang.gdata.from_xml_opt_cnt(node, 'hostname', 'http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg')
+    yang.gdata.maybe_add(children, 'hostname', from_xml_Cisco_IOS_XR_um_hostname_cfg__hostname, child_hostname)
+    child_routing_policy = yang.gdata.from_xml_opt_cnt(node, 'routing-policy', 'http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg')
+    yang.gdata.maybe_add(children, 'routing-policy', from_xml_Cisco_IOS_XR_policy_repository_cfg__routing_policy, child_routing_policy)
+    return yang.gdata.Container(children)
 
 schema_namespaces: set[str] = {
     'http://cisco.com/ns/yang/Cisco-IOS-XR-um-vrf-cfg',

--- a/src/respnet/devices/JuniperCRPD_23_4R1_9.act
+++ b/src/respnet/devices/JuniperCRPD_23_4R1_9.act
@@ -7,8 +7,14 @@ import yang.gdata
 # == This file is generated ==
 
 
+mut def from_xml_junos_conf_root__configuration__rcsid(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__version(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__system__host_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__system(yang.adata.MNode):
     host_name: ?str
@@ -30,23 +36,45 @@ class junos_conf_root__configuration__system(yang.adata.MNode):
             return junos_conf_root__configuration__system(host_name=n.get_opt_str('host-name'))
         return junos_conf_root__configuration__system()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__system:
-        if n != None:
-            return junos_conf_root__configuration__system(host_name=yang.gdata.from_xml_opt_str(n, 'host-name'))
-        return junos_conf_root__configuration__system()
 
+mut def from_xml_junos_conf_root__configuration__system(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_host_name = yang.gdata.from_xml_opt_str(node, 'host-name')
+    yang.gdata.maybe_add(children, 'host-name', from_xml_junos_conf_root__configuration__system__host_name, child_host_name)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__mtu(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__mac(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__native_vlan_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__alias(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__vlan_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__encapsulation(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet__address__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry(yang.adata.MNode):
     name: str
@@ -65,10 +93,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry:
         return junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry(name=n.get_str('name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry:
-        return junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry(name=yang.gdata.from_xml_str(n, 'name'))
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry]
@@ -106,13 +130,18 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet_
                 res.append(junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet__address__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet__address(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet__address_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet(yang.adata.MNode):
     address: junos_conf_root__configuration__interfaces__interface__unit__family__inet__address
@@ -134,13 +163,15 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet(
             return junos_conf_root__configuration__interfaces__interface__unit__family__inet(address=junos_conf_root__configuration__interfaces__interface__unit__family__inet__address.from_gdata(n.get_opt_list('address')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__interfaces__interface__unit__family__inet:
-        if n != None:
-            return junos_conf_root__configuration__interfaces__interface__unit__family__inet(address=junos_conf_root__configuration__interfaces__interface__unit__family__inet__address.from_xml(yang.gdata.get_xml_children(n, 'address')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address = yang.gdata.from_xml_opt_list(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet__address, child_address)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry(yang.adata.MNode):
     name: str
@@ -159,10 +190,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry:
         return junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry(name=n.get_str('name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry:
-        return junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry(name=yang.gdata.from_xml_str(n, 'name'))
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry]
@@ -200,13 +227,18 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
                 res.append(junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__inet6(yang.adata.MNode):
     address: junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address
@@ -228,13 +260,15 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__inet6
             return junos_conf_root__configuration__interfaces__interface__unit__family__inet6(address=junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address.from_gdata(n.get_opt_list('address')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__interfaces__interface__unit__family__inet6:
-        if n != None:
-            return junos_conf_root__configuration__interfaces__interface__unit__family__inet6(address=junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address.from_xml(yang.gdata.get_xml_children(n, 'address')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address = yang.gdata.from_xml_opt_list(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6__address, child_address)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso__address__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry(yang.adata.MNode):
     name: str
@@ -253,10 +287,6 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso__
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry:
         return junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry(name=n.get_str('name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry:
-        return junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry(name=yang.gdata.from_xml_str(n, 'name'))
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__iso__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry]
@@ -294,13 +324,18 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso__
                 res.append(junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso__address__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso__address(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso__address_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family__iso(yang.adata.MNode):
     address: junos_conf_root__configuration__interfaces__interface__unit__family__iso__address
@@ -322,12 +357,12 @@ class junos_conf_root__configuration__interfaces__interface__unit__family__iso(y
             return junos_conf_root__configuration__interfaces__interface__unit__family__iso(address=junos_conf_root__configuration__interfaces__interface__unit__family__iso__address.from_gdata(n.get_opt_list('address')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__interfaces__interface__unit__family__iso:
-        if n != None:
-            return junos_conf_root__configuration__interfaces__interface__unit__family__iso(address=junos_conf_root__configuration__interfaces__interface__unit__family__iso__address.from_xml(yang.gdata.get_xml_children(n, 'address')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address = yang.gdata.from_xml_opt_list(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso__address, child_address)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__interfaces__interface__unit__family(yang.adata.MNode):
     inet: ?junos_conf_root__configuration__interfaces__interface__unit__family__inet
@@ -374,14 +409,22 @@ class junos_conf_root__configuration__interfaces__interface__unit__family(yang.a
             return junos_conf_root__configuration__interfaces__interface__unit__family(inet=junos_conf_root__configuration__interfaces__interface__unit__family__inet.from_gdata(n.get_opt_container('inet')), inet6=junos_conf_root__configuration__interfaces__interface__unit__family__inet6.from_gdata(n.get_opt_container('inet6')), iso=junos_conf_root__configuration__interfaces__interface__unit__family__iso.from_gdata(n.get_opt_container('iso')))
         return junos_conf_root__configuration__interfaces__interface__unit__family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__interfaces__interface__unit__family:
-        if n != None:
-            return junos_conf_root__configuration__interfaces__interface__unit__family(inet=junos_conf_root__configuration__interfaces__interface__unit__family__inet.from_xml(yang.gdata.get_xml_opt_child(n, 'inet')), inet6=junos_conf_root__configuration__interfaces__interface__unit__family__inet6.from_xml(yang.gdata.get_xml_opt_child(n, 'inet6')), iso=junos_conf_root__configuration__interfaces__interface__unit__family__iso.from_xml(yang.gdata.get_xml_opt_child(n, 'iso')))
-        return junos_conf_root__configuration__interfaces__interface__unit__family()
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_inet = yang.gdata.from_xml_opt_cnt(node, 'inet')
+    yang.gdata.maybe_add(children, 'inet', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet, child_inet)
+    child_inet6 = yang.gdata.from_xml_opt_cnt(node, 'inet6')
+    yang.gdata.maybe_add(children, 'inet6', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__inet6, child_inet6)
+    child_iso = yang.gdata.from_xml_opt_cnt(node, 'iso')
+    yang.gdata.maybe_add(children, 'iso', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family__iso, child_iso)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__mtu(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit__mac(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__interfaces__interface__unit_entry(yang.adata.MNode):
     name: str
@@ -436,10 +479,6 @@ class junos_conf_root__configuration__interfaces__interface__unit_entry(yang.ada
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface__unit_entry:
         return junos_conf_root__configuration__interfaces__interface__unit_entry(name=n.get_str('name'), alias=n.get_opt_str('alias'), description=n.get_opt_str('description'), vlan_id=n.get_opt_str('vlan-id'), encapsulation=n.get_opt_str('encapsulation'), family=junos_conf_root__configuration__interfaces__interface__unit__family.from_gdata(n.get_opt_container('family')), mtu=n.get_opt_value('mtu'), mac=n.get_opt_str('mac'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__interfaces__interface__unit_entry:
-        return junos_conf_root__configuration__interfaces__interface__unit_entry(name=yang.gdata.from_xml_str(n, 'name'), alias=yang.gdata.from_xml_opt_str(n, 'alias'), description=yang.gdata.from_xml_opt_str(n, 'description'), vlan_id=yang.gdata.from_xml_opt_str(n, 'vlan-id'), encapsulation=yang.gdata.from_xml_opt_str(n, 'encapsulation'), family=junos_conf_root__configuration__interfaces__interface__unit__family.from_xml(yang.gdata.get_xml_opt_child(n, 'family')), mtu=yang.gdata.from_xml_opt_value(n, 'mtu'), mac=yang.gdata.from_xml_opt_str(n, 'mac'))
-
 class junos_conf_root__configuration__interfaces__interface__unit(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface__unit_entry]
     mut def __init__(self, elements=[]):
@@ -476,21 +515,56 @@ class junos_conf_root__configuration__interfaces__interface__unit(yang.adata.MNo
                 res.append(junos_conf_root__configuration__interfaces__interface__unit_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__interfaces__interface__unit_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__interfaces__interface__unit_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__interfaces__interface__unit__name, child_name)
+    child_alias = yang.gdata.from_xml_opt_str(node, 'alias')
+    yang.gdata.maybe_add(children, 'alias', from_xml_junos_conf_root__configuration__interfaces__interface__unit__alias, child_alias)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_junos_conf_root__configuration__interfaces__interface__unit__description, child_description)
+    child_vlan_id = yang.gdata.from_xml_opt_str(node, 'vlan-id')
+    yang.gdata.maybe_add(children, 'vlan-id', from_xml_junos_conf_root__configuration__interfaces__interface__unit__vlan_id, child_vlan_id)
+    child_encapsulation = yang.gdata.from_xml_opt_str(node, 'encapsulation')
+    yang.gdata.maybe_add(children, 'encapsulation', from_xml_junos_conf_root__configuration__interfaces__interface__unit__encapsulation, child_encapsulation)
+    child_family = yang.gdata.from_xml_opt_cnt(node, 'family')
+    yang.gdata.maybe_add(children, 'family', from_xml_junos_conf_root__configuration__interfaces__interface__unit__family, child_family)
+    child_mtu = yang.gdata.from_xml_opt_value(node, 'mtu')
+    yang.gdata.maybe_add(children, 'mtu', from_xml_junos_conf_root__configuration__interfaces__interface__unit__mtu, child_mtu)
+    child_mac = yang.gdata.from_xml_opt_str(node, 'mac')
+    yang.gdata.maybe_add(children, 'mac', from_xml_junos_conf_root__configuration__interfaces__interface__unit__mac, child_mac)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__unit(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__interfaces__interface__unit_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__encapsulation(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__vlan_tagging(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__stacked_vlan_tagging(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__flexible_vlan_tagging(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__vlan_vci_tagging(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__per_unit_scheduler(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__no_per_unit_scheduler(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__shared_scheduler(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler(yang.adata.MNode):
 
@@ -508,12 +582,10 @@ class junos_conf_root__configuration__interfaces__interface__hierarchical_schedu
             return junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler:
-        if n != None:
-            return junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler()
-        return None
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__interfaces__interface_entry(yang.adata.MNode):
     name: str
@@ -608,10 +680,6 @@ class junos_conf_root__configuration__interfaces__interface_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__interfaces__interface_entry:
         return junos_conf_root__configuration__interfaces__interface_entry(name=n.get_str('name'), description=n.get_opt_str('description'), mtu=n.get_opt_value('mtu'), mac=n.get_opt_str('mac'), native_vlan_id=n.get_opt_value('native-vlan-id'), unit=junos_conf_root__configuration__interfaces__interface__unit.from_gdata(n.get_opt_list('unit')), encapsulation=n.get_opt_str('encapsulation'), vlan_tagging=n.get_opt_bool('vlan-tagging'), stacked_vlan_tagging=n.get_opt_bool('stacked-vlan-tagging'), flexible_vlan_tagging=n.get_opt_bool('flexible-vlan-tagging'), vlan_vci_tagging=n.get_opt_bool('vlan-vci-tagging'), per_unit_scheduler=n.get_opt_bool('per-unit-scheduler'), no_per_unit_scheduler=n.get_opt_bool('no-per-unit-scheduler'), shared_scheduler=n.get_opt_bool('shared-scheduler'), hierarchical_scheduler=junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler.from_gdata(n.get_opt_container('hierarchical-scheduler')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__interfaces__interface_entry:
-        return junos_conf_root__configuration__interfaces__interface_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), mtu=yang.gdata.from_xml_opt_value(n, 'mtu'), mac=yang.gdata.from_xml_opt_str(n, 'mac'), native_vlan_id=yang.gdata.from_xml_opt_value(n, 'native-vlan-id'), unit=junos_conf_root__configuration__interfaces__interface__unit.from_xml(yang.gdata.get_xml_children(n, 'unit')), encapsulation=yang.gdata.from_xml_opt_str(n, 'encapsulation'), vlan_tagging=yang.gdata.from_xml_opt_bool(n, 'vlan-tagging'), stacked_vlan_tagging=yang.gdata.from_xml_opt_bool(n, 'stacked-vlan-tagging'), flexible_vlan_tagging=yang.gdata.from_xml_opt_bool(n, 'flexible-vlan-tagging'), vlan_vci_tagging=yang.gdata.from_xml_opt_bool(n, 'vlan-vci-tagging'), per_unit_scheduler=yang.gdata.from_xml_opt_bool(n, 'per-unit-scheduler'), no_per_unit_scheduler=yang.gdata.from_xml_opt_bool(n, 'no-per-unit-scheduler'), shared_scheduler=yang.gdata.from_xml_opt_bool(n, 'shared-scheduler'), hierarchical_scheduler=junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler.from_xml(yang.gdata.get_xml_opt_child(n, 'hierarchical-scheduler')))
-
 class junos_conf_root__configuration__interfaces__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -648,13 +716,46 @@ class junos_conf_root__configuration__interfaces__interface(yang.adata.MNode):
                 res.append(junos_conf_root__configuration__interfaces__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__interfaces__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__interfaces__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__interfaces__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__interfaces__interface__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_junos_conf_root__configuration__interfaces__interface__description, child_description)
+    child_mtu = yang.gdata.from_xml_opt_value(node, 'mtu')
+    yang.gdata.maybe_add(children, 'mtu', from_xml_junos_conf_root__configuration__interfaces__interface__mtu, child_mtu)
+    child_mac = yang.gdata.from_xml_opt_str(node, 'mac')
+    yang.gdata.maybe_add(children, 'mac', from_xml_junos_conf_root__configuration__interfaces__interface__mac, child_mac)
+    child_native_vlan_id = yang.gdata.from_xml_opt_value(node, 'native-vlan-id')
+    yang.gdata.maybe_add(children, 'native-vlan-id', from_xml_junos_conf_root__configuration__interfaces__interface__native_vlan_id, child_native_vlan_id)
+    child_unit = yang.gdata.from_xml_opt_list(node, 'unit')
+    yang.gdata.maybe_add(children, 'unit', from_xml_junos_conf_root__configuration__interfaces__interface__unit, child_unit)
+    child_encapsulation = yang.gdata.from_xml_opt_str(node, 'encapsulation')
+    yang.gdata.maybe_add(children, 'encapsulation', from_xml_junos_conf_root__configuration__interfaces__interface__encapsulation, child_encapsulation)
+    child_vlan_tagging = yang.gdata.from_xml_opt_bool(node, 'vlan-tagging')
+    yang.gdata.maybe_add(children, 'vlan-tagging', from_xml_junos_conf_root__configuration__interfaces__interface__vlan_tagging, child_vlan_tagging)
+    child_stacked_vlan_tagging = yang.gdata.from_xml_opt_bool(node, 'stacked-vlan-tagging')
+    yang.gdata.maybe_add(children, 'stacked-vlan-tagging', from_xml_junos_conf_root__configuration__interfaces__interface__stacked_vlan_tagging, child_stacked_vlan_tagging)
+    child_flexible_vlan_tagging = yang.gdata.from_xml_opt_bool(node, 'flexible-vlan-tagging')
+    yang.gdata.maybe_add(children, 'flexible-vlan-tagging', from_xml_junos_conf_root__configuration__interfaces__interface__flexible_vlan_tagging, child_flexible_vlan_tagging)
+    child_vlan_vci_tagging = yang.gdata.from_xml_opt_bool(node, 'vlan-vci-tagging')
+    yang.gdata.maybe_add(children, 'vlan-vci-tagging', from_xml_junos_conf_root__configuration__interfaces__interface__vlan_vci_tagging, child_vlan_vci_tagging)
+    child_per_unit_scheduler = yang.gdata.from_xml_opt_bool(node, 'per-unit-scheduler')
+    yang.gdata.maybe_add(children, 'per-unit-scheduler', from_xml_junos_conf_root__configuration__interfaces__interface__per_unit_scheduler, child_per_unit_scheduler)
+    child_no_per_unit_scheduler = yang.gdata.from_xml_opt_bool(node, 'no-per-unit-scheduler')
+    yang.gdata.maybe_add(children, 'no-per-unit-scheduler', from_xml_junos_conf_root__configuration__interfaces__interface__no_per_unit_scheduler, child_no_per_unit_scheduler)
+    child_shared_scheduler = yang.gdata.from_xml_opt_bool(node, 'shared-scheduler')
+    yang.gdata.maybe_add(children, 'shared-scheduler', from_xml_junos_conf_root__configuration__interfaces__interface__shared_scheduler, child_shared_scheduler)
+    child_hierarchical_scheduler = yang.gdata.from_xml_opt_cnt(node, 'hierarchical-scheduler')
+    yang.gdata.maybe_add(children, 'hierarchical-scheduler', from_xml_junos_conf_root__configuration__interfaces__interface__hierarchical_scheduler, child_hierarchical_scheduler)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__interfaces__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__interfaces__interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 class junos_conf_root__configuration__interfaces(yang.adata.MNode):
     interface: junos_conf_root__configuration__interfaces__interface
@@ -676,21 +777,39 @@ class junos_conf_root__configuration__interfaces(yang.adata.MNode):
             return junos_conf_root__configuration__interfaces(interface=junos_conf_root__configuration__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__interfaces()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__interfaces:
-        if n != None:
-            return junos_conf_root__configuration__interfaces(interface=junos_conf_root__configuration__interfaces__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')))
-        return junos_conf_root__configuration__interfaces()
 
+mut def from_xml_junos_conf_root__configuration__interfaces(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__interfaces__interface, child_interface)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__apply_groups(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__apply_groups_except(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__instance_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__interface__any(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__interface__unicast(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__interface__multicast(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__interface__primary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__routing_instances__instance__interface_entry(yang.adata.MNode):
     name: str
@@ -730,10 +849,6 @@ class junos_conf_root__configuration__routing_instances__instance__interface_ent
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__interface_entry:
         return junos_conf_root__configuration__routing_instances__instance__interface_entry(name=n.get_str('name'), any=n.get_opt_bool('any'), unicast=n.get_opt_bool('unicast'), multicast=n.get_opt_bool('multicast'), primary=n.get_opt_bool('primary'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__routing_instances__instance__interface_entry:
-        return junos_conf_root__configuration__routing_instances__instance__interface_entry(name=yang.gdata.from_xml_str(n, 'name'), any=yang.gdata.from_xml_opt_bool(n, 'any'), unicast=yang.gdata.from_xml_opt_bool(n, 'unicast'), multicast=yang.gdata.from_xml_opt_bool(n, 'multicast'), primary=yang.gdata.from_xml_opt_bool(n, 'primary'))
-
 class junos_conf_root__configuration__routing_instances__instance__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__interface_entry]
     mut def __init__(self, elements=[]):
@@ -770,14 +885,29 @@ class junos_conf_root__configuration__routing_instances__instance__interface(yan
                 res.append(junos_conf_root__configuration__routing_instances__instance__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__routing_instances__instance__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__routing_instances__instance__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__routing_instances__instance__interface__name, child_name)
+    child_any = yang.gdata.from_xml_opt_bool(node, 'any')
+    yang.gdata.maybe_add(children, 'any', from_xml_junos_conf_root__configuration__routing_instances__instance__interface__any, child_any)
+    child_unicast = yang.gdata.from_xml_opt_bool(node, 'unicast')
+    yang.gdata.maybe_add(children, 'unicast', from_xml_junos_conf_root__configuration__routing_instances__instance__interface__unicast, child_unicast)
+    child_multicast = yang.gdata.from_xml_opt_bool(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_junos_conf_root__configuration__routing_instances__instance__interface__multicast, child_multicast)
+    child_primary = yang.gdata.from_xml_opt_bool(node, 'primary')
+    yang.gdata.maybe_add(children, 'primary', from_xml_junos_conf_root__configuration__routing_instances__instance__interface__primary, child_primary)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__routing_instances__instance__interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
+
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__route_distinguisher__rd_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__routing_instances__instance__route_distinguisher(yang.adata.MNode):
     rd_type: ?str
@@ -799,18 +929,30 @@ class junos_conf_root__configuration__routing_instances__instance__route_disting
             return junos_conf_root__configuration__routing_instances__instance__route_distinguisher(rd_type=n.get_opt_str('rd-type'))
         return junos_conf_root__configuration__routing_instances__instance__route_distinguisher()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__routing_instances__instance__route_distinguisher:
-        if n != None:
-            return junos_conf_root__configuration__routing_instances__instance__route_distinguisher(rd_type=yang.gdata.from_xml_opt_str(n, 'rd-type'))
-        return junos_conf_root__configuration__routing_instances__instance__route_distinguisher()
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__route_distinguisher(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rd_type = yang.gdata.from_xml_opt_str(node, 'rd-type')
+    yang.gdata.maybe_add(children, 'rd-type', from_xml_junos_conf_root__configuration__routing_instances__instance__route_distinguisher__rd_type, child_rd_type)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__export_default_action(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__import_default_action(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target__community(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target__import(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target__export(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target__auto(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__routing_instances__instance__vrf_target(yang.adata.MNode):
     community: ?str
@@ -847,15 +989,27 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_target(ya
             return junos_conf_root__configuration__routing_instances__instance__vrf_target(community=n.get_opt_str('community'), import_=n.get_opt_str('import'), export=n.get_opt_str('export'), auto=n.get_opt_bool('auto'))
         return junos_conf_root__configuration__routing_instances__instance__vrf_target()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__routing_instances__instance__vrf_target:
-        if n != None:
-            return junos_conf_root__configuration__routing_instances__instance__vrf_target(community=yang.gdata.from_xml_opt_str(n, 'community'), import_=yang.gdata.from_xml_opt_str(n, 'import'), export=yang.gdata.from_xml_opt_str(n, 'export'), auto=yang.gdata.from_xml_opt_bool(n, 'auto'))
-        return junos_conf_root__configuration__routing_instances__instance__vrf_target()
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_community = yang.gdata.from_xml_opt_str(node, 'community')
+    yang.gdata.maybe_add(children, 'community', from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target__community, child_community)
+    child_import_ = yang.gdata.from_xml_opt_str(node, 'import')
+    yang.gdata.maybe_add(children, 'import', from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target__import, child_import_)
+    child_export = yang.gdata.from_xml_opt_str(node, 'export')
+    yang.gdata.maybe_add(children, 'export', from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target__export, child_export)
+    child_auto = yang.gdata.from_xml_opt_bool(node, 'auto')
+    yang.gdata.maybe_add(children, 'auto', from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target__auto, child_auto)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__no_vrf_advertise(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_table_label__static(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_table_label__source_class_usage(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__routing_instances__instance__vrf_table_label(yang.adata.MNode):
     static: ?value
@@ -882,24 +1036,50 @@ class junos_conf_root__configuration__routing_instances__instance__vrf_table_lab
             return junos_conf_root__configuration__routing_instances__instance__vrf_table_label(static=n.get_opt_value('static'), source_class_usage=n.get_opt_bool('source-class-usage'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__routing_instances__instance__vrf_table_label:
-        if n != None:
-            return junos_conf_root__configuration__routing_instances__instance__vrf_table_label(static=yang.gdata.from_xml_opt_value(n, 'static'), source_class_usage=yang.gdata.from_xml_opt_bool(n, 'source-class-usage'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_table_label(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_static = yang.gdata.from_xml_opt_value(node, 'static')
+    yang.gdata.maybe_add(children, 'static', from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_table_label__static, child_static)
+    child_source_class_usage = yang.gdata.from_xml_opt_bool(node, 'source-class-usage')
+    yang.gdata.maybe_add(children, 'source-class-usage', from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_table_label__source_class_usage, child_source_class_usage)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__passive(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__import(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__export(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__peer_as(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__as_override(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__authentication_algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop__ttl(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop__no_nexthop_change(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop(yang.adata.MNode):
     ttl: ?value
@@ -926,12 +1106,14 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
             return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop(ttl=n.get_opt_value('ttl'), no_nexthop_change=n.get_opt_bool('no-nexthop-change'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop:
-        if n != None:
-            return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop(ttl=yang.gdata.from_xml_opt_value(n, 'ttl'), no_nexthop_change=yang.gdata.from_xml_opt_bool(n, 'no-nexthop-change'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ttl = yang.gdata.from_xml_opt_value(node, 'ttl')
+    yang.gdata.maybe_add(children, 'ttl', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop__ttl, child_ttl)
+    child_no_nexthop_change = yang.gdata.from_xml_opt_bool(node, 'no-nexthop-change')
+    yang.gdata.maybe_add(children, 'no-nexthop-change', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop__no_nexthop_change, child_no_nexthop_change)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry(yang.adata.MNode):
     name: str
@@ -986,10 +1168,6 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry:
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry(name=n.get_str('name'), description=n.get_opt_str('description'), peer_as=n.get_opt_str('peer-as'), authentication_key=n.get_opt_str('authentication-key'), as_override=n.get_opt_bool('as-override'), authentication_algorithm=n.get_opt_str('authentication-algorithm'), multihop=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop.from_gdata(n.get_opt_container('multihop')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry:
-        return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), peer_as=yang.gdata.from_xml_opt_str(n, 'peer-as'), authentication_key=yang.gdata.from_xml_opt_str(n, 'authentication-key'), as_override=yang.gdata.from_xml_opt_bool(n, 'as-override'), authentication_algorithm=yang.gdata.from_xml_opt_str(n, 'authentication-algorithm'), multihop=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop.from_xml(yang.gdata.get_xml_opt_child(n, 'multihop')))
-
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -1026,13 +1204,30 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
                 res.append(junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__description, child_description)
+    child_peer_as = yang.gdata.from_xml_opt_str(node, 'peer-as')
+    yang.gdata.maybe_add(children, 'peer-as', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__peer_as, child_peer_as)
+    child_authentication_key = yang.gdata.from_xml_opt_str(node, 'authentication-key')
+    yang.gdata.maybe_add(children, 'authentication-key', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__authentication_key, child_authentication_key)
+    child_as_override = yang.gdata.from_xml_opt_bool(node, 'as-override')
+    yang.gdata.maybe_add(children, 'as-override', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__as_override, child_as_override)
+    child_authentication_algorithm = yang.gdata.from_xml_opt_str(node, 'authentication-algorithm')
+    yang.gdata.maybe_add(children, 'authentication-algorithm', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__authentication_algorithm, child_authentication_algorithm)
+    child_multihop = yang.gdata.from_xml_opt_cnt(node, 'multihop')
+    yang.gdata.maybe_add(children, 'multihop', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor__multihop, child_multihop)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry(yang.adata.MNode):
     name: str
@@ -1067,10 +1262,6 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry:
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry(name=n.get_str('name'), passive=n.get_opt_bool('passive'), import_=n.get_opt_strs('import'), export=n.get_opt_strs('export'), neighbor=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor.from_gdata(n.get_opt_list('neighbor')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry:
-        return junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry(name=yang.gdata.from_xml_str(n, 'name'), passive=yang.gdata.from_xml_opt_bool(n, 'passive'), import_=yang.gdata.from_xml_opt_strs(n, 'import'), export=yang.gdata.from_xml_opt_strs(n, 'export'), neighbor=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor.from_xml(yang.gdata.get_xml_children(n, 'neighbor')))
 
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry]
@@ -1108,13 +1299,26 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
                 res.append(junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__name, child_name)
+    child_passive = yang.gdata.from_xml_opt_bool(node, 'passive')
+    yang.gdata.maybe_add(children, 'passive', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__passive, child_passive)
+    child_import_ = yang.gdata.from_xml_opt_strs(node, 'import')
+    yang.gdata.maybe_add(children, 'import', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__import, child_import_)
+    child_export = yang.gdata.from_xml_opt_strs(node, 'export')
+    yang.gdata.maybe_add(children, 'export', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__export, child_export)
+    child_neighbor = yang.gdata.from_xml_opt_list(node, 'neighbor')
+    yang.gdata.maybe_add(children, 'neighbor', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group__neighbor, child_neighbor)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__routing_instances__instance__protocols__bgp(yang.adata.MNode):
     group: junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group
@@ -1136,14 +1340,18 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__bg
             return junos_conf_root__configuration__routing_instances__instance__protocols__bgp(group=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group.from_gdata(n.get_opt_list('group')))
         return junos_conf_root__configuration__routing_instances__instance__protocols__bgp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols__bgp:
-        if n != None:
-            return junos_conf_root__configuration__routing_instances__instance__protocols__bgp(group=junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return junos_conf_root__configuration__routing_instances__instance__protocols__bgp()
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp__group, child_group)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__evpn__control_word(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__evpn__no_mac_learning(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__routing_instances__instance__protocols__evpn(yang.adata.MNode):
     control_word: ?bool
@@ -1170,12 +1378,14 @@ class junos_conf_root__configuration__routing_instances__instance__protocols__ev
             return junos_conf_root__configuration__routing_instances__instance__protocols__evpn(control_word=n.get_opt_bool('control-word'), no_mac_learning=n.get_opt_bool('no-mac-learning'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__routing_instances__instance__protocols__evpn:
-        if n != None:
-            return junos_conf_root__configuration__routing_instances__instance__protocols__evpn(control_word=yang.gdata.from_xml_opt_bool(n, 'control-word'), no_mac_learning=yang.gdata.from_xml_opt_bool(n, 'no-mac-learning'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__evpn(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_control_word = yang.gdata.from_xml_opt_bool(node, 'control-word')
+    yang.gdata.maybe_add(children, 'control-word', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__evpn__control_word, child_control_word)
+    child_no_mac_learning = yang.gdata.from_xml_opt_bool(node, 'no-mac-learning')
+    yang.gdata.maybe_add(children, 'no-mac-learning', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__evpn__no_mac_learning, child_no_mac_learning)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__routing_instances__instance__protocols(yang.adata.MNode):
     bgp: junos_conf_root__configuration__routing_instances__instance__protocols__bgp
@@ -1207,12 +1417,14 @@ class junos_conf_root__configuration__routing_instances__instance__protocols(yan
             return junos_conf_root__configuration__routing_instances__instance__protocols(bgp=junos_conf_root__configuration__routing_instances__instance__protocols__bgp.from_gdata(n.get_opt_container('bgp')), evpn=junos_conf_root__configuration__routing_instances__instance__protocols__evpn.from_gdata(n.get_opt_container('evpn')))
         return junos_conf_root__configuration__routing_instances__instance__protocols()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__routing_instances__instance__protocols:
-        if n != None:
-            return junos_conf_root__configuration__routing_instances__instance__protocols(bgp=junos_conf_root__configuration__routing_instances__instance__protocols__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')), evpn=junos_conf_root__configuration__routing_instances__instance__protocols__evpn.from_xml(yang.gdata.get_xml_opt_child(n, 'evpn')))
-        return junos_conf_root__configuration__routing_instances__instance__protocols()
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance__protocols(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__bgp, child_bgp)
+    child_evpn = yang.gdata.from_xml_opt_cnt(node, 'evpn')
+    yang.gdata.maybe_add(children, 'evpn', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols__evpn, child_evpn)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__routing_instances__instance_entry(yang.adata.MNode):
     name: str
@@ -1288,10 +1500,6 @@ class junos_conf_root__configuration__routing_instances__instance_entry(yang.ada
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__routing_instances__instance_entry:
         return junos_conf_root__configuration__routing_instances__instance_entry(name=n.get_str('name'), apply_groups=n.get_opt_strs('apply-groups'), apply_groups_except=n.get_opt_strs('apply-groups-except'), instance_type=n.get_opt_str('instance-type'), interface=junos_conf_root__configuration__routing_instances__instance__interface.from_gdata(n.get_opt_list('interface')), route_distinguisher=junos_conf_root__configuration__routing_instances__instance__route_distinguisher.from_gdata(n.get_opt_container('route-distinguisher')), export_default_action=n.get_opt_str('export-default-action'), import_default_action=n.get_opt_str('import-default-action'), vrf_target=junos_conf_root__configuration__routing_instances__instance__vrf_target.from_gdata(n.get_opt_container('vrf-target')), no_vrf_advertise=n.get_opt_bool('no-vrf-advertise'), vrf_table_label=junos_conf_root__configuration__routing_instances__instance__vrf_table_label.from_gdata(n.get_opt_container('vrf-table-label')), protocols=junos_conf_root__configuration__routing_instances__instance__protocols.from_gdata(n.get_opt_container('protocols')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__routing_instances__instance_entry:
-        return junos_conf_root__configuration__routing_instances__instance_entry(name=yang.gdata.from_xml_str(n, 'name'), apply_groups=yang.gdata.from_xml_opt_strs(n, 'apply-groups'), apply_groups_except=yang.gdata.from_xml_opt_strs(n, 'apply-groups-except'), instance_type=yang.gdata.from_xml_opt_str(n, 'instance-type'), interface=junos_conf_root__configuration__routing_instances__instance__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')), route_distinguisher=junos_conf_root__configuration__routing_instances__instance__route_distinguisher.from_xml(yang.gdata.get_xml_opt_child(n, 'route-distinguisher')), export_default_action=yang.gdata.from_xml_opt_str(n, 'export-default-action'), import_default_action=yang.gdata.from_xml_opt_str(n, 'import-default-action'), vrf_target=junos_conf_root__configuration__routing_instances__instance__vrf_target.from_xml(yang.gdata.get_xml_opt_child(n, 'vrf-target')), no_vrf_advertise=yang.gdata.from_xml_opt_bool(n, 'no-vrf-advertise'), vrf_table_label=junos_conf_root__configuration__routing_instances__instance__vrf_table_label.from_xml(yang.gdata.get_xml_opt_child(n, 'vrf-table-label')), protocols=junos_conf_root__configuration__routing_instances__instance__protocols.from_xml(yang.gdata.get_xml_opt_child(n, 'protocols')))
-
 class junos_conf_root__configuration__routing_instances__instance(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__routing_instances__instance_entry]
     mut def __init__(self, elements=[]):
@@ -1328,13 +1536,40 @@ class junos_conf_root__configuration__routing_instances__instance(yang.adata.MNo
                 res.append(junos_conf_root__configuration__routing_instances__instance_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__routing_instances__instance_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__routing_instances__instance_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__routing_instances__instance__name, child_name)
+    child_apply_groups = yang.gdata.from_xml_opt_strs(node, 'apply-groups')
+    yang.gdata.maybe_add(children, 'apply-groups', from_xml_junos_conf_root__configuration__routing_instances__instance__apply_groups, child_apply_groups)
+    child_apply_groups_except = yang.gdata.from_xml_opt_strs(node, 'apply-groups-except')
+    yang.gdata.maybe_add(children, 'apply-groups-except', from_xml_junos_conf_root__configuration__routing_instances__instance__apply_groups_except, child_apply_groups_except)
+    child_instance_type = yang.gdata.from_xml_opt_str(node, 'instance-type')
+    yang.gdata.maybe_add(children, 'instance-type', from_xml_junos_conf_root__configuration__routing_instances__instance__instance_type, child_instance_type)
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__routing_instances__instance__interface, child_interface)
+    child_route_distinguisher = yang.gdata.from_xml_opt_cnt(node, 'route-distinguisher')
+    yang.gdata.maybe_add(children, 'route-distinguisher', from_xml_junos_conf_root__configuration__routing_instances__instance__route_distinguisher, child_route_distinguisher)
+    child_export_default_action = yang.gdata.from_xml_opt_str(node, 'export-default-action')
+    yang.gdata.maybe_add(children, 'export-default-action', from_xml_junos_conf_root__configuration__routing_instances__instance__export_default_action, child_export_default_action)
+    child_import_default_action = yang.gdata.from_xml_opt_str(node, 'import-default-action')
+    yang.gdata.maybe_add(children, 'import-default-action', from_xml_junos_conf_root__configuration__routing_instances__instance__import_default_action, child_import_default_action)
+    child_vrf_target = yang.gdata.from_xml_opt_cnt(node, 'vrf-target')
+    yang.gdata.maybe_add(children, 'vrf-target', from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_target, child_vrf_target)
+    child_no_vrf_advertise = yang.gdata.from_xml_opt_bool(node, 'no-vrf-advertise')
+    yang.gdata.maybe_add(children, 'no-vrf-advertise', from_xml_junos_conf_root__configuration__routing_instances__instance__no_vrf_advertise, child_no_vrf_advertise)
+    child_vrf_table_label = yang.gdata.from_xml_opt_cnt(node, 'vrf-table-label')
+    yang.gdata.maybe_add(children, 'vrf-table-label', from_xml_junos_conf_root__configuration__routing_instances__instance__vrf_table_label, child_vrf_table_label)
+    child_protocols = yang.gdata.from_xml_opt_cnt(node, 'protocols')
+    yang.gdata.maybe_add(children, 'protocols', from_xml_junos_conf_root__configuration__routing_instances__instance__protocols, child_protocols)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__routing_instances__instance(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__routing_instances__instance_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 class junos_conf_root__configuration__routing_instances(yang.adata.MNode):
     instance: junos_conf_root__configuration__routing_instances__instance
@@ -1356,15 +1591,21 @@ class junos_conf_root__configuration__routing_instances(yang.adata.MNode):
             return junos_conf_root__configuration__routing_instances(instance=junos_conf_root__configuration__routing_instances__instance.from_gdata(n.get_opt_list('instance')))
         return junos_conf_root__configuration__routing_instances()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__routing_instances:
-        if n != None:
-            return junos_conf_root__configuration__routing_instances(instance=junos_conf_root__configuration__routing_instances__instance.from_xml(yang.gdata.get_xml_children(n, 'instance')))
-        return junos_conf_root__configuration__routing_instances()
 
+mut def from_xml_junos_conf_root__configuration__routing_instances(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_instance = yang.gdata.from_xml_opt_list(node, 'instance')
+    yang.gdata.maybe_add(children, 'instance', from_xml_junos_conf_root__configuration__routing_instances__instance, child_instance)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__when__time__start_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__when__time__to__end_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__groups__when__time__to(yang.adata.MNode):
     end_time: ?str
@@ -1386,12 +1627,12 @@ class junos_conf_root__configuration__groups__when__time__to(yang.adata.MNode):
             return junos_conf_root__configuration__groups__when__time__to(end_time=n.get_opt_str('end-time'))
         return junos_conf_root__configuration__groups__when__time__to()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__when__time__to:
-        if n != None:
-            return junos_conf_root__configuration__groups__when__time__to(end_time=yang.gdata.from_xml_opt_str(n, 'end-time'))
-        return junos_conf_root__configuration__groups__when__time__to()
 
+mut def from_xml_junos_conf_root__configuration__groups__when__time__to(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_end_time = yang.gdata.from_xml_opt_str(node, 'end-time')
+    yang.gdata.maybe_add(children, 'end-time', from_xml_junos_conf_root__configuration__groups__when__time__to__end_time, child_end_time)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__groups__when__time(yang.adata.MNode):
     start_time: ?str
@@ -1418,17 +1659,29 @@ class junos_conf_root__configuration__groups__when__time(yang.adata.MNode):
             return junos_conf_root__configuration__groups__when__time(start_time=n.get_opt_str('start-time'), to=junos_conf_root__configuration__groups__when__time__to.from_gdata(n.get_opt_container('to')))
         return junos_conf_root__configuration__groups__when__time()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__when__time:
-        if n != None:
-            return junos_conf_root__configuration__groups__when__time(start_time=yang.gdata.from_xml_opt_str(n, 'start-time'), to=junos_conf_root__configuration__groups__when__time__to.from_xml(yang.gdata.get_xml_opt_child(n, 'to')))
-        return junos_conf_root__configuration__groups__when__time()
 
+mut def from_xml_junos_conf_root__configuration__groups__when__time(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_start_time = yang.gdata.from_xml_opt_str(node, 'start-time')
+    yang.gdata.maybe_add(children, 'start-time', from_xml_junos_conf_root__configuration__groups__when__time__start_time, child_start_time)
+    child_to = yang.gdata.from_xml_opt_cnt(node, 'to')
+    yang.gdata.maybe_add(children, 'to', from_xml_junos_conf_root__configuration__groups__when__time__to, child_to)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__when__chassis(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__when__model(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__when__routing_engine(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__when__member(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__when__node(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class junos_conf_root__configuration__groups__when(yang.adata.MNode):
     time: junos_conf_root__configuration__groups__when__time
@@ -1475,15 +1728,31 @@ class junos_conf_root__configuration__groups__when(yang.adata.MNode):
             return junos_conf_root__configuration__groups__when(time=junos_conf_root__configuration__groups__when__time.from_gdata(n.get_opt_container('time')), chassis=n.get_opt_str('chassis'), model=n.get_opt_str('model'), routing_engine=n.get_opt_str('routing-engine'), member=n.get_opt_str('member'), node=n.get_opt_str('node'))
         return junos_conf_root__configuration__groups__when()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__when:
-        if n != None:
-            return junos_conf_root__configuration__groups__when(time=junos_conf_root__configuration__groups__when__time.from_xml(yang.gdata.get_xml_opt_child(n, 'time')), chassis=yang.gdata.from_xml_opt_str(n, 'chassis'), model=yang.gdata.from_xml_opt_str(n, 'model'), routing_engine=yang.gdata.from_xml_opt_str(n, 'routing-engine'), member=yang.gdata.from_xml_opt_str(n, 'member'), node=yang.gdata.from_xml_opt_str(n, 'node'))
-        return junos_conf_root__configuration__groups__when()
 
+mut def from_xml_junos_conf_root__configuration__groups__when(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_time = yang.gdata.from_xml_opt_cnt(node, 'time')
+    yang.gdata.maybe_add(children, 'time', from_xml_junos_conf_root__configuration__groups__when__time, child_time)
+    child_chassis = yang.gdata.from_xml_opt_str(node, 'chassis')
+    yang.gdata.maybe_add(children, 'chassis', from_xml_junos_conf_root__configuration__groups__when__chassis, child_chassis)
+    child_model = yang.gdata.from_xml_opt_str(node, 'model')
+    yang.gdata.maybe_add(children, 'model', from_xml_junos_conf_root__configuration__groups__when__model, child_model)
+    child_routing_engine = yang.gdata.from_xml_opt_str(node, 'routing-engine')
+    yang.gdata.maybe_add(children, 'routing-engine', from_xml_junos_conf_root__configuration__groups__when__routing_engine, child_routing_engine)
+    child_member = yang.gdata.from_xml_opt_str(node, 'member')
+    yang.gdata.maybe_add(children, 'member', from_xml_junos_conf_root__configuration__groups__when__member, child_member)
+    child_node = yang.gdata.from_xml_opt_str(node, 'node')
+    yang.gdata.maybe_add(children, 'node', from_xml_junos_conf_root__configuration__groups__when__node, child_node)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__rcsid(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__version(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__system__host_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__groups__system(yang.adata.MNode):
     host_name: ?str
@@ -1505,23 +1774,45 @@ class junos_conf_root__configuration__groups__system(yang.adata.MNode):
             return junos_conf_root__configuration__groups__system(host_name=n.get_opt_str('host-name'))
         return junos_conf_root__configuration__groups__system()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__system:
-        if n != None:
-            return junos_conf_root__configuration__groups__system(host_name=yang.gdata.from_xml_opt_str(n, 'host-name'))
-        return junos_conf_root__configuration__groups__system()
 
+mut def from_xml_junos_conf_root__configuration__groups__system(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_host_name = yang.gdata.from_xml_opt_str(node, 'host-name')
+    yang.gdata.maybe_add(children, 'host-name', from_xml_junos_conf_root__configuration__groups__system__host_name, child_host_name)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__mtu(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__mac(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__native_vlan_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__alias(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__vlan_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__encapsulation(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry(yang.adata.MNode):
     name: str
@@ -1540,10 +1831,6 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry:
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry(name=n.get_str('name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry:
-        return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry(name=yang.gdata.from_xml_str(n, 'name'))
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry]
@@ -1581,13 +1868,18 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
                 res.append(junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet(yang.adata.MNode):
     address: junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address
@@ -1609,13 +1901,15 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address.from_gdata(n.get_opt_list('address')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet:
-        if n != None:
-            return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address.from_xml(yang.gdata.get_xml_children(n, 'address')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address = yang.gdata.from_xml_opt_list(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet__address, child_address)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry(yang.adata.MNode):
     name: str
@@ -1634,10 +1928,6 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry:
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry(name=n.get_str('name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry:
-        return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry(name=yang.gdata.from_xml_str(n, 'name'))
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry]
@@ -1675,13 +1965,18 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
                 res.append(junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6(yang.adata.MNode):
     address: junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address
@@ -1703,13 +1998,15 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address.from_gdata(n.get_opt_list('address')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6:
-        if n != None:
-            return junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address.from_xml(yang.gdata.get_xml_children(n, 'address')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address = yang.gdata.from_xml_opt_list(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6__address, child_address)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry(yang.adata.MNode):
     name: str
@@ -1728,10 +2025,6 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry:
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry(name=n.get_str('name'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry:
-        return junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry(name=yang.gdata.from_xml_str(n, 'name'))
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry]
@@ -1769,13 +2062,18 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
                 res.append(junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso(yang.adata.MNode):
     address: junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address
@@ -1797,12 +2095,12 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address.from_gdata(n.get_opt_list('address')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso:
-        if n != None:
-            return junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso(address=junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address.from_xml(yang.gdata.get_xml_children(n, 'address')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address = yang.gdata.from_xml_opt_list(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso__address, child_address)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit__family(yang.adata.MNode):
     inet: ?junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet
@@ -1849,14 +2147,22 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit__famil
             return junos_conf_root__configuration__groups__interfaces__interface__unit__family(inet=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet.from_gdata(n.get_opt_container('inet')), inet6=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6.from_gdata(n.get_opt_container('inet6')), iso=junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso.from_gdata(n.get_opt_container('iso')))
         return junos_conf_root__configuration__groups__interfaces__interface__unit__family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit__family:
-        if n != None:
-            return junos_conf_root__configuration__groups__interfaces__interface__unit__family(inet=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet.from_xml(yang.gdata.get_xml_opt_child(n, 'inet')), inet6=junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6.from_xml(yang.gdata.get_xml_opt_child(n, 'inet6')), iso=junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso.from_xml(yang.gdata.get_xml_opt_child(n, 'iso')))
-        return junos_conf_root__configuration__groups__interfaces__interface__unit__family()
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_inet = yang.gdata.from_xml_opt_cnt(node, 'inet')
+    yang.gdata.maybe_add(children, 'inet', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet, child_inet)
+    child_inet6 = yang.gdata.from_xml_opt_cnt(node, 'inet6')
+    yang.gdata.maybe_add(children, 'inet6', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__inet6, child_inet6)
+    child_iso = yang.gdata.from_xml_opt_cnt(node, 'iso')
+    yang.gdata.maybe_add(children, 'iso', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family__iso, child_iso)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__mtu(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__mac(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__groups__interfaces__interface__unit_entry(yang.adata.MNode):
     name: str
@@ -1911,10 +2217,6 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit_entry(
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit_entry:
         return junos_conf_root__configuration__groups__interfaces__interface__unit_entry(name=n.get_str('name'), alias=n.get_opt_str('alias'), description=n.get_opt_str('description'), vlan_id=n.get_opt_str('vlan-id'), encapsulation=n.get_opt_str('encapsulation'), family=junos_conf_root__configuration__groups__interfaces__interface__unit__family.from_gdata(n.get_opt_container('family')), mtu=n.get_opt_value('mtu'), mac=n.get_opt_str('mac'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__interfaces__interface__unit_entry:
-        return junos_conf_root__configuration__groups__interfaces__interface__unit_entry(name=yang.gdata.from_xml_str(n, 'name'), alias=yang.gdata.from_xml_opt_str(n, 'alias'), description=yang.gdata.from_xml_opt_str(n, 'description'), vlan_id=yang.gdata.from_xml_opt_str(n, 'vlan-id'), encapsulation=yang.gdata.from_xml_opt_str(n, 'encapsulation'), family=junos_conf_root__configuration__groups__interfaces__interface__unit__family.from_xml(yang.gdata.get_xml_opt_child(n, 'family')), mtu=yang.gdata.from_xml_opt_value(n, 'mtu'), mac=yang.gdata.from_xml_opt_str(n, 'mac'))
-
 class junos_conf_root__configuration__groups__interfaces__interface__unit(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface__unit_entry]
     mut def __init__(self, elements=[]):
@@ -1951,21 +2253,56 @@ class junos_conf_root__configuration__groups__interfaces__interface__unit(yang.a
                 res.append(junos_conf_root__configuration__groups__interfaces__interface__unit_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__interfaces__interface__unit_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__interfaces__interface__unit_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__name, child_name)
+    child_alias = yang.gdata.from_xml_opt_str(node, 'alias')
+    yang.gdata.maybe_add(children, 'alias', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__alias, child_alias)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__description, child_description)
+    child_vlan_id = yang.gdata.from_xml_opt_str(node, 'vlan-id')
+    yang.gdata.maybe_add(children, 'vlan-id', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__vlan_id, child_vlan_id)
+    child_encapsulation = yang.gdata.from_xml_opt_str(node, 'encapsulation')
+    yang.gdata.maybe_add(children, 'encapsulation', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__encapsulation, child_encapsulation)
+    child_family = yang.gdata.from_xml_opt_cnt(node, 'family')
+    yang.gdata.maybe_add(children, 'family', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__family, child_family)
+    child_mtu = yang.gdata.from_xml_opt_value(node, 'mtu')
+    yang.gdata.maybe_add(children, 'mtu', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__mtu, child_mtu)
+    child_mac = yang.gdata.from_xml_opt_str(node, 'mac')
+    yang.gdata.maybe_add(children, 'mac', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit__mac, child_mac)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__encapsulation(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__vlan_tagging(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__stacked_vlan_tagging(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__flexible_vlan_tagging(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__vlan_vci_tagging(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__per_unit_scheduler(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__no_per_unit_scheduler(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__shared_scheduler(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler(yang.adata.MNode):
 
@@ -1983,12 +2320,10 @@ class junos_conf_root__configuration__groups__interfaces__interface__hierarchica
             return junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler:
-        if n != None:
-            return junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler()
-        return None
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__groups__interfaces__interface_entry(yang.adata.MNode):
     name: str
@@ -2083,10 +2418,6 @@ class junos_conf_root__configuration__groups__interfaces__interface_entry(yang.a
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__interfaces__interface_entry:
         return junos_conf_root__configuration__groups__interfaces__interface_entry(name=n.get_str('name'), description=n.get_opt_str('description'), mtu=n.get_opt_value('mtu'), mac=n.get_opt_str('mac'), native_vlan_id=n.get_opt_value('native-vlan-id'), unit=junos_conf_root__configuration__groups__interfaces__interface__unit.from_gdata(n.get_opt_list('unit')), encapsulation=n.get_opt_str('encapsulation'), vlan_tagging=n.get_opt_bool('vlan-tagging'), stacked_vlan_tagging=n.get_opt_bool('stacked-vlan-tagging'), flexible_vlan_tagging=n.get_opt_bool('flexible-vlan-tagging'), vlan_vci_tagging=n.get_opt_bool('vlan-vci-tagging'), per_unit_scheduler=n.get_opt_bool('per-unit-scheduler'), no_per_unit_scheduler=n.get_opt_bool('no-per-unit-scheduler'), shared_scheduler=n.get_opt_bool('shared-scheduler'), hierarchical_scheduler=junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler.from_gdata(n.get_opt_container('hierarchical-scheduler')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__interfaces__interface_entry:
-        return junos_conf_root__configuration__groups__interfaces__interface_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), mtu=yang.gdata.from_xml_opt_value(n, 'mtu'), mac=yang.gdata.from_xml_opt_str(n, 'mac'), native_vlan_id=yang.gdata.from_xml_opt_value(n, 'native-vlan-id'), unit=junos_conf_root__configuration__groups__interfaces__interface__unit.from_xml(yang.gdata.get_xml_children(n, 'unit')), encapsulation=yang.gdata.from_xml_opt_str(n, 'encapsulation'), vlan_tagging=yang.gdata.from_xml_opt_bool(n, 'vlan-tagging'), stacked_vlan_tagging=yang.gdata.from_xml_opt_bool(n, 'stacked-vlan-tagging'), flexible_vlan_tagging=yang.gdata.from_xml_opt_bool(n, 'flexible-vlan-tagging'), vlan_vci_tagging=yang.gdata.from_xml_opt_bool(n, 'vlan-vci-tagging'), per_unit_scheduler=yang.gdata.from_xml_opt_bool(n, 'per-unit-scheduler'), no_per_unit_scheduler=yang.gdata.from_xml_opt_bool(n, 'no-per-unit-scheduler'), shared_scheduler=yang.gdata.from_xml_opt_bool(n, 'shared-scheduler'), hierarchical_scheduler=junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler.from_xml(yang.gdata.get_xml_opt_child(n, 'hierarchical-scheduler')))
-
 class junos_conf_root__configuration__groups__interfaces__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -2123,13 +2454,46 @@ class junos_conf_root__configuration__groups__interfaces__interface(yang.adata.M
                 res.append(junos_conf_root__configuration__groups__interfaces__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__interfaces__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__interfaces__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__interfaces__interface__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_junos_conf_root__configuration__groups__interfaces__interface__description, child_description)
+    child_mtu = yang.gdata.from_xml_opt_value(node, 'mtu')
+    yang.gdata.maybe_add(children, 'mtu', from_xml_junos_conf_root__configuration__groups__interfaces__interface__mtu, child_mtu)
+    child_mac = yang.gdata.from_xml_opt_str(node, 'mac')
+    yang.gdata.maybe_add(children, 'mac', from_xml_junos_conf_root__configuration__groups__interfaces__interface__mac, child_mac)
+    child_native_vlan_id = yang.gdata.from_xml_opt_value(node, 'native-vlan-id')
+    yang.gdata.maybe_add(children, 'native-vlan-id', from_xml_junos_conf_root__configuration__groups__interfaces__interface__native_vlan_id, child_native_vlan_id)
+    child_unit = yang.gdata.from_xml_opt_list(node, 'unit')
+    yang.gdata.maybe_add(children, 'unit', from_xml_junos_conf_root__configuration__groups__interfaces__interface__unit, child_unit)
+    child_encapsulation = yang.gdata.from_xml_opt_str(node, 'encapsulation')
+    yang.gdata.maybe_add(children, 'encapsulation', from_xml_junos_conf_root__configuration__groups__interfaces__interface__encapsulation, child_encapsulation)
+    child_vlan_tagging = yang.gdata.from_xml_opt_bool(node, 'vlan-tagging')
+    yang.gdata.maybe_add(children, 'vlan-tagging', from_xml_junos_conf_root__configuration__groups__interfaces__interface__vlan_tagging, child_vlan_tagging)
+    child_stacked_vlan_tagging = yang.gdata.from_xml_opt_bool(node, 'stacked-vlan-tagging')
+    yang.gdata.maybe_add(children, 'stacked-vlan-tagging', from_xml_junos_conf_root__configuration__groups__interfaces__interface__stacked_vlan_tagging, child_stacked_vlan_tagging)
+    child_flexible_vlan_tagging = yang.gdata.from_xml_opt_bool(node, 'flexible-vlan-tagging')
+    yang.gdata.maybe_add(children, 'flexible-vlan-tagging', from_xml_junos_conf_root__configuration__groups__interfaces__interface__flexible_vlan_tagging, child_flexible_vlan_tagging)
+    child_vlan_vci_tagging = yang.gdata.from_xml_opt_bool(node, 'vlan-vci-tagging')
+    yang.gdata.maybe_add(children, 'vlan-vci-tagging', from_xml_junos_conf_root__configuration__groups__interfaces__interface__vlan_vci_tagging, child_vlan_vci_tagging)
+    child_per_unit_scheduler = yang.gdata.from_xml_opt_bool(node, 'per-unit-scheduler')
+    yang.gdata.maybe_add(children, 'per-unit-scheduler', from_xml_junos_conf_root__configuration__groups__interfaces__interface__per_unit_scheduler, child_per_unit_scheduler)
+    child_no_per_unit_scheduler = yang.gdata.from_xml_opt_bool(node, 'no-per-unit-scheduler')
+    yang.gdata.maybe_add(children, 'no-per-unit-scheduler', from_xml_junos_conf_root__configuration__groups__interfaces__interface__no_per_unit_scheduler, child_no_per_unit_scheduler)
+    child_shared_scheduler = yang.gdata.from_xml_opt_bool(node, 'shared-scheduler')
+    yang.gdata.maybe_add(children, 'shared-scheduler', from_xml_junos_conf_root__configuration__groups__interfaces__interface__shared_scheduler, child_shared_scheduler)
+    child_hierarchical_scheduler = yang.gdata.from_xml_opt_cnt(node, 'hierarchical-scheduler')
+    yang.gdata.maybe_add(children, 'hierarchical-scheduler', from_xml_junos_conf_root__configuration__groups__interfaces__interface__hierarchical_scheduler, child_hierarchical_scheduler)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__groups__interfaces__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__interfaces__interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 class junos_conf_root__configuration__groups__interfaces(yang.adata.MNode):
     interface: junos_conf_root__configuration__groups__interfaces__interface
@@ -2151,21 +2515,39 @@ class junos_conf_root__configuration__groups__interfaces(yang.adata.MNode):
             return junos_conf_root__configuration__groups__interfaces(interface=junos_conf_root__configuration__groups__interfaces__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__groups__interfaces()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__interfaces:
-        if n != None:
-            return junos_conf_root__configuration__groups__interfaces(interface=junos_conf_root__configuration__groups__interfaces__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')))
-        return junos_conf_root__configuration__groups__interfaces()
 
+mut def from_xml_junos_conf_root__configuration__groups__interfaces(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__groups__interfaces__interface, child_interface)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__apply_groups(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__apply_groups_except(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__instance_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__any(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__unicast(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__multicast(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__primary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__interface_entry(yang.adata.MNode):
     name: str
@@ -2205,10 +2587,6 @@ class junos_conf_root__configuration__groups__routing_instances__instance__inter
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__interface_entry:
         return junos_conf_root__configuration__groups__routing_instances__instance__interface_entry(name=n.get_str('name'), any=n.get_opt_bool('any'), unicast=n.get_opt_bool('unicast'), multicast=n.get_opt_bool('multicast'), primary=n.get_opt_bool('primary'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__interface_entry:
-        return junos_conf_root__configuration__groups__routing_instances__instance__interface_entry(name=yang.gdata.from_xml_str(n, 'name'), any=yang.gdata.from_xml_opt_bool(n, 'any'), unicast=yang.gdata.from_xml_opt_bool(n, 'unicast'), multicast=yang.gdata.from_xml_opt_bool(n, 'multicast'), primary=yang.gdata.from_xml_opt_bool(n, 'primary'))
-
 class junos_conf_root__configuration__groups__routing_instances__instance__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__routing_instances__instance__interface_entry]
     mut def __init__(self, elements=[]):
@@ -2245,14 +2623,29 @@ class junos_conf_root__configuration__groups__routing_instances__instance__inter
                 res.append(junos_conf_root__configuration__groups__routing_instances__instance__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__routing_instances__instance__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__routing_instances__instance__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__name, child_name)
+    child_any = yang.gdata.from_xml_opt_bool(node, 'any')
+    yang.gdata.maybe_add(children, 'any', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__any, child_any)
+    child_unicast = yang.gdata.from_xml_opt_bool(node, 'unicast')
+    yang.gdata.maybe_add(children, 'unicast', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__unicast, child_unicast)
+    child_multicast = yang.gdata.from_xml_opt_bool(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__multicast, child_multicast)
+    child_primary = yang.gdata.from_xml_opt_bool(node, 'primary')
+    yang.gdata.maybe_add(children, 'primary', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface__primary, child_primary)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
+
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher__rd_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher(yang.adata.MNode):
     rd_type: ?str
@@ -2274,18 +2667,30 @@ class junos_conf_root__configuration__groups__routing_instances__instance__route
             return junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher(rd_type=n.get_opt_str('rd-type'))
         return junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher:
-        if n != None:
-            return junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher(rd_type=yang.gdata.from_xml_opt_str(n, 'rd-type'))
-        return junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher()
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rd_type = yang.gdata.from_xml_opt_str(node, 'rd-type')
+    yang.gdata.maybe_add(children, 'rd-type', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher__rd_type, child_rd_type)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__export_default_action(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__import_default_action(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target__community(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target__import(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target__export(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target__auto(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__vrf_target(yang.adata.MNode):
     community: ?str
@@ -2322,15 +2727,27 @@ class junos_conf_root__configuration__groups__routing_instances__instance__vrf_t
             return junos_conf_root__configuration__groups__routing_instances__instance__vrf_target(community=n.get_opt_str('community'), import_=n.get_opt_str('import'), export=n.get_opt_str('export'), auto=n.get_opt_bool('auto'))
         return junos_conf_root__configuration__groups__routing_instances__instance__vrf_target()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__vrf_target:
-        if n != None:
-            return junos_conf_root__configuration__groups__routing_instances__instance__vrf_target(community=yang.gdata.from_xml_opt_str(n, 'community'), import_=yang.gdata.from_xml_opt_str(n, 'import'), export=yang.gdata.from_xml_opt_str(n, 'export'), auto=yang.gdata.from_xml_opt_bool(n, 'auto'))
-        return junos_conf_root__configuration__groups__routing_instances__instance__vrf_target()
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_community = yang.gdata.from_xml_opt_str(node, 'community')
+    yang.gdata.maybe_add(children, 'community', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target__community, child_community)
+    child_import_ = yang.gdata.from_xml_opt_str(node, 'import')
+    yang.gdata.maybe_add(children, 'import', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target__import, child_import_)
+    child_export = yang.gdata.from_xml_opt_str(node, 'export')
+    yang.gdata.maybe_add(children, 'export', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target__export, child_export)
+    child_auto = yang.gdata.from_xml_opt_bool(node, 'auto')
+    yang.gdata.maybe_add(children, 'auto', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target__auto, child_auto)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__no_vrf_advertise(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label__static(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label__source_class_usage(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label(yang.adata.MNode):
     static: ?value
@@ -2357,24 +2774,50 @@ class junos_conf_root__configuration__groups__routing_instances__instance__vrf_t
             return junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label(static=n.get_opt_value('static'), source_class_usage=n.get_opt_bool('source-class-usage'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label:
-        if n != None:
-            return junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label(static=yang.gdata.from_xml_opt_value(n, 'static'), source_class_usage=yang.gdata.from_xml_opt_bool(n, 'source-class-usage'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_static = yang.gdata.from_xml_opt_value(node, 'static')
+    yang.gdata.maybe_add(children, 'static', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label__static, child_static)
+    child_source_class_usage = yang.gdata.from_xml_opt_bool(node, 'source-class-usage')
+    yang.gdata.maybe_add(children, 'source-class-usage', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label__source_class_usage, child_source_class_usage)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__passive(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__import(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__export(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__peer_as(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__as_override(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__authentication_algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop__ttl(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop__no_nexthop_change(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop(yang.adata.MNode):
     ttl: ?value
@@ -2401,12 +2844,14 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop(ttl=n.get_opt_value('ttl'), no_nexthop_change=n.get_opt_bool('no-nexthop-change'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop:
-        if n != None:
-            return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop(ttl=yang.gdata.from_xml_opt_value(n, 'ttl'), no_nexthop_change=yang.gdata.from_xml_opt_bool(n, 'no-nexthop-change'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ttl = yang.gdata.from_xml_opt_value(node, 'ttl')
+    yang.gdata.maybe_add(children, 'ttl', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop__ttl, child_ttl)
+    child_no_nexthop_change = yang.gdata.from_xml_opt_bool(node, 'no-nexthop-change')
+    yang.gdata.maybe_add(children, 'no-nexthop-change', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop__no_nexthop_change, child_no_nexthop_change)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry(yang.adata.MNode):
     name: str
@@ -2461,10 +2906,6 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry:
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry(name=n.get_str('name'), description=n.get_opt_str('description'), peer_as=n.get_opt_str('peer-as'), authentication_key=n.get_opt_str('authentication-key'), as_override=n.get_opt_bool('as-override'), authentication_algorithm=n.get_opt_str('authentication-algorithm'), multihop=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop.from_gdata(n.get_opt_container('multihop')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry:
-        return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), peer_as=yang.gdata.from_xml_opt_str(n, 'peer-as'), authentication_key=yang.gdata.from_xml_opt_str(n, 'authentication-key'), as_override=yang.gdata.from_xml_opt_bool(n, 'as-override'), authentication_algorithm=yang.gdata.from_xml_opt_str(n, 'authentication-algorithm'), multihop=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop.from_xml(yang.gdata.get_xml_opt_child(n, 'multihop')))
-
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -2501,13 +2942,30 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
                 res.append(junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__description, child_description)
+    child_peer_as = yang.gdata.from_xml_opt_str(node, 'peer-as')
+    yang.gdata.maybe_add(children, 'peer-as', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__peer_as, child_peer_as)
+    child_authentication_key = yang.gdata.from_xml_opt_str(node, 'authentication-key')
+    yang.gdata.maybe_add(children, 'authentication-key', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__authentication_key, child_authentication_key)
+    child_as_override = yang.gdata.from_xml_opt_bool(node, 'as-override')
+    yang.gdata.maybe_add(children, 'as-override', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__as_override, child_as_override)
+    child_authentication_algorithm = yang.gdata.from_xml_opt_str(node, 'authentication-algorithm')
+    yang.gdata.maybe_add(children, 'authentication-algorithm', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__authentication_algorithm, child_authentication_algorithm)
+    child_multihop = yang.gdata.from_xml_opt_cnt(node, 'multihop')
+    yang.gdata.maybe_add(children, 'multihop', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor__multihop, child_multihop)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry(yang.adata.MNode):
     name: str
@@ -2542,10 +3000,6 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry:
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry(name=n.get_str('name'), passive=n.get_opt_bool('passive'), import_=n.get_opt_strs('import'), export=n.get_opt_strs('export'), neighbor=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor.from_gdata(n.get_opt_list('neighbor')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry:
-        return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry(name=yang.gdata.from_xml_str(n, 'name'), passive=yang.gdata.from_xml_opt_bool(n, 'passive'), import_=yang.gdata.from_xml_opt_strs(n, 'import'), export=yang.gdata.from_xml_opt_strs(n, 'export'), neighbor=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor.from_xml(yang.gdata.get_xml_children(n, 'neighbor')))
 
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry]
@@ -2583,13 +3037,26 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
                 res.append(junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__name, child_name)
+    child_passive = yang.gdata.from_xml_opt_bool(node, 'passive')
+    yang.gdata.maybe_add(children, 'passive', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__passive, child_passive)
+    child_import_ = yang.gdata.from_xml_opt_strs(node, 'import')
+    yang.gdata.maybe_add(children, 'import', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__import, child_import_)
+    child_export = yang.gdata.from_xml_opt_strs(node, 'export')
+    yang.gdata.maybe_add(children, 'export', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__export, child_export)
+    child_neighbor = yang.gdata.from_xml_opt_list(node, 'neighbor')
+    yang.gdata.maybe_add(children, 'neighbor', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group__neighbor, child_neighbor)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp(yang.adata.MNode):
     group: junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group
@@ -2611,14 +3078,18 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp(group=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group.from_gdata(n.get_opt_list('group')))
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp:
-        if n != None:
-            return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp(group=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp()
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp__group, child_group)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn__control_word(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn__no_mac_learning(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn(yang.adata.MNode):
     control_word: ?bool
@@ -2645,12 +3116,14 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn(control_word=n.get_opt_bool('control-word'), no_mac_learning=n.get_opt_bool('no-mac-learning'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn:
-        if n != None:
-            return junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn(control_word=yang.gdata.from_xml_opt_bool(n, 'control-word'), no_mac_learning=yang.gdata.from_xml_opt_bool(n, 'no-mac-learning'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_control_word = yang.gdata.from_xml_opt_bool(node, 'control-word')
+    yang.gdata.maybe_add(children, 'control-word', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn__control_word, child_control_word)
+    child_no_mac_learning = yang.gdata.from_xml_opt_bool(node, 'no-mac-learning')
+    yang.gdata.maybe_add(children, 'no-mac-learning', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn__no_mac_learning, child_no_mac_learning)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__groups__routing_instances__instance__protocols(yang.adata.MNode):
     bgp: junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp
@@ -2682,12 +3155,14 @@ class junos_conf_root__configuration__groups__routing_instances__instance__proto
             return junos_conf_root__configuration__groups__routing_instances__instance__protocols(bgp=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp.from_gdata(n.get_opt_container('bgp')), evpn=junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn.from_gdata(n.get_opt_container('evpn')))
         return junos_conf_root__configuration__groups__routing_instances__instance__protocols()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__routing_instances__instance__protocols:
-        if n != None:
-            return junos_conf_root__configuration__groups__routing_instances__instance__protocols(bgp=junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')), evpn=junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn.from_xml(yang.gdata.get_xml_opt_child(n, 'evpn')))
-        return junos_conf_root__configuration__groups__routing_instances__instance__protocols()
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__bgp, child_bgp)
+    child_evpn = yang.gdata.from_xml_opt_cnt(node, 'evpn')
+    yang.gdata.maybe_add(children, 'evpn', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols__evpn, child_evpn)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__groups__routing_instances__instance_entry(yang.adata.MNode):
     name: str
@@ -2763,10 +3238,6 @@ class junos_conf_root__configuration__groups__routing_instances__instance_entry(
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups__routing_instances__instance_entry:
         return junos_conf_root__configuration__groups__routing_instances__instance_entry(name=n.get_str('name'), apply_groups=n.get_opt_strs('apply-groups'), apply_groups_except=n.get_opt_strs('apply-groups-except'), instance_type=n.get_opt_str('instance-type'), interface=junos_conf_root__configuration__groups__routing_instances__instance__interface.from_gdata(n.get_opt_list('interface')), route_distinguisher=junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher.from_gdata(n.get_opt_container('route-distinguisher')), export_default_action=n.get_opt_str('export-default-action'), import_default_action=n.get_opt_str('import-default-action'), vrf_target=junos_conf_root__configuration__groups__routing_instances__instance__vrf_target.from_gdata(n.get_opt_container('vrf-target')), no_vrf_advertise=n.get_opt_bool('no-vrf-advertise'), vrf_table_label=junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label.from_gdata(n.get_opt_container('vrf-table-label')), protocols=junos_conf_root__configuration__groups__routing_instances__instance__protocols.from_gdata(n.get_opt_container('protocols')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups__routing_instances__instance_entry:
-        return junos_conf_root__configuration__groups__routing_instances__instance_entry(name=yang.gdata.from_xml_str(n, 'name'), apply_groups=yang.gdata.from_xml_opt_strs(n, 'apply-groups'), apply_groups_except=yang.gdata.from_xml_opt_strs(n, 'apply-groups-except'), instance_type=yang.gdata.from_xml_opt_str(n, 'instance-type'), interface=junos_conf_root__configuration__groups__routing_instances__instance__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')), route_distinguisher=junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher.from_xml(yang.gdata.get_xml_opt_child(n, 'route-distinguisher')), export_default_action=yang.gdata.from_xml_opt_str(n, 'export-default-action'), import_default_action=yang.gdata.from_xml_opt_str(n, 'import-default-action'), vrf_target=junos_conf_root__configuration__groups__routing_instances__instance__vrf_target.from_xml(yang.gdata.get_xml_opt_child(n, 'vrf-target')), no_vrf_advertise=yang.gdata.from_xml_opt_bool(n, 'no-vrf-advertise'), vrf_table_label=junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label.from_xml(yang.gdata.get_xml_opt_child(n, 'vrf-table-label')), protocols=junos_conf_root__configuration__groups__routing_instances__instance__protocols.from_xml(yang.gdata.get_xml_opt_child(n, 'protocols')))
-
 class junos_conf_root__configuration__groups__routing_instances__instance(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups__routing_instances__instance_entry]
     mut def __init__(self, elements=[]):
@@ -2803,13 +3274,40 @@ class junos_conf_root__configuration__groups__routing_instances__instance(yang.a
                 res.append(junos_conf_root__configuration__groups__routing_instances__instance_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups__routing_instances__instance_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups__routing_instances__instance_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__name, child_name)
+    child_apply_groups = yang.gdata.from_xml_opt_strs(node, 'apply-groups')
+    yang.gdata.maybe_add(children, 'apply-groups', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__apply_groups, child_apply_groups)
+    child_apply_groups_except = yang.gdata.from_xml_opt_strs(node, 'apply-groups-except')
+    yang.gdata.maybe_add(children, 'apply-groups-except', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__apply_groups_except, child_apply_groups_except)
+    child_instance_type = yang.gdata.from_xml_opt_str(node, 'instance-type')
+    yang.gdata.maybe_add(children, 'instance-type', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__instance_type, child_instance_type)
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__interface, child_interface)
+    child_route_distinguisher = yang.gdata.from_xml_opt_cnt(node, 'route-distinguisher')
+    yang.gdata.maybe_add(children, 'route-distinguisher', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__route_distinguisher, child_route_distinguisher)
+    child_export_default_action = yang.gdata.from_xml_opt_str(node, 'export-default-action')
+    yang.gdata.maybe_add(children, 'export-default-action', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__export_default_action, child_export_default_action)
+    child_import_default_action = yang.gdata.from_xml_opt_str(node, 'import-default-action')
+    yang.gdata.maybe_add(children, 'import-default-action', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__import_default_action, child_import_default_action)
+    child_vrf_target = yang.gdata.from_xml_opt_cnt(node, 'vrf-target')
+    yang.gdata.maybe_add(children, 'vrf-target', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_target, child_vrf_target)
+    child_no_vrf_advertise = yang.gdata.from_xml_opt_bool(node, 'no-vrf-advertise')
+    yang.gdata.maybe_add(children, 'no-vrf-advertise', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__no_vrf_advertise, child_no_vrf_advertise)
+    child_vrf_table_label = yang.gdata.from_xml_opt_cnt(node, 'vrf-table-label')
+    yang.gdata.maybe_add(children, 'vrf-table-label', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__vrf_table_label, child_vrf_table_label)
+    child_protocols = yang.gdata.from_xml_opt_cnt(node, 'protocols')
+    yang.gdata.maybe_add(children, 'protocols', from_xml_junos_conf_root__configuration__groups__routing_instances__instance__protocols, child_protocols)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances__instance(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups__routing_instances__instance_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 class junos_conf_root__configuration__groups__routing_instances(yang.adata.MNode):
     instance: junos_conf_root__configuration__groups__routing_instances__instance
@@ -2831,12 +3329,12 @@ class junos_conf_root__configuration__groups__routing_instances(yang.adata.MNode
             return junos_conf_root__configuration__groups__routing_instances(instance=junos_conf_root__configuration__groups__routing_instances__instance.from_gdata(n.get_opt_list('instance')))
         return junos_conf_root__configuration__groups__routing_instances()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__groups__routing_instances:
-        if n != None:
-            return junos_conf_root__configuration__groups__routing_instances(instance=junos_conf_root__configuration__groups__routing_instances__instance.from_xml(yang.gdata.get_xml_children(n, 'instance')))
-        return junos_conf_root__configuration__groups__routing_instances()
 
+mut def from_xml_junos_conf_root__configuration__groups__routing_instances(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_instance = yang.gdata.from_xml_opt_list(node, 'instance')
+    yang.gdata.maybe_add(children, 'instance', from_xml_junos_conf_root__configuration__groups__routing_instances__instance, child_instance)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__groups_entry(yang.adata.MNode):
     name: str
@@ -2886,10 +3384,6 @@ class junos_conf_root__configuration__groups_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__groups_entry:
         return junos_conf_root__configuration__groups_entry(name=n.get_str('name'), when=junos_conf_root__configuration__groups__when.from_gdata(n.get_opt_container('when')), rcsid=n.get_opt_str('rcsid'), version=n.get_opt_str('version'), system=junos_conf_root__configuration__groups__system.from_gdata(n.get_opt_container('system')), interfaces=junos_conf_root__configuration__groups__interfaces.from_gdata(n.get_opt_container('interfaces')), routing_instances=junos_conf_root__configuration__groups__routing_instances.from_gdata(n.get_opt_container('routing-instances')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__groups_entry:
-        return junos_conf_root__configuration__groups_entry(name=yang.gdata.from_xml_str(n, 'name'), when=junos_conf_root__configuration__groups__when.from_xml(yang.gdata.get_xml_opt_child(n, 'when')), rcsid=yang.gdata.from_xml_opt_str(n, 'rcsid'), version=yang.gdata.from_xml_opt_str(n, 'version'), system=junos_conf_root__configuration__groups__system.from_xml(yang.gdata.get_xml_opt_child(n, 'system')), interfaces=junos_conf_root__configuration__groups__interfaces.from_xml(yang.gdata.get_xml_opt_child(n, 'interfaces')), routing_instances=junos_conf_root__configuration__groups__routing_instances.from_xml(yang.gdata.get_xml_opt_child(n, 'routing-instances')))
-
 class junos_conf_root__configuration__groups(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__groups_entry]
     mut def __init__(self, elements=[]):
@@ -2926,14 +3420,33 @@ class junos_conf_root__configuration__groups(yang.adata.MNode):
                 res.append(junos_conf_root__configuration__groups_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__groups_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__groups_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__groups_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__groups__name, child_name)
+    child_when = yang.gdata.from_xml_opt_cnt(node, 'when')
+    yang.gdata.maybe_add(children, 'when', from_xml_junos_conf_root__configuration__groups__when, child_when)
+    child_rcsid = yang.gdata.from_xml_opt_str(node, 'rcsid')
+    yang.gdata.maybe_add(children, 'rcsid', from_xml_junos_conf_root__configuration__groups__rcsid, child_rcsid)
+    child_version = yang.gdata.from_xml_opt_str(node, 'version')
+    yang.gdata.maybe_add(children, 'version', from_xml_junos_conf_root__configuration__groups__version, child_version)
+    child_system = yang.gdata.from_xml_opt_cnt(node, 'system')
+    yang.gdata.maybe_add(children, 'system', from_xml_junos_conf_root__configuration__groups__system, child_system)
+    child_interfaces = yang.gdata.from_xml_opt_cnt(node, 'interfaces')
+    yang.gdata.maybe_add(children, 'interfaces', from_xml_junos_conf_root__configuration__groups__interfaces, child_interfaces)
+    child_routing_instances = yang.gdata.from_xml_opt_cnt(node, 'routing-instances')
+    yang.gdata.maybe_add(children, 'routing-instances', from_xml_junos_conf_root__configuration__groups__routing_instances, child_routing_instances)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__groups(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__groups_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
+
+mut def from_xml_junos_conf_root__configuration__routing_options__autonomous_system__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__routing_options__autonomous_system(yang.adata.MNode):
     as_number: ?str
@@ -2955,12 +3468,12 @@ class junos_conf_root__configuration__routing_options__autonomous_system(yang.ad
             return junos_conf_root__configuration__routing_options__autonomous_system(as_number=n.get_opt_str('as-number'))
         return junos_conf_root__configuration__routing_options__autonomous_system()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__routing_options__autonomous_system:
-        if n != None:
-            return junos_conf_root__configuration__routing_options__autonomous_system(as_number=yang.gdata.from_xml_opt_str(n, 'as-number'))
-        return junos_conf_root__configuration__routing_options__autonomous_system()
 
+mut def from_xml_junos_conf_root__configuration__routing_options__autonomous_system(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_number = yang.gdata.from_xml_opt_str(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_junos_conf_root__configuration__routing_options__autonomous_system__as_number, child_as_number)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__routing_options(yang.adata.MNode):
     autonomous_system: junos_conf_root__configuration__routing_options__autonomous_system
@@ -2982,17 +3495,27 @@ class junos_conf_root__configuration__routing_options(yang.adata.MNode):
             return junos_conf_root__configuration__routing_options(autonomous_system=junos_conf_root__configuration__routing_options__autonomous_system.from_gdata(n.get_opt_container('autonomous-system')))
         return junos_conf_root__configuration__routing_options()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__routing_options:
-        if n != None:
-            return junos_conf_root__configuration__routing_options(autonomous_system=junos_conf_root__configuration__routing_options__autonomous_system.from_xml(yang.gdata.get_xml_opt_child(n, 'autonomous-system')))
-        return junos_conf_root__configuration__routing_options()
 
+mut def from_xml_junos_conf_root__configuration__routing_options(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_autonomous_system = yang.gdata.from_xml_opt_cnt(node, 'autonomous-system')
+    yang.gdata.maybe_add(children, 'autonomous-system', from_xml_junos_conf_root__configuration__routing_options__autonomous_system, child_autonomous_system)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__l2vpn_use_bgp_rules(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__cisco_non_deterministic(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__always_compare_med(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp__med_multiplier(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp__igp_multiplier(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(yang.adata.MNode):
     med_multiplier: ?value
@@ -3019,14 +3542,20 @@ class junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_i
             return junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(med_multiplier=n.get_opt_value('med-multiplier'), igp_multiplier=n.get_opt_value('igp-multiplier'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(med_multiplier=yang.gdata.from_xml_opt_value(n, 'med-multiplier'), igp_multiplier=yang.gdata.from_xml_opt_value(n, 'igp-multiplier'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_med_multiplier = yang.gdata.from_xml_opt_value(node, 'med-multiplier')
+    yang.gdata.maybe_add(children, 'med-multiplier', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp__med_multiplier, child_med_multiplier)
+    child_igp_multiplier = yang.gdata.from_xml_opt_value(node, 'igp-multiplier')
+    yang.gdata.maybe_add(children, 'igp-multiplier', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp__igp_multiplier, child_igp_multiplier)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__external_router_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__as_path_ignore(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__path_selection(yang.adata.MNode):
     l2vpn_use_bgp_rules: ?bool
@@ -3078,21 +3607,49 @@ class junos_conf_root__configuration__protocols__bgp__path_selection(yang.adata.
             return junos_conf_root__configuration__protocols__bgp__path_selection(l2vpn_use_bgp_rules=n.get_opt_bool('l2vpn-use-bgp-rules'), cisco_non_deterministic=n.get_opt_bool('cisco-non-deterministic'), always_compare_med=n.get_opt_bool('always-compare-med'), med_plus_igp=junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp.from_gdata(n.get_opt_container('med-plus-igp')), external_router_id=n.get_opt_bool('external-router-id'), as_path_ignore=n.get_opt_bool('as-path-ignore'))
         return junos_conf_root__configuration__protocols__bgp__path_selection()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__path_selection:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__path_selection(l2vpn_use_bgp_rules=yang.gdata.from_xml_opt_bool(n, 'l2vpn-use-bgp-rules'), cisco_non_deterministic=yang.gdata.from_xml_opt_bool(n, 'cisco-non-deterministic'), always_compare_med=yang.gdata.from_xml_opt_bool(n, 'always-compare-med'), med_plus_igp=junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp.from_xml(yang.gdata.get_xml_opt_child(n, 'med-plus-igp')), external_router_id=yang.gdata.from_xml_opt_bool(n, 'external-router-id'), as_path_ignore=yang.gdata.from_xml_opt_bool(n, 'as-path-ignore'))
-        return junos_conf_root__configuration__protocols__bgp__path_selection()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__path_selection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l2vpn_use_bgp_rules = yang.gdata.from_xml_opt_bool(node, 'l2vpn-use-bgp-rules')
+    yang.gdata.maybe_add(children, 'l2vpn-use-bgp-rules', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__l2vpn_use_bgp_rules, child_l2vpn_use_bgp_rules)
+    child_cisco_non_deterministic = yang.gdata.from_xml_opt_bool(node, 'cisco-non-deterministic')
+    yang.gdata.maybe_add(children, 'cisco-non-deterministic', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__cisco_non_deterministic, child_cisco_non_deterministic)
+    child_always_compare_med = yang.gdata.from_xml_opt_bool(node, 'always-compare-med')
+    yang.gdata.maybe_add(children, 'always-compare-med', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__always_compare_med, child_always_compare_med)
+    child_med_plus_igp = yang.gdata.from_xml_opt_cnt(node, 'med-plus-igp')
+    yang.gdata.maybe_add(children, 'med-plus-igp', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__med_plus_igp, child_med_plus_igp)
+    child_external_router_id = yang.gdata.from_xml_opt_bool(node, 'external-router-id')
+    yang.gdata.maybe_add(children, 'external-router-id', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__external_router_id, child_external_router_id)
+    child_as_path_ignore = yang.gdata.from_xml_opt_bool(node, 'as-path-ignore')
+    yang.gdata.maybe_add(children, 'as-path-ignore', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection__as_path_ignore, child_as_path_ignore)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__local_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__hold_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__maximum(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout__forever(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout__timeout(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(yang.adata.MNode):
     forever: ?bool
@@ -3119,12 +3676,14 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, 'forever'), timeout=yang.gdata.from_xml_opt_value(n, 'timeout'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_forever = yang.gdata.from_xml_opt_bool(node, 'forever')
+    yang.gdata.maybe_add(children, 'forever', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout__forever, child_forever)
+    child_timeout = yang.gdata.from_xml_opt_value(node, 'timeout')
+    yang.gdata.maybe_add(children, 'timeout', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout__timeout, child_timeout)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(yang.adata.MNode):
     limit_threshold: ?value
@@ -3156,13 +3715,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container('idle-timeout')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, 'idle-timeout')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__limit_threshold, child_limit_threshold)
+    child_idle_timeout = yang.gdata.from_xml_opt_cnt(node, 'idle-timeout')
+    yang.gdata.maybe_add(children, 'idle-timeout', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown__idle_timeout, child_idle_timeout)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(yang.adata.MNode):
     limit_threshold: ?value
@@ -3184,13 +3747,15 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess__limit_threshold, child_limit_threshold)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(yang.adata.MNode):
     limit_threshold: ?value
@@ -3212,12 +3777,12 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess__limit_threshold, child_limit_threshold)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(yang.adata.MNode):
     maximum: ?value
@@ -3269,16 +3834,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_container('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_container('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_container('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(maximum=yang.gdata.from_xml_opt_value(n, 'maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, 'teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, 'drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, 'hide-excess')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_maximum = yang.gdata.from_xml_opt_value(node, 'maximum')
+    yang.gdata.maybe_add(children, 'maximum', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__maximum, child_maximum)
+    child_teardown = yang.gdata.from_xml_opt_cnt(node, 'teardown')
+    yang.gdata.maybe_add(children, 'teardown', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__teardown, child_teardown)
+    child_drop_excess = yang.gdata.from_xml_opt_cnt(node, 'drop-excess')
+    yang.gdata.maybe_add(children, 'drop-excess', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__drop_excess, child_drop_excess)
+    child_hide_excess = yang.gdata.from_xml_opt_cnt(node, 'hide-excess')
+    yang.gdata.maybe_add(children, 'hide-excess', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit__hide_excess, child_hide_excess)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__maximum(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__forever(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__timeout(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(yang.adata.MNode):
     forever: ?bool
@@ -3305,12 +3884,14 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, 'forever'), timeout=yang.gdata.from_xml_opt_value(n, 'timeout'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_forever = yang.gdata.from_xml_opt_bool(node, 'forever')
+    yang.gdata.maybe_add(children, 'forever', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__forever, child_forever)
+    child_timeout = yang.gdata.from_xml_opt_value(node, 'timeout')
+    yang.gdata.maybe_add(children, 'timeout', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__timeout, child_timeout)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(yang.adata.MNode):
     limit_threshold: ?value
@@ -3342,13 +3923,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container('idle-timeout')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, 'idle-timeout')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__limit_threshold, child_limit_threshold)
+    child_idle_timeout = yang.gdata.from_xml_opt_cnt(node, 'idle-timeout')
+    yang.gdata.maybe_add(children, 'idle-timeout', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout, child_idle_timeout)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(yang.adata.MNode):
     limit_threshold: ?value
@@ -3370,13 +3955,15 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess__limit_threshold, child_limit_threshold)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(yang.adata.MNode):
     limit_threshold: ?value
@@ -3398,12 +3985,12 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess__limit_threshold, child_limit_threshold)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(yang.adata.MNode):
     maximum: ?value
@@ -3455,13 +4042,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_container('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_container('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_container('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(maximum=yang.gdata.from_xml_opt_value(n, 'maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, 'teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, 'drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, 'hide-excess')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_maximum = yang.gdata.from_xml_opt_value(node, 'maximum')
+    yang.gdata.maybe_add(children, 'maximum', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__maximum, child_maximum)
+    child_teardown = yang.gdata.from_xml_opt_cnt(node, 'teardown')
+    yang.gdata.maybe_add(children, 'teardown', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__teardown, child_teardown)
+    child_drop_excess = yang.gdata.from_xml_opt_cnt(node, 'drop-excess')
+    yang.gdata.maybe_add(children, 'drop-excess', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__drop_excess, child_drop_excess)
+    child_hide_excess = yang.gdata.from_xml_opt_cnt(node, 'hide-excess')
+    yang.gdata.maybe_add(children, 'hide-excess', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit__hide_excess, child_hide_excess)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group__ribgroup_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group(yang.adata.MNode):
     ribgroup_name: ?str
@@ -3483,15 +4078,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group(ribgroup_name=n.get_opt_str('ribgroup-name'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group(ribgroup_name=yang.gdata.from_xml_opt_str(n, 'ribgroup-name'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ribgroup_name = yang.gdata.from_xml_opt_str(node, 'ribgroup-name')
+    yang.gdata.maybe_add(children, 'ribgroup-name', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group__ribgroup_name, child_ribgroup_name)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__receive(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode__all_paths(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode__equal_cost_paths(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode(yang.adata.MNode):
     all_paths: ?bool
@@ -3518,16 +4119,26 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode(all_paths=n.get_opt_bool('all-paths'), equal_cost_paths=n.get_opt_bool('equal-cost-paths'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode(all_paths=yang.gdata.from_xml_opt_bool(n, 'all-paths'), equal_cost_paths=yang.gdata.from_xml_opt_bool(n, 'equal-cost-paths'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_all_paths = yang.gdata.from_xml_opt_bool(node, 'all-paths')
+    yang.gdata.maybe_add(children, 'all-paths', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode__all_paths, child_all_paths)
+    child_equal_cost_paths = yang.gdata.from_xml_opt_bool(node, 'equal-cost-paths')
+    yang.gdata.maybe_add(children, 'equal-cost-paths', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode__equal_cost_paths, child_equal_cost_paths)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__prefix_policy(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_count(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__include_backup_path(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__multipath(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(yang.adata.MNode):
     path_selection_mode: junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode
@@ -3567,12 +4178,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_container('path-selection-mode')), prefix_policy=n.get_opt_strs('prefix-policy'), path_count=n.get_opt_value('path-count'), include_backup_path=n.get_opt_value('include-backup-path'), multipath=n.get_opt_bool('multipath'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode.from_xml(yang.gdata.get_xml_opt_child(n, 'path-selection-mode')), prefix_policy=yang.gdata.from_xml_opt_strs(n, 'prefix-policy'), path_count=yang.gdata.from_xml_opt_value(n, 'path-count'), include_backup_path=yang.gdata.from_xml_opt_value(n, 'include-backup-path'), multipath=yang.gdata.from_xml_opt_bool(n, 'multipath'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_path_selection_mode = yang.gdata.from_xml_opt_cnt(node, 'path-selection-mode')
+    yang.gdata.maybe_add(children, 'path-selection-mode', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_selection_mode, child_path_selection_mode)
+    child_prefix_policy = yang.gdata.from_xml_opt_strs(node, 'prefix-policy')
+    yang.gdata.maybe_add(children, 'prefix-policy', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__prefix_policy, child_prefix_policy)
+    child_path_count = yang.gdata.from_xml_opt_value(node, 'path-count')
+    yang.gdata.maybe_add(children, 'path-count', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__path_count, child_path_count)
+    child_include_backup_path = yang.gdata.from_xml_opt_value(node, 'include-backup-path')
+    yang.gdata.maybe_add(children, 'include-backup-path', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__include_backup_path, child_include_backup_path)
+    child_multipath = yang.gdata.from_xml_opt_bool(node, 'multipath')
+    yang.gdata.maybe_add(children, 'multipath', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send__multipath, child_multipath)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path(yang.adata.MNode):
     receive: ?bool
@@ -3604,13 +4223,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path(receive=n.get_opt_bool('receive'), send=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send.from_gdata(n.get_opt_container('send')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path(receive=yang.gdata.from_xml_opt_bool(n, 'receive'), send=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send.from_xml(yang.gdata.get_xml_opt_child(n, 'send')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_receive = yang.gdata.from_xml_opt_bool(node, 'receive')
+    yang.gdata.maybe_add(children, 'receive', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__receive, child_receive)
+    child_send = yang.gdata.from_xml_opt_cnt(node, 'send')
+    yang.gdata.maybe_add(children, 'send', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path__send, child_send)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp(yang.adata.MNode):
     disable: ?bool
@@ -3632,15 +4255,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp(disable=n.get_opt_bool('disable'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp(disable=yang.gdata.from_xml_opt_bool(n, 'disable'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp__disable, child_disable)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__damping(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__local_ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops__loops(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(yang.adata.MNode):
     loops: ?value
@@ -3662,15 +4291,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(loops=n.get_opt_value('loops'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(loops=yang.gdata.from_xml_opt_value(n, 'loops'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_loops = yang.gdata.from_xml_opt_value(node, 'loops')
+    yang.gdata.maybe_add(children, 'loops', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops__loops, child_loops)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__always_wait_for_krt_drain(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay__routing_uptime(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay__inbound_convergence(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(yang.adata.MNode):
     routing_uptime: ?value
@@ -3697,14 +4332,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_value('routing-uptime'), inbound_convergence=n.get_opt_value('inbound-convergence'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=yang.gdata.from_xml_opt_value(n, 'routing-uptime'), inbound_convergence=yang.gdata.from_xml_opt_value(n, 'inbound-convergence'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_routing_uptime = yang.gdata.from_xml_opt_value(node, 'routing-uptime')
+    yang.gdata.maybe_add(children, 'routing-uptime', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay__routing_uptime, child_routing_uptime)
+    child_inbound_convergence = yang.gdata.from_xml_opt_value(node, 'inbound-convergence')
+    yang.gdata.maybe_add(children, 'inbound-convergence', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay__inbound_convergence, child_inbound_convergence)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay__route_age(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay__routing_uptime(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(yang.adata.MNode):
     route_age: ?value
@@ -3731,12 +4372,14 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_value('route-age'), routing_uptime=n.get_opt_value('routing-uptime'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=yang.gdata.from_xml_opt_value(n, 'route-age'), routing_uptime=yang.gdata.from_xml_opt_value(n, 'routing-uptime'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_age = yang.gdata.from_xml_opt_value(node, 'route-age')
+    yang.gdata.maybe_add(children, 'route-age', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay__route_age, child_route_age)
+    child_routing_uptime = yang.gdata.from_xml_opt_value(node, 'routing-uptime')
+    yang.gdata.maybe_add(children, 'routing-uptime', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay__routing_uptime, child_routing_uptime)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements(yang.adata.MNode):
     always_wait_for_krt_drain: ?bool
@@ -3768,14 +4411,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements(always_wait_for_krt_drain=n.get_opt_bool('always-wait-for-krt-drain'), minimum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay.from_gdata(n.get_opt_container('minimum-delay')), maximum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay.from_gdata(n.get_opt_container('maximum-delay')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements(always_wait_for_krt_drain=yang.gdata.from_xml_opt_bool(n, 'always-wait-for-krt-drain'), minimum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay.from_xml(yang.gdata.get_xml_opt_child(n, 'minimum-delay')), maximum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay.from_xml(yang.gdata.get_xml_opt_child(n, 'maximum-delay')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_always_wait_for_krt_drain = yang.gdata.from_xml_opt_bool(node, 'always-wait-for-krt-drain')
+    yang.gdata.maybe_add(children, 'always-wait-for-krt-drain', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__always_wait_for_krt_drain, child_always_wait_for_krt_drain)
+    child_minimum_delay = yang.gdata.from_xml_opt_cnt(node, 'minimum-delay')
+    yang.gdata.maybe_add(children, 'minimum-delay', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__minimum_delay, child_minimum_delay)
+    child_maximum_delay = yang.gdata.from_xml_opt_cnt(node, 'maximum-delay')
+    yang.gdata.maybe_add(children, 'maximum-delay', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements__maximum_delay, child_maximum_delay)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution__no_resolution(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution__preserve_nexthop_hierarchy(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution(yang.adata.MNode):
     no_resolution: ?bool
@@ -3802,13 +4453,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution(no_resolution=n.get_opt_bool('no-resolution'), preserve_nexthop_hierarchy=n.get_opt_bool('preserve-nexthop-hierarchy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution(no_resolution=yang.gdata.from_xml_opt_bool(n, 'no-resolution'), preserve_nexthop_hierarchy=yang.gdata.from_xml_opt_bool(n, 'preserve-nexthop-hierarchy'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_no_resolution = yang.gdata.from_xml_opt_bool(node, 'no-resolution')
+    yang.gdata.maybe_add(children, 'no-resolution', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution__no_resolution, child_no_resolution)
+    child_preserve_nexthop_hierarchy = yang.gdata.from_xml_opt_bool(node, 'preserve-nexthop-hierarchy')
+    yang.gdata.maybe_add(children, 'preserve-nexthop-hierarchy', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution__preserve_nexthop_hierarchy, child_preserve_nexthop_hierarchy)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build__maximum_delay(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(yang.adata.MNode):
     maximum_delay: ?value
@@ -3830,14 +4485,18 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_value('maximum-delay'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(maximum_delay=yang.gdata.from_xml_opt_value(n, 'maximum-delay'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_maximum_delay = yang.gdata.from_xml_opt_value(node, 'maximum-delay')
+    yang.gdata.maybe_add(children, 'maximum-delay', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build__maximum_delay, child_maximum_delay)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter__stale_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter(yang.adata.MNode):
     disable: ?bool
@@ -3864,15 +4523,23 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter(disable=n.get_opt_bool('disable'), stale_time=n.get_opt_str('stale-time'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter(disable=yang.gdata.from_xml_opt_bool(n, 'disable'), stale_time=yang.gdata.from_xml_opt_str(n, 'stale-time'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter__disable, child_disable)
+    child_stale_time = yang.gdata.from_xml_opt_str(node, 'stale-time')
+    yang.gdata.maybe_add(children, 'stale-time', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter__stale_time, child_stale_time)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention__retention_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention__retention_policy(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention(yang.adata.MNode):
     disable: ?bool
@@ -3902,12 +4569,16 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention(disable=n.get_opt_bool('disable'), retention_time=n.get_opt_str('retention-time'), retention_policy=n.get_opt_strs('retention-policy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention(disable=yang.gdata.from_xml_opt_bool(n, 'disable'), retention_time=yang.gdata.from_xml_opt_str(n, 'retention-time'), retention_policy=yang.gdata.from_xml_opt_strs(n, 'retention-policy'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention__disable, child_disable)
+    child_retention_time = yang.gdata.from_xml_opt_str(node, 'retention-time')
+    yang.gdata.maybe_add(children, 'retention-time', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention__retention_time, child_retention_time)
+    child_retention_policy = yang.gdata.from_xml_opt_strs(node, 'retention-policy')
+    yang.gdata.maybe_add(children, 'retention-policy', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention__retention_policy, child_retention_policy)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived(yang.adata.MNode):
     restarter: junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter
@@ -3934,13 +4605,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived(restarter=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter.from_gdata(n.get_opt_container('restarter')), extended_route_retention=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention.from_gdata(n.get_opt_container('extended-route-retention')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived(restarter=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter.from_xml(yang.gdata.get_xml_opt_child(n, 'restarter')), extended_route_retention=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention.from_xml(yang.gdata.get_xml_opt_child(n, 'extended-route-retention')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_restarter = yang.gdata.from_xml_opt_cnt(node, 'restarter')
+    yang.gdata.maybe_add(children, 'restarter', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__restarter, child_restarter)
+    child_extended_route_retention = yang.gdata.from_xml_opt_cnt(node, 'extended-route-retention')
+    yang.gdata.maybe_add(children, 'extended-route-retention', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived__extended_route_retention, child_extended_route_retention)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__forwarding_state_bit(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart(yang.adata.MNode):
     long_lived: junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived
@@ -3967,19 +4642,35 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart(long_lived=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived.from_gdata(n.get_opt_container('long-lived')), forwarding_state_bit=n.get_opt_str('forwarding-state-bit'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart(long_lived=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived.from_xml(yang.gdata.get_xml_opt_child(n, 'long-lived')), forwarding_state_bit=yang.gdata.from_xml_opt_str(n, 'forwarding-state-bit'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_long_lived = yang.gdata.from_xml_opt_cnt(node, 'long-lived')
+    yang.gdata.maybe_add(children, 'long-lived', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__long_lived, child_long_lived)
+    child_forwarding_state_bit = yang.gdata.from_xml_opt_str(node, 'forwarding-state-bit')
+    yang.gdata.maybe_add(children, 'forwarding-state-bit', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart__forwarding_state_bit, child_forwarding_state_bit)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__extended_nexthop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__extended_nexthop_color(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__extended_nexthop_tunnel(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__no_install(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_age_bgp_view(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority__expedited(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(yang.adata.MNode):
     priority: ?value
@@ -4006,14 +4697,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(priority=yang.gdata.from_xml_opt_value(n, 'priority'), expedited=yang.gdata.from_xml_opt_bool(n, 'expedited'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_priority = yang.gdata.from_xml_opt_value(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority__priority, child_priority)
+    child_expedited = yang.gdata.from_xml_opt_bool(node, 'expedited')
+    yang.gdata.maybe_add(children, 'expedited', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority__expedited, child_expedited)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority__expedited(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(yang.adata.MNode):
     priority: ?value
@@ -4040,14 +4737,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(priority=yang.gdata.from_xml_opt_value(n, 'priority'), expedited=yang.gdata.from_xml_opt_bool(n, 'expedited'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_priority = yang.gdata.from_xml_opt_value(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority__priority, child_priority)
+    child_expedited = yang.gdata.from_xml_opt_bool(node, 'expedited')
+    yang.gdata.maybe_add(children, 'expedited', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority__expedited, child_expedited)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority__expedited(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(yang.adata.MNode):
     priority: ?value
@@ -4074,15 +4777,23 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(priority=yang.gdata.from_xml_opt_value(n, 'priority'), expedited=yang.gdata.from_xml_opt_bool(n, 'expedited'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_priority = yang.gdata.from_xml_opt_value(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority__priority, child_priority)
+    child_expedited = yang.gdata.from_xml_opt_bool(node, 'expedited')
+    yang.gdata.maybe_add(children, 'expedited', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority__expedited, child_expedited)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__advertise_srv6_service(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accept_srv6_service(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label__community(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label(yang.adata.MNode):
     community: ?str
@@ -4104,13 +4815,15 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label(community=n.get_opt_str('community'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label(community=yang.gdata.from_xml_opt_str(n, 'community'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_community = yang.gdata.from_xml_opt_str(node, 'community')
+    yang.gdata.maybe_add(children, 'community', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label__community, child_community)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier__context_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier(yang.adata.MNode):
     context_id: ?str
@@ -4132,13 +4845,15 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier(context_id=n.get_opt_str('context-id'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier(context_id=yang.gdata.from_xml_opt_str(n, 'context-id'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_context_id = yang.gdata.from_xml_opt_str(node, 'context-id')
+    yang.gdata.maybe_add(children, 'context-id', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier__context_id, child_context_id)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__keep_import(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection(yang.adata.MNode):
     context_identifier: junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier
@@ -4163,14 +4878,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection(context_identifier=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier.from_gdata(n.get_opt_container('context-identifier')), keep_import=n.get_opt_strs('keep-import'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection(context_identifier=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier.from_xml(yang.gdata.get_xml_opt_child(n, 'context-identifier')), keep_import=yang.gdata.from_xml_opt_strs(n, 'keep-import'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_context_identifier = yang.gdata.from_xml_opt_cnt(node, 'context-identifier')
+    yang.gdata.maybe_add(children, 'context-identifier', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__context_identifier, child_context_identifier)
+    child_keep_import = yang.gdata.from_xml_opt_strs(node, 'keep-import')
+    yang.gdata.maybe_add(children, 'keep-import', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection__keep_import, child_keep_import)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accept_local_nexthop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accept_own(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast(yang.adata.MNode):
     prefix_limit: junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit
@@ -4342,12 +5063,62 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__u
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast(prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit.from_gdata(n.get_opt_container('prefix-limit')), accepted_prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit.from_gdata(n.get_opt_container('accepted-prefix-limit')), rib_group=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group.from_gdata(n.get_opt_container('rib-group')), add_path=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path.from_gdata(n.get_opt_container('add-path')), aigp=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp.from_gdata(n.get_opt_container('aigp')), damping=n.get_opt_bool('damping'), local_ipv4_address=n.get_opt_str('local-ipv4-address'), loops=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops.from_gdata(n.get_opt_container('loops')), delay_route_advertisements=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements.from_gdata(n.get_opt_container('delay-route-advertisements')), nexthop_resolution=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution.from_gdata(n.get_opt_container('nexthop-resolution')), defer_initial_multipath_build=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build.from_gdata(n.get_opt_container('defer-initial-multipath-build')), graceful_restart=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart.from_gdata(n.get_opt_container('graceful-restart')), extended_nexthop=n.get_opt_bool('extended-nexthop'), extended_nexthop_color=n.get_opt_bool('extended-nexthop-color'), extended_nexthop_tunnel=n.get_opt_bool('extended-nexthop-tunnel'), no_install=n.get_opt_bool('no-install'), route_age_bgp_view=n.get_opt_bool('route-age-bgp-view'), output_queue_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority.from_gdata(n.get_opt_container('output-queue-priority')), route_refresh_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority.from_gdata(n.get_opt_container('route-refresh-priority')), withdraw_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority.from_gdata(n.get_opt_container('withdraw-priority')), advertise_srv6_service=n.get_opt_bool('advertise-srv6-service'), accept_srv6_service=n.get_opt_bool('accept-srv6-service'), aggregate_label=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label.from_gdata(n.get_opt_container('aggregate-label')), egress_protection=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection.from_gdata(n.get_opt_container('egress-protection')), accept_local_nexthop=n.get_opt_bool('accept-local-nexthop'), accept_own=n.get_opt_bool('accept-own'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast(prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit.from_xml(yang.gdata.get_xml_opt_child(n, 'prefix-limit')), accepted_prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit.from_xml(yang.gdata.get_xml_opt_child(n, 'accepted-prefix-limit')), rib_group=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group.from_xml(yang.gdata.get_xml_opt_child(n, 'rib-group')), add_path=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path.from_xml(yang.gdata.get_xml_opt_child(n, 'add-path')), aigp=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp.from_xml(yang.gdata.get_xml_opt_child(n, 'aigp')), damping=yang.gdata.from_xml_opt_bool(n, 'damping'), local_ipv4_address=yang.gdata.from_xml_opt_str(n, 'local-ipv4-address'), loops=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops.from_xml(yang.gdata.get_xml_opt_child(n, 'loops')), delay_route_advertisements=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements.from_xml(yang.gdata.get_xml_opt_child(n, 'delay-route-advertisements')), nexthop_resolution=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution.from_xml(yang.gdata.get_xml_opt_child(n, 'nexthop-resolution')), defer_initial_multipath_build=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build.from_xml(yang.gdata.get_xml_opt_child(n, 'defer-initial-multipath-build')), graceful_restart=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart.from_xml(yang.gdata.get_xml_opt_child(n, 'graceful-restart')), extended_nexthop=yang.gdata.from_xml_opt_bool(n, 'extended-nexthop'), extended_nexthop_color=yang.gdata.from_xml_opt_bool(n, 'extended-nexthop-color'), extended_nexthop_tunnel=yang.gdata.from_xml_opt_bool(n, 'extended-nexthop-tunnel'), no_install=yang.gdata.from_xml_opt_bool(n, 'no-install'), route_age_bgp_view=yang.gdata.from_xml_opt_bool(n, 'route-age-bgp-view'), output_queue_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority.from_xml(yang.gdata.get_xml_opt_child(n, 'output-queue-priority')), route_refresh_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority.from_xml(yang.gdata.get_xml_opt_child(n, 'route-refresh-priority')), withdraw_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority.from_xml(yang.gdata.get_xml_opt_child(n, 'withdraw-priority')), advertise_srv6_service=yang.gdata.from_xml_opt_bool(n, 'advertise-srv6-service'), accept_srv6_service=yang.gdata.from_xml_opt_bool(n, 'accept-srv6-service'), aggregate_label=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label.from_xml(yang.gdata.get_xml_opt_child(n, 'aggregate-label')), egress_protection=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection.from_xml(yang.gdata.get_xml_opt_child(n, 'egress-protection')), accept_local_nexthop=yang.gdata.from_xml_opt_bool(n, 'accept-local-nexthop'), accept_own=yang.gdata.from_xml_opt_bool(n, 'accept-own'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_prefix_limit = yang.gdata.from_xml_opt_cnt(node, 'prefix-limit')
+    yang.gdata.maybe_add(children, 'prefix-limit', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__prefix_limit, child_prefix_limit)
+    child_accepted_prefix_limit = yang.gdata.from_xml_opt_cnt(node, 'accepted-prefix-limit')
+    yang.gdata.maybe_add(children, 'accepted-prefix-limit', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accepted_prefix_limit, child_accepted_prefix_limit)
+    child_rib_group = yang.gdata.from_xml_opt_cnt(node, 'rib-group')
+    yang.gdata.maybe_add(children, 'rib-group', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__rib_group, child_rib_group)
+    child_add_path = yang.gdata.from_xml_opt_cnt(node, 'add-path')
+    yang.gdata.maybe_add(children, 'add-path', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__add_path, child_add_path)
+    child_aigp = yang.gdata.from_xml_opt_cnt(node, 'aigp')
+    yang.gdata.maybe_add(children, 'aigp', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aigp, child_aigp)
+    child_damping = yang.gdata.from_xml_opt_bool(node, 'damping')
+    yang.gdata.maybe_add(children, 'damping', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__damping, child_damping)
+    child_local_ipv4_address = yang.gdata.from_xml_opt_str(node, 'local-ipv4-address')
+    yang.gdata.maybe_add(children, 'local-ipv4-address', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__local_ipv4_address, child_local_ipv4_address)
+    child_loops = yang.gdata.from_xml_opt_cnt(node, 'loops')
+    yang.gdata.maybe_add(children, 'loops', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__loops, child_loops)
+    child_delay_route_advertisements = yang.gdata.from_xml_opt_cnt(node, 'delay-route-advertisements')
+    yang.gdata.maybe_add(children, 'delay-route-advertisements', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__delay_route_advertisements, child_delay_route_advertisements)
+    child_nexthop_resolution = yang.gdata.from_xml_opt_cnt(node, 'nexthop-resolution')
+    yang.gdata.maybe_add(children, 'nexthop-resolution', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__nexthop_resolution, child_nexthop_resolution)
+    child_defer_initial_multipath_build = yang.gdata.from_xml_opt_cnt(node, 'defer-initial-multipath-build')
+    yang.gdata.maybe_add(children, 'defer-initial-multipath-build', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__defer_initial_multipath_build, child_defer_initial_multipath_build)
+    child_graceful_restart = yang.gdata.from_xml_opt_cnt(node, 'graceful-restart')
+    yang.gdata.maybe_add(children, 'graceful-restart', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__graceful_restart, child_graceful_restart)
+    child_extended_nexthop = yang.gdata.from_xml_opt_bool(node, 'extended-nexthop')
+    yang.gdata.maybe_add(children, 'extended-nexthop', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__extended_nexthop, child_extended_nexthop)
+    child_extended_nexthop_color = yang.gdata.from_xml_opt_bool(node, 'extended-nexthop-color')
+    yang.gdata.maybe_add(children, 'extended-nexthop-color', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__extended_nexthop_color, child_extended_nexthop_color)
+    child_extended_nexthop_tunnel = yang.gdata.from_xml_opt_bool(node, 'extended-nexthop-tunnel')
+    yang.gdata.maybe_add(children, 'extended-nexthop-tunnel', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__extended_nexthop_tunnel, child_extended_nexthop_tunnel)
+    child_no_install = yang.gdata.from_xml_opt_bool(node, 'no-install')
+    yang.gdata.maybe_add(children, 'no-install', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__no_install, child_no_install)
+    child_route_age_bgp_view = yang.gdata.from_xml_opt_bool(node, 'route-age-bgp-view')
+    yang.gdata.maybe_add(children, 'route-age-bgp-view', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_age_bgp_view, child_route_age_bgp_view)
+    child_output_queue_priority = yang.gdata.from_xml_opt_cnt(node, 'output-queue-priority')
+    yang.gdata.maybe_add(children, 'output-queue-priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__output_queue_priority, child_output_queue_priority)
+    child_route_refresh_priority = yang.gdata.from_xml_opt_cnt(node, 'route-refresh-priority')
+    yang.gdata.maybe_add(children, 'route-refresh-priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__route_refresh_priority, child_route_refresh_priority)
+    child_withdraw_priority = yang.gdata.from_xml_opt_cnt(node, 'withdraw-priority')
+    yang.gdata.maybe_add(children, 'withdraw-priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__withdraw_priority, child_withdraw_priority)
+    child_advertise_srv6_service = yang.gdata.from_xml_opt_bool(node, 'advertise-srv6-service')
+    yang.gdata.maybe_add(children, 'advertise-srv6-service', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__advertise_srv6_service, child_advertise_srv6_service)
+    child_accept_srv6_service = yang.gdata.from_xml_opt_bool(node, 'accept-srv6-service')
+    yang.gdata.maybe_add(children, 'accept-srv6-service', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accept_srv6_service, child_accept_srv6_service)
+    child_aggregate_label = yang.gdata.from_xml_opt_cnt(node, 'aggregate-label')
+    yang.gdata.maybe_add(children, 'aggregate-label', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__aggregate_label, child_aggregate_label)
+    child_egress_protection = yang.gdata.from_xml_opt_cnt(node, 'egress-protection')
+    yang.gdata.maybe_add(children, 'egress-protection', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__egress_protection, child_egress_protection)
+    child_accept_local_nexthop = yang.gdata.from_xml_opt_bool(node, 'accept-local-nexthop')
+    yang.gdata.maybe_add(children, 'accept-local-nexthop', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accept_local_nexthop, child_accept_local_nexthop)
+    child_accept_own = yang.gdata.from_xml_opt_bool(node, 'accept-own')
+    yang.gdata.maybe_add(children, 'accept-own', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast__accept_own, child_accept_own)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(yang.adata.MNode):
     unicast: ?junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast
@@ -4374,16 +5145,24 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(ya
             return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(unicast=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast.from_gdata(n.get_opt_container('unicast')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(unicast=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast.from_xml(yang.gdata.get_xml_opt_child(n, 'unicast')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_unicast = yang.gdata.from_xml_opt_cnt(node, 'unicast')
+    yang.gdata.maybe_add(children, 'unicast', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn__unicast, child_unicast)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__maximum(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout__forever(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout__timeout(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(yang.adata.MNode):
     forever: ?bool
@@ -4410,12 +5189,14 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, 'forever'), timeout=yang.gdata.from_xml_opt_value(n, 'timeout'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_forever = yang.gdata.from_xml_opt_bool(node, 'forever')
+    yang.gdata.maybe_add(children, 'forever', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout__forever, child_forever)
+    child_timeout = yang.gdata.from_xml_opt_value(node, 'timeout')
+    yang.gdata.maybe_add(children, 'timeout', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout__timeout, child_timeout)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(yang.adata.MNode):
     limit_threshold: ?value
@@ -4447,13 +5228,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container('idle-timeout')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, 'idle-timeout')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__limit_threshold, child_limit_threshold)
+    child_idle_timeout = yang.gdata.from_xml_opt_cnt(node, 'idle-timeout')
+    yang.gdata.maybe_add(children, 'idle-timeout', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown__idle_timeout, child_idle_timeout)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(yang.adata.MNode):
     limit_threshold: ?value
@@ -4475,13 +5260,15 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess__limit_threshold, child_limit_threshold)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(yang.adata.MNode):
     limit_threshold: ?value
@@ -4503,12 +5290,12 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess__limit_threshold, child_limit_threshold)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(yang.adata.MNode):
     maximum: ?value
@@ -4560,16 +5347,30 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown.from_gdata(n.get_opt_container('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess.from_gdata(n.get_opt_container('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess.from_gdata(n.get_opt_container('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(maximum=yang.gdata.from_xml_opt_value(n, 'maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, 'teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, 'drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, 'hide-excess')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_maximum = yang.gdata.from_xml_opt_value(node, 'maximum')
+    yang.gdata.maybe_add(children, 'maximum', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__maximum, child_maximum)
+    child_teardown = yang.gdata.from_xml_opt_cnt(node, 'teardown')
+    yang.gdata.maybe_add(children, 'teardown', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__teardown, child_teardown)
+    child_drop_excess = yang.gdata.from_xml_opt_cnt(node, 'drop-excess')
+    yang.gdata.maybe_add(children, 'drop-excess', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__drop_excess, child_drop_excess)
+    child_hide_excess = yang.gdata.from_xml_opt_cnt(node, 'hide-excess')
+    yang.gdata.maybe_add(children, 'hide-excess', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit__hide_excess, child_hide_excess)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__maximum(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__forever(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__timeout(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(yang.adata.MNode):
     forever: ?bool
@@ -4596,12 +5397,14 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=n.get_opt_bool('forever'), timeout=n.get_opt_value('timeout'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(forever=yang.gdata.from_xml_opt_bool(n, 'forever'), timeout=yang.gdata.from_xml_opt_value(n, 'timeout'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_forever = yang.gdata.from_xml_opt_bool(node, 'forever')
+    yang.gdata.maybe_add(children, 'forever', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__forever, child_forever)
+    child_timeout = yang.gdata.from_xml_opt_value(node, 'timeout')
+    yang.gdata.maybe_add(children, 'timeout', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout__timeout, child_timeout)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(yang.adata.MNode):
     limit_threshold: ?value
@@ -4633,13 +5436,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=n.get_opt_value('limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_gdata(n.get_opt_container('idle-timeout')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'), idle_timeout=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout.from_xml(yang.gdata.get_xml_opt_child(n, 'idle-timeout')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__limit_threshold, child_limit_threshold)
+    child_idle_timeout = yang.gdata.from_xml_opt_cnt(node, 'idle-timeout')
+    yang.gdata.maybe_add(children, 'idle-timeout', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown__idle_timeout, child_idle_timeout)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(yang.adata.MNode):
     limit_threshold: ?value
@@ -4661,13 +5468,15 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess__limit_threshold, child_limit_threshold)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess__limit_threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(yang.adata.MNode):
     limit_threshold: ?value
@@ -4689,12 +5498,12 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=n.get_opt_value('limit-threshold'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(limit_threshold=yang.gdata.from_xml_opt_value(n, 'limit-threshold'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_limit_threshold = yang.gdata.from_xml_opt_value(node, 'limit-threshold')
+    yang.gdata.maybe_add(children, 'limit-threshold', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess__limit_threshold, child_limit_threshold)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(yang.adata.MNode):
     maximum: ?value
@@ -4746,13 +5555,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(maximum=n.get_opt_value('maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown.from_gdata(n.get_opt_container('teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess.from_gdata(n.get_opt_container('drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess.from_gdata(n.get_opt_container('hide-excess')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(maximum=yang.gdata.from_xml_opt_value(n, 'maximum'), teardown=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown.from_xml(yang.gdata.get_xml_opt_child(n, 'teardown')), drop_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess.from_xml(yang.gdata.get_xml_opt_child(n, 'drop-excess')), hide_excess=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess.from_xml(yang.gdata.get_xml_opt_child(n, 'hide-excess')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_maximum = yang.gdata.from_xml_opt_value(node, 'maximum')
+    yang.gdata.maybe_add(children, 'maximum', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__maximum, child_maximum)
+    child_teardown = yang.gdata.from_xml_opt_cnt(node, 'teardown')
+    yang.gdata.maybe_add(children, 'teardown', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__teardown, child_teardown)
+    child_drop_excess = yang.gdata.from_xml_opt_cnt(node, 'drop-excess')
+    yang.gdata.maybe_add(children, 'drop-excess', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__drop_excess, child_drop_excess)
+    child_hide_excess = yang.gdata.from_xml_opt_cnt(node, 'hide-excess')
+    yang.gdata.maybe_add(children, 'hide-excess', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit__hide_excess, child_hide_excess)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group__ribgroup_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group(yang.adata.MNode):
     ribgroup_name: ?str
@@ -4774,15 +5591,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group(ribgroup_name=n.get_opt_str('ribgroup-name'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group(ribgroup_name=yang.gdata.from_xml_opt_str(n, 'ribgroup-name'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ribgroup_name = yang.gdata.from_xml_opt_str(node, 'ribgroup-name')
+    yang.gdata.maybe_add(children, 'ribgroup-name', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group__ribgroup_name, child_ribgroup_name)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__receive(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode__all_paths(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode__equal_cost_paths(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode(yang.adata.MNode):
     all_paths: ?bool
@@ -4809,16 +5632,26 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode(all_paths=n.get_opt_bool('all-paths'), equal_cost_paths=n.get_opt_bool('equal-cost-paths'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode(all_paths=yang.gdata.from_xml_opt_bool(n, 'all-paths'), equal_cost_paths=yang.gdata.from_xml_opt_bool(n, 'equal-cost-paths'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_all_paths = yang.gdata.from_xml_opt_bool(node, 'all-paths')
+    yang.gdata.maybe_add(children, 'all-paths', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode__all_paths, child_all_paths)
+    child_equal_cost_paths = yang.gdata.from_xml_opt_bool(node, 'equal-cost-paths')
+    yang.gdata.maybe_add(children, 'equal-cost-paths', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode__equal_cost_paths, child_equal_cost_paths)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__prefix_policy(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_count(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__include_backup_path(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__multipath(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(yang.adata.MNode):
     path_selection_mode: junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode
@@ -4858,12 +5691,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode.from_gdata(n.get_opt_container('path-selection-mode')), prefix_policy=n.get_opt_strs('prefix-policy'), path_count=n.get_opt_value('path-count'), include_backup_path=n.get_opt_value('include-backup-path'), multipath=n.get_opt_bool('multipath'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(path_selection_mode=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode.from_xml(yang.gdata.get_xml_opt_child(n, 'path-selection-mode')), prefix_policy=yang.gdata.from_xml_opt_strs(n, 'prefix-policy'), path_count=yang.gdata.from_xml_opt_value(n, 'path-count'), include_backup_path=yang.gdata.from_xml_opt_value(n, 'include-backup-path'), multipath=yang.gdata.from_xml_opt_bool(n, 'multipath'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_path_selection_mode = yang.gdata.from_xml_opt_cnt(node, 'path-selection-mode')
+    yang.gdata.maybe_add(children, 'path-selection-mode', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_selection_mode, child_path_selection_mode)
+    child_prefix_policy = yang.gdata.from_xml_opt_strs(node, 'prefix-policy')
+    yang.gdata.maybe_add(children, 'prefix-policy', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__prefix_policy, child_prefix_policy)
+    child_path_count = yang.gdata.from_xml_opt_value(node, 'path-count')
+    yang.gdata.maybe_add(children, 'path-count', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__path_count, child_path_count)
+    child_include_backup_path = yang.gdata.from_xml_opt_value(node, 'include-backup-path')
+    yang.gdata.maybe_add(children, 'include-backup-path', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__include_backup_path, child_include_backup_path)
+    child_multipath = yang.gdata.from_xml_opt_bool(node, 'multipath')
+    yang.gdata.maybe_add(children, 'multipath', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send__multipath, child_multipath)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path(yang.adata.MNode):
     receive: ?bool
@@ -4895,13 +5736,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path(receive=n.get_opt_bool('receive'), send=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send.from_gdata(n.get_opt_container('send')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path(receive=yang.gdata.from_xml_opt_bool(n, 'receive'), send=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send.from_xml(yang.gdata.get_xml_opt_child(n, 'send')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_receive = yang.gdata.from_xml_opt_bool(node, 'receive')
+    yang.gdata.maybe_add(children, 'receive', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__receive, child_receive)
+    child_send = yang.gdata.from_xml_opt_cnt(node, 'send')
+    yang.gdata.maybe_add(children, 'send', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path__send, child_send)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp(yang.adata.MNode):
     disable: ?bool
@@ -4923,15 +5768,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp(disable=n.get_opt_bool('disable'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp(disable=yang.gdata.from_xml_opt_bool(n, 'disable'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp__disable, child_disable)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__damping(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__local_ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops__loops(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(yang.adata.MNode):
     loops: ?value
@@ -4953,15 +5804,21 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(loops=n.get_opt_value('loops'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(loops=yang.gdata.from_xml_opt_value(n, 'loops'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_loops = yang.gdata.from_xml_opt_value(node, 'loops')
+    yang.gdata.maybe_add(children, 'loops', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops__loops, child_loops)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__always_wait_for_krt_drain(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay__routing_uptime(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay__inbound_convergence(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(yang.adata.MNode):
     routing_uptime: ?value
@@ -4988,14 +5845,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=n.get_opt_value('routing-uptime'), inbound_convergence=n.get_opt_value('inbound-convergence'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(routing_uptime=yang.gdata.from_xml_opt_value(n, 'routing-uptime'), inbound_convergence=yang.gdata.from_xml_opt_value(n, 'inbound-convergence'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_routing_uptime = yang.gdata.from_xml_opt_value(node, 'routing-uptime')
+    yang.gdata.maybe_add(children, 'routing-uptime', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay__routing_uptime, child_routing_uptime)
+    child_inbound_convergence = yang.gdata.from_xml_opt_value(node, 'inbound-convergence')
+    yang.gdata.maybe_add(children, 'inbound-convergence', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay__inbound_convergence, child_inbound_convergence)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay__route_age(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay__routing_uptime(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(yang.adata.MNode):
     route_age: ?value
@@ -5022,12 +5885,14 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=n.get_opt_value('route-age'), routing_uptime=n.get_opt_value('routing-uptime'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(route_age=yang.gdata.from_xml_opt_value(n, 'route-age'), routing_uptime=yang.gdata.from_xml_opt_value(n, 'routing-uptime'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_route_age = yang.gdata.from_xml_opt_value(node, 'route-age')
+    yang.gdata.maybe_add(children, 'route-age', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay__route_age, child_route_age)
+    child_routing_uptime = yang.gdata.from_xml_opt_value(node, 'routing-uptime')
+    yang.gdata.maybe_add(children, 'routing-uptime', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay__routing_uptime, child_routing_uptime)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements(yang.adata.MNode):
     always_wait_for_krt_drain: ?bool
@@ -5059,14 +5924,22 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements(always_wait_for_krt_drain=n.get_opt_bool('always-wait-for-krt-drain'), minimum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay.from_gdata(n.get_opt_container('minimum-delay')), maximum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay.from_gdata(n.get_opt_container('maximum-delay')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements(always_wait_for_krt_drain=yang.gdata.from_xml_opt_bool(n, 'always-wait-for-krt-drain'), minimum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay.from_xml(yang.gdata.get_xml_opt_child(n, 'minimum-delay')), maximum_delay=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay.from_xml(yang.gdata.get_xml_opt_child(n, 'maximum-delay')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_always_wait_for_krt_drain = yang.gdata.from_xml_opt_bool(node, 'always-wait-for-krt-drain')
+    yang.gdata.maybe_add(children, 'always-wait-for-krt-drain', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__always_wait_for_krt_drain, child_always_wait_for_krt_drain)
+    child_minimum_delay = yang.gdata.from_xml_opt_cnt(node, 'minimum-delay')
+    yang.gdata.maybe_add(children, 'minimum-delay', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__minimum_delay, child_minimum_delay)
+    child_maximum_delay = yang.gdata.from_xml_opt_cnt(node, 'maximum-delay')
+    yang.gdata.maybe_add(children, 'maximum-delay', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements__maximum_delay, child_maximum_delay)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution__no_resolution(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution__preserve_nexthop_hierarchy(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution(yang.adata.MNode):
     no_resolution: ?bool
@@ -5093,13 +5966,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution(no_resolution=n.get_opt_bool('no-resolution'), preserve_nexthop_hierarchy=n.get_opt_bool('preserve-nexthop-hierarchy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution(no_resolution=yang.gdata.from_xml_opt_bool(n, 'no-resolution'), preserve_nexthop_hierarchy=yang.gdata.from_xml_opt_bool(n, 'preserve-nexthop-hierarchy'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_no_resolution = yang.gdata.from_xml_opt_bool(node, 'no-resolution')
+    yang.gdata.maybe_add(children, 'no-resolution', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution__no_resolution, child_no_resolution)
+    child_preserve_nexthop_hierarchy = yang.gdata.from_xml_opt_bool(node, 'preserve-nexthop-hierarchy')
+    yang.gdata.maybe_add(children, 'preserve-nexthop-hierarchy', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution__preserve_nexthop_hierarchy, child_preserve_nexthop_hierarchy)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build__maximum_delay(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(yang.adata.MNode):
     maximum_delay: ?value
@@ -5121,14 +5998,18 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(maximum_delay=n.get_opt_value('maximum-delay'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(maximum_delay=yang.gdata.from_xml_opt_value(n, 'maximum-delay'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_maximum_delay = yang.gdata.from_xml_opt_value(node, 'maximum-delay')
+    yang.gdata.maybe_add(children, 'maximum-delay', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build__maximum_delay, child_maximum_delay)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter__stale_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter(yang.adata.MNode):
     disable: ?bool
@@ -5155,15 +6036,23 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter(disable=n.get_opt_bool('disable'), stale_time=n.get_opt_str('stale-time'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter(disable=yang.gdata.from_xml_opt_bool(n, 'disable'), stale_time=yang.gdata.from_xml_opt_str(n, 'stale-time'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter__disable, child_disable)
+    child_stale_time = yang.gdata.from_xml_opt_str(node, 'stale-time')
+    yang.gdata.maybe_add(children, 'stale-time', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter__stale_time, child_stale_time)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention__retention_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention__retention_policy(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention(yang.adata.MNode):
     disable: ?bool
@@ -5193,12 +6082,16 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention(disable=n.get_opt_bool('disable'), retention_time=n.get_opt_str('retention-time'), retention_policy=n.get_opt_strs('retention-policy'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention(disable=yang.gdata.from_xml_opt_bool(n, 'disable'), retention_time=yang.gdata.from_xml_opt_str(n, 'retention-time'), retention_policy=yang.gdata.from_xml_opt_strs(n, 'retention-policy'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention__disable, child_disable)
+    child_retention_time = yang.gdata.from_xml_opt_str(node, 'retention-time')
+    yang.gdata.maybe_add(children, 'retention-time', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention__retention_time, child_retention_time)
+    child_retention_policy = yang.gdata.from_xml_opt_strs(node, 'retention-policy')
+    yang.gdata.maybe_add(children, 'retention-policy', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention__retention_policy, child_retention_policy)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived(yang.adata.MNode):
     restarter: junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter
@@ -5225,13 +6118,17 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived(restarter=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter.from_gdata(n.get_opt_container('restarter')), extended_route_retention=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention.from_gdata(n.get_opt_container('extended-route-retention')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived(restarter=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter.from_xml(yang.gdata.get_xml_opt_child(n, 'restarter')), extended_route_retention=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention.from_xml(yang.gdata.get_xml_opt_child(n, 'extended-route-retention')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_restarter = yang.gdata.from_xml_opt_cnt(node, 'restarter')
+    yang.gdata.maybe_add(children, 'restarter', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__restarter, child_restarter)
+    child_extended_route_retention = yang.gdata.from_xml_opt_cnt(node, 'extended-route-retention')
+    yang.gdata.maybe_add(children, 'extended-route-retention', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived__extended_route_retention, child_extended_route_retention)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__forwarding_state_bit(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart(yang.adata.MNode):
     long_lived: junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived
@@ -5258,19 +6155,35 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart(long_lived=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived.from_gdata(n.get_opt_container('long-lived')), forwarding_state_bit=n.get_opt_str('forwarding-state-bit'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart(long_lived=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived.from_xml(yang.gdata.get_xml_opt_child(n, 'long-lived')), forwarding_state_bit=yang.gdata.from_xml_opt_str(n, 'forwarding-state-bit'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_long_lived = yang.gdata.from_xml_opt_cnt(node, 'long-lived')
+    yang.gdata.maybe_add(children, 'long-lived', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__long_lived, child_long_lived)
+    child_forwarding_state_bit = yang.gdata.from_xml_opt_str(node, 'forwarding-state-bit')
+    yang.gdata.maybe_add(children, 'forwarding-state-bit', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart__forwarding_state_bit, child_forwarding_state_bit)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__extended_nexthop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__extended_nexthop_color(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__extended_nexthop_tunnel(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__no_install(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_age_bgp_view(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority__expedited(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(yang.adata.MNode):
     priority: ?value
@@ -5297,14 +6210,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(priority=yang.gdata.from_xml_opt_value(n, 'priority'), expedited=yang.gdata.from_xml_opt_bool(n, 'expedited'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_priority = yang.gdata.from_xml_opt_value(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority__priority, child_priority)
+    child_expedited = yang.gdata.from_xml_opt_bool(node, 'expedited')
+    yang.gdata.maybe_add(children, 'expedited', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority__expedited, child_expedited)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority__expedited(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(yang.adata.MNode):
     priority: ?value
@@ -5331,14 +6250,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(priority=yang.gdata.from_xml_opt_value(n, 'priority'), expedited=yang.gdata.from_xml_opt_bool(n, 'expedited'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_priority = yang.gdata.from_xml_opt_value(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority__priority, child_priority)
+    child_expedited = yang.gdata.from_xml_opt_bool(node, 'expedited')
+    yang.gdata.maybe_add(children, 'expedited', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority__expedited, child_expedited)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority__priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority__expedited(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(yang.adata.MNode):
     priority: ?value
@@ -5365,15 +6290,23 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(priority=n.get_opt_value('priority'), expedited=n.get_opt_bool('expedited'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(priority=yang.gdata.from_xml_opt_value(n, 'priority'), expedited=yang.gdata.from_xml_opt_bool(n, 'expedited'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_priority = yang.gdata.from_xml_opt_value(node, 'priority')
+    yang.gdata.maybe_add(children, 'priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority__priority, child_priority)
+    child_expedited = yang.gdata.from_xml_opt_bool(node, 'expedited')
+    yang.gdata.maybe_add(children, 'expedited', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority__expedited, child_expedited)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__advertise_srv6_service(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accept_srv6_service(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label__community(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label(yang.adata.MNode):
     community: ?str
@@ -5395,13 +6328,15 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label(community=n.get_opt_str('community'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label(community=yang.gdata.from_xml_opt_str(n, 'community'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_community = yang.gdata.from_xml_opt_str(node, 'community')
+    yang.gdata.maybe_add(children, 'community', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label__community, child_community)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier__context_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier(yang.adata.MNode):
     context_id: ?str
@@ -5423,13 +6358,15 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier(context_id=n.get_opt_str('context-id'))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier(context_id=yang.gdata.from_xml_opt_str(n, 'context-id'))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_context_id = yang.gdata.from_xml_opt_str(node, 'context-id')
+    yang.gdata.maybe_add(children, 'context-id', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier__context_id, child_context_id)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__keep_import(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection(yang.adata.MNode):
     context_identifier: junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier
@@ -5454,14 +6391,20 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection(context_identifier=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier.from_gdata(n.get_opt_container('context-identifier')), keep_import=n.get_opt_strs('keep-import'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection(context_identifier=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier.from_xml(yang.gdata.get_xml_opt_child(n, 'context-identifier')), keep_import=yang.gdata.from_xml_opt_strs(n, 'keep-import'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_context_identifier = yang.gdata.from_xml_opt_cnt(node, 'context-identifier')
+    yang.gdata.maybe_add(children, 'context-identifier', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__context_identifier, child_context_identifier)
+    child_keep_import = yang.gdata.from_xml_opt_strs(node, 'keep-import')
+    yang.gdata.maybe_add(children, 'keep-import', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection__keep_import, child_keep_import)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accept_local_nexthop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accept_own(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast(yang.adata.MNode):
     prefix_limit: junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit
@@ -5633,12 +6576,62 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast(prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit.from_gdata(n.get_opt_container('prefix-limit')), accepted_prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit.from_gdata(n.get_opt_container('accepted-prefix-limit')), rib_group=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group.from_gdata(n.get_opt_container('rib-group')), add_path=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path.from_gdata(n.get_opt_container('add-path')), aigp=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp.from_gdata(n.get_opt_container('aigp')), damping=n.get_opt_bool('damping'), local_ipv4_address=n.get_opt_str('local-ipv4-address'), loops=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops.from_gdata(n.get_opt_container('loops')), delay_route_advertisements=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements.from_gdata(n.get_opt_container('delay-route-advertisements')), nexthop_resolution=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution.from_gdata(n.get_opt_container('nexthop-resolution')), defer_initial_multipath_build=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build.from_gdata(n.get_opt_container('defer-initial-multipath-build')), graceful_restart=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart.from_gdata(n.get_opt_container('graceful-restart')), extended_nexthop=n.get_opt_bool('extended-nexthop'), extended_nexthop_color=n.get_opt_bool('extended-nexthop-color'), extended_nexthop_tunnel=n.get_opt_bool('extended-nexthop-tunnel'), no_install=n.get_opt_bool('no-install'), route_age_bgp_view=n.get_opt_bool('route-age-bgp-view'), output_queue_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority.from_gdata(n.get_opt_container('output-queue-priority')), route_refresh_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority.from_gdata(n.get_opt_container('route-refresh-priority')), withdraw_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority.from_gdata(n.get_opt_container('withdraw-priority')), advertise_srv6_service=n.get_opt_bool('advertise-srv6-service'), accept_srv6_service=n.get_opt_bool('accept-srv6-service'), aggregate_label=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label.from_gdata(n.get_opt_container('aggregate-label')), egress_protection=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection.from_gdata(n.get_opt_container('egress-protection')), accept_local_nexthop=n.get_opt_bool('accept-local-nexthop'), accept_own=n.get_opt_bool('accept-own'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast(prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit.from_xml(yang.gdata.get_xml_opt_child(n, 'prefix-limit')), accepted_prefix_limit=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit.from_xml(yang.gdata.get_xml_opt_child(n, 'accepted-prefix-limit')), rib_group=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group.from_xml(yang.gdata.get_xml_opt_child(n, 'rib-group')), add_path=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path.from_xml(yang.gdata.get_xml_opt_child(n, 'add-path')), aigp=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp.from_xml(yang.gdata.get_xml_opt_child(n, 'aigp')), damping=yang.gdata.from_xml_opt_bool(n, 'damping'), local_ipv4_address=yang.gdata.from_xml_opt_str(n, 'local-ipv4-address'), loops=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops.from_xml(yang.gdata.get_xml_opt_child(n, 'loops')), delay_route_advertisements=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements.from_xml(yang.gdata.get_xml_opt_child(n, 'delay-route-advertisements')), nexthop_resolution=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution.from_xml(yang.gdata.get_xml_opt_child(n, 'nexthop-resolution')), defer_initial_multipath_build=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build.from_xml(yang.gdata.get_xml_opt_child(n, 'defer-initial-multipath-build')), graceful_restart=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart.from_xml(yang.gdata.get_xml_opt_child(n, 'graceful-restart')), extended_nexthop=yang.gdata.from_xml_opt_bool(n, 'extended-nexthop'), extended_nexthop_color=yang.gdata.from_xml_opt_bool(n, 'extended-nexthop-color'), extended_nexthop_tunnel=yang.gdata.from_xml_opt_bool(n, 'extended-nexthop-tunnel'), no_install=yang.gdata.from_xml_opt_bool(n, 'no-install'), route_age_bgp_view=yang.gdata.from_xml_opt_bool(n, 'route-age-bgp-view'), output_queue_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority.from_xml(yang.gdata.get_xml_opt_child(n, 'output-queue-priority')), route_refresh_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority.from_xml(yang.gdata.get_xml_opt_child(n, 'route-refresh-priority')), withdraw_priority=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority.from_xml(yang.gdata.get_xml_opt_child(n, 'withdraw-priority')), advertise_srv6_service=yang.gdata.from_xml_opt_bool(n, 'advertise-srv6-service'), accept_srv6_service=yang.gdata.from_xml_opt_bool(n, 'accept-srv6-service'), aggregate_label=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label.from_xml(yang.gdata.get_xml_opt_child(n, 'aggregate-label')), egress_protection=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection.from_xml(yang.gdata.get_xml_opt_child(n, 'egress-protection')), accept_local_nexthop=yang.gdata.from_xml_opt_bool(n, 'accept-local-nexthop'), accept_own=yang.gdata.from_xml_opt_bool(n, 'accept-own'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_prefix_limit = yang.gdata.from_xml_opt_cnt(node, 'prefix-limit')
+    yang.gdata.maybe_add(children, 'prefix-limit', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__prefix_limit, child_prefix_limit)
+    child_accepted_prefix_limit = yang.gdata.from_xml_opt_cnt(node, 'accepted-prefix-limit')
+    yang.gdata.maybe_add(children, 'accepted-prefix-limit', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accepted_prefix_limit, child_accepted_prefix_limit)
+    child_rib_group = yang.gdata.from_xml_opt_cnt(node, 'rib-group')
+    yang.gdata.maybe_add(children, 'rib-group', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__rib_group, child_rib_group)
+    child_add_path = yang.gdata.from_xml_opt_cnt(node, 'add-path')
+    yang.gdata.maybe_add(children, 'add-path', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__add_path, child_add_path)
+    child_aigp = yang.gdata.from_xml_opt_cnt(node, 'aigp')
+    yang.gdata.maybe_add(children, 'aigp', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aigp, child_aigp)
+    child_damping = yang.gdata.from_xml_opt_bool(node, 'damping')
+    yang.gdata.maybe_add(children, 'damping', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__damping, child_damping)
+    child_local_ipv4_address = yang.gdata.from_xml_opt_str(node, 'local-ipv4-address')
+    yang.gdata.maybe_add(children, 'local-ipv4-address', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__local_ipv4_address, child_local_ipv4_address)
+    child_loops = yang.gdata.from_xml_opt_cnt(node, 'loops')
+    yang.gdata.maybe_add(children, 'loops', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__loops, child_loops)
+    child_delay_route_advertisements = yang.gdata.from_xml_opt_cnt(node, 'delay-route-advertisements')
+    yang.gdata.maybe_add(children, 'delay-route-advertisements', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__delay_route_advertisements, child_delay_route_advertisements)
+    child_nexthop_resolution = yang.gdata.from_xml_opt_cnt(node, 'nexthop-resolution')
+    yang.gdata.maybe_add(children, 'nexthop-resolution', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__nexthop_resolution, child_nexthop_resolution)
+    child_defer_initial_multipath_build = yang.gdata.from_xml_opt_cnt(node, 'defer-initial-multipath-build')
+    yang.gdata.maybe_add(children, 'defer-initial-multipath-build', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__defer_initial_multipath_build, child_defer_initial_multipath_build)
+    child_graceful_restart = yang.gdata.from_xml_opt_cnt(node, 'graceful-restart')
+    yang.gdata.maybe_add(children, 'graceful-restart', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__graceful_restart, child_graceful_restart)
+    child_extended_nexthop = yang.gdata.from_xml_opt_bool(node, 'extended-nexthop')
+    yang.gdata.maybe_add(children, 'extended-nexthop', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__extended_nexthop, child_extended_nexthop)
+    child_extended_nexthop_color = yang.gdata.from_xml_opt_bool(node, 'extended-nexthop-color')
+    yang.gdata.maybe_add(children, 'extended-nexthop-color', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__extended_nexthop_color, child_extended_nexthop_color)
+    child_extended_nexthop_tunnel = yang.gdata.from_xml_opt_bool(node, 'extended-nexthop-tunnel')
+    yang.gdata.maybe_add(children, 'extended-nexthop-tunnel', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__extended_nexthop_tunnel, child_extended_nexthop_tunnel)
+    child_no_install = yang.gdata.from_xml_opt_bool(node, 'no-install')
+    yang.gdata.maybe_add(children, 'no-install', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__no_install, child_no_install)
+    child_route_age_bgp_view = yang.gdata.from_xml_opt_bool(node, 'route-age-bgp-view')
+    yang.gdata.maybe_add(children, 'route-age-bgp-view', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_age_bgp_view, child_route_age_bgp_view)
+    child_output_queue_priority = yang.gdata.from_xml_opt_cnt(node, 'output-queue-priority')
+    yang.gdata.maybe_add(children, 'output-queue-priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__output_queue_priority, child_output_queue_priority)
+    child_route_refresh_priority = yang.gdata.from_xml_opt_cnt(node, 'route-refresh-priority')
+    yang.gdata.maybe_add(children, 'route-refresh-priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__route_refresh_priority, child_route_refresh_priority)
+    child_withdraw_priority = yang.gdata.from_xml_opt_cnt(node, 'withdraw-priority')
+    yang.gdata.maybe_add(children, 'withdraw-priority', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__withdraw_priority, child_withdraw_priority)
+    child_advertise_srv6_service = yang.gdata.from_xml_opt_bool(node, 'advertise-srv6-service')
+    yang.gdata.maybe_add(children, 'advertise-srv6-service', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__advertise_srv6_service, child_advertise_srv6_service)
+    child_accept_srv6_service = yang.gdata.from_xml_opt_bool(node, 'accept-srv6-service')
+    yang.gdata.maybe_add(children, 'accept-srv6-service', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accept_srv6_service, child_accept_srv6_service)
+    child_aggregate_label = yang.gdata.from_xml_opt_cnt(node, 'aggregate-label')
+    yang.gdata.maybe_add(children, 'aggregate-label', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__aggregate_label, child_aggregate_label)
+    child_egress_protection = yang.gdata.from_xml_opt_cnt(node, 'egress-protection')
+    yang.gdata.maybe_add(children, 'egress-protection', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__egress_protection, child_egress_protection)
+    child_accept_local_nexthop = yang.gdata.from_xml_opt_bool(node, 'accept-local-nexthop')
+    yang.gdata.maybe_add(children, 'accept-local-nexthop', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accept_local_nexthop, child_accept_local_nexthop)
+    child_accept_own = yang.gdata.from_xml_opt_bool(node, 'accept-own')
+    yang.gdata.maybe_add(children, 'accept-own', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast__accept_own, child_accept_own)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(yang.adata.MNode):
     unicast: ?junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast
@@ -5665,12 +6658,12 @@ class junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(y
             return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(unicast=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast.from_gdata(n.get_opt_container('unicast')))
         return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(unicast=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast.from_xml(yang.gdata.get_xml_opt_child(n, 'unicast')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_unicast = yang.gdata.from_xml_opt_cnt(node, 'unicast')
+    yang.gdata.maybe_add(children, 'unicast', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn__unicast, child_unicast)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling(yang.adata.MNode):
 
@@ -5688,12 +6681,10 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn__signa
             return junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling()
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__evpn(yang.adata.MNode):
     signaling: ?junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling
@@ -5720,12 +6711,12 @@ class junos_conf_root__configuration__protocols__bgp__group__family__evpn(yang.a
             return junos_conf_root__configuration__protocols__bgp__group__family__evpn(signaling=junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling.from_gdata(n.get_opt_container('signaling')))
         return junos_conf_root__configuration__protocols__bgp__group__family__evpn()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family__evpn:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__evpn(signaling=junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling.from_xml(yang.gdata.get_xml_opt_child(n, 'signaling')))
-        return junos_conf_root__configuration__protocols__bgp__group__family__evpn()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__evpn(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_signaling = yang.gdata.from_xml_opt_cnt(node, 'signaling')
+    yang.gdata.maybe_add(children, 'signaling', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__evpn__signaling, child_signaling)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__bgp__group__family__route_target(yang.adata.MNode):
 
@@ -5743,12 +6734,10 @@ class junos_conf_root__configuration__protocols__bgp__group__family__route_targe
             return junos_conf_root__configuration__protocols__bgp__group__family__route_target()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__bgp__group__family__route_target:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family__route_target()
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family__route_target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__bgp__group__family(yang.adata.MNode):
     inet_vpn: junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn
@@ -5790,21 +6779,45 @@ class junos_conf_root__configuration__protocols__bgp__group__family(yang.adata.M
             return junos_conf_root__configuration__protocols__bgp__group__family(inet_vpn=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn.from_gdata(n.get_opt_container('inet-vpn')), inet6_vpn=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn.from_gdata(n.get_opt_container('inet6-vpn')), evpn=junos_conf_root__configuration__protocols__bgp__group__family__evpn.from_gdata(n.get_opt_container('evpn')), route_target=junos_conf_root__configuration__protocols__bgp__group__family__route_target.from_gdata(n.get_opt_container('route-target')))
         return junos_conf_root__configuration__protocols__bgp__group__family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__family:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp__group__family(inet_vpn=junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn.from_xml(yang.gdata.get_xml_opt_child(n, 'inet-vpn')), inet6_vpn=junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn.from_xml(yang.gdata.get_xml_opt_child(n, 'inet6-vpn')), evpn=junos_conf_root__configuration__protocols__bgp__group__family__evpn.from_xml(yang.gdata.get_xml_opt_child(n, 'evpn')), route_target=junos_conf_root__configuration__protocols__bgp__group__family__route_target.from_xml(yang.gdata.get_xml_opt_child(n, 'route-target')))
-        return junos_conf_root__configuration__protocols__bgp__group__family()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_inet_vpn = yang.gdata.from_xml_opt_cnt(node, 'inet-vpn')
+    yang.gdata.maybe_add(children, 'inet-vpn', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet_vpn, child_inet_vpn)
+    child_inet6_vpn = yang.gdata.from_xml_opt_cnt(node, 'inet6-vpn')
+    yang.gdata.maybe_add(children, 'inet6-vpn', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__inet6_vpn, child_inet6_vpn)
+    child_evpn = yang.gdata.from_xml_opt_cnt(node, 'evpn')
+    yang.gdata.maybe_add(children, 'evpn', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__evpn, child_evpn)
+    child_route_target = yang.gdata.from_xml_opt_cnt(node, 'route-target')
+    yang.gdata.maybe_add(children, 'route-target', from_xml_junos_conf_root__configuration__protocols__bgp__group__family__route_target, child_route_target)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__authentication_algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__tcpao_auth_mismatch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__authentication_key_chain(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__export(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__tcp_mss(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor__passive(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(yang.adata.MNode):
     name: str
@@ -5833,10 +6846,6 @@ class junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(yang
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group__neighbor_entry:
         return junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(name=n.get_str('name'), description=n.get_opt_str('description'), passive=n.get_opt_bool('passive'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__bgp__group__neighbor_entry:
-        return junos_conf_root__configuration__protocols__bgp__group__neighbor_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), passive=yang.gdata.from_xml_opt_bool(n, 'passive'))
 
 class junos_conf_root__configuration__protocols__bgp__group__neighbor(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__bgp__group__neighbor_entry]
@@ -5874,13 +6883,22 @@ class junos_conf_root__configuration__protocols__bgp__group__neighbor(yang.adata
                 res.append(junos_conf_root__configuration__protocols__bgp__group__neighbor_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__bgp__group__neighbor_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__bgp__group__neighbor_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor__description, child_description)
+    child_passive = yang.gdata.from_xml_opt_bool(node, 'passive')
+    yang.gdata.maybe_add(children, 'passive', from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor__passive, child_passive)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNode):
     name: str
@@ -5958,10 +6976,6 @@ class junos_conf_root__configuration__protocols__bgp__group_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__bgp__group_entry:
         return junos_conf_root__configuration__protocols__bgp__group_entry(name=n.get_str('name'), type=n.get_opt_str('type'), description=n.get_opt_str('description'), local_address=n.get_opt_str('local-address'), hold_time=n.get_opt_value('hold-time'), family=junos_conf_root__configuration__protocols__bgp__group__family.from_gdata(n.get_opt_container('family')), authentication_key=n.get_opt_str('authentication-key'), authentication_algorithm=n.get_opt_str('authentication-algorithm'), tcpao_auth_mismatch=n.get_opt_str('tcpao-auth-mismatch'), authentication_key_chain=n.get_opt_str('authentication-key-chain'), export=n.get_opt_strs('export'), tcp_mss=n.get_opt_value('tcp-mss'), neighbor=junos_conf_root__configuration__protocols__bgp__group__neighbor.from_gdata(n.get_opt_list('neighbor')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__bgp__group_entry:
-        return junos_conf_root__configuration__protocols__bgp__group_entry(name=yang.gdata.from_xml_str(n, 'name'), type=yang.gdata.from_xml_opt_str(n, 'type'), description=yang.gdata.from_xml_opt_str(n, 'description'), local_address=yang.gdata.from_xml_opt_str(n, 'local-address'), hold_time=yang.gdata.from_xml_opt_value(n, 'hold-time'), family=junos_conf_root__configuration__protocols__bgp__group__family.from_xml(yang.gdata.get_xml_opt_child(n, 'family')), authentication_key=yang.gdata.from_xml_opt_str(n, 'authentication-key'), authentication_algorithm=yang.gdata.from_xml_opt_str(n, 'authentication-algorithm'), tcpao_auth_mismatch=yang.gdata.from_xml_opt_str(n, 'tcpao-auth-mismatch'), authentication_key_chain=yang.gdata.from_xml_opt_str(n, 'authentication-key-chain'), export=yang.gdata.from_xml_opt_strs(n, 'export'), tcp_mss=yang.gdata.from_xml_opt_value(n, 'tcp-mss'), neighbor=junos_conf_root__configuration__protocols__bgp__group__neighbor.from_xml(yang.gdata.get_xml_children(n, 'neighbor')))
-
 class junos_conf_root__configuration__protocols__bgp__group(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__bgp__group_entry]
     mut def __init__(self, elements=[]):
@@ -5998,14 +7012,45 @@ class junos_conf_root__configuration__protocols__bgp__group(yang.adata.MNode):
                 res.append(junos_conf_root__configuration__protocols__bgp__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__bgp__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__bgp__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__bgp__group__name, child_name)
+    child_type = yang.gdata.from_xml_opt_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_junos_conf_root__configuration__protocols__bgp__group__type, child_type)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_junos_conf_root__configuration__protocols__bgp__group__description, child_description)
+    child_local_address = yang.gdata.from_xml_opt_str(node, 'local-address')
+    yang.gdata.maybe_add(children, 'local-address', from_xml_junos_conf_root__configuration__protocols__bgp__group__local_address, child_local_address)
+    child_hold_time = yang.gdata.from_xml_opt_value(node, 'hold-time')
+    yang.gdata.maybe_add(children, 'hold-time', from_xml_junos_conf_root__configuration__protocols__bgp__group__hold_time, child_hold_time)
+    child_family = yang.gdata.from_xml_opt_cnt(node, 'family')
+    yang.gdata.maybe_add(children, 'family', from_xml_junos_conf_root__configuration__protocols__bgp__group__family, child_family)
+    child_authentication_key = yang.gdata.from_xml_opt_str(node, 'authentication-key')
+    yang.gdata.maybe_add(children, 'authentication-key', from_xml_junos_conf_root__configuration__protocols__bgp__group__authentication_key, child_authentication_key)
+    child_authentication_algorithm = yang.gdata.from_xml_opt_str(node, 'authentication-algorithm')
+    yang.gdata.maybe_add(children, 'authentication-algorithm', from_xml_junos_conf_root__configuration__protocols__bgp__group__authentication_algorithm, child_authentication_algorithm)
+    child_tcpao_auth_mismatch = yang.gdata.from_xml_opt_str(node, 'tcpao-auth-mismatch')
+    yang.gdata.maybe_add(children, 'tcpao-auth-mismatch', from_xml_junos_conf_root__configuration__protocols__bgp__group__tcpao_auth_mismatch, child_tcpao_auth_mismatch)
+    child_authentication_key_chain = yang.gdata.from_xml_opt_str(node, 'authentication-key-chain')
+    yang.gdata.maybe_add(children, 'authentication-key-chain', from_xml_junos_conf_root__configuration__protocols__bgp__group__authentication_key_chain, child_authentication_key_chain)
+    child_export = yang.gdata.from_xml_opt_strs(node, 'export')
+    yang.gdata.maybe_add(children, 'export', from_xml_junos_conf_root__configuration__protocols__bgp__group__export, child_export)
+    child_tcp_mss = yang.gdata.from_xml_opt_value(node, 'tcp-mss')
+    yang.gdata.maybe_add(children, 'tcp-mss', from_xml_junos_conf_root__configuration__protocols__bgp__group__tcp_mss, child_tcp_mss)
+    child_neighbor = yang.gdata.from_xml_opt_list(node, 'neighbor')
+    yang.gdata.maybe_add(children, 'neighbor', from_xml_junos_conf_root__configuration__protocols__bgp__group__neighbor, child_neighbor)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__bgp__group_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
+
+mut def from_xml_junos_conf_root__configuration__protocols__bgp__log_updown(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__bgp(yang.adata.MNode):
     path_selection: junos_conf_root__configuration__protocols__bgp__path_selection
@@ -6037,15 +7082,25 @@ class junos_conf_root__configuration__protocols__bgp(yang.adata.MNode):
             return junos_conf_root__configuration__protocols__bgp(path_selection=junos_conf_root__configuration__protocols__bgp__path_selection.from_gdata(n.get_opt_container('path-selection')), group=junos_conf_root__configuration__protocols__bgp__group.from_gdata(n.get_opt_list('group')), log_updown=n.get_opt_bool('log-updown'))
         return junos_conf_root__configuration__protocols__bgp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__bgp:
-        if n != None:
-            return junos_conf_root__configuration__protocols__bgp(path_selection=junos_conf_root__configuration__protocols__bgp__path_selection.from_xml(yang.gdata.get_xml_opt_child(n, 'path-selection')), group=junos_conf_root__configuration__protocols__bgp__group.from_xml(yang.gdata.get_xml_children(n, 'group')), log_updown=yang.gdata.from_xml_opt_bool(n, 'log-updown'))
-        return junos_conf_root__configuration__protocols__bgp()
 
+mut def from_xml_junos_conf_root__configuration__protocols__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_path_selection = yang.gdata.from_xml_opt_cnt(node, 'path-selection')
+    yang.gdata.maybe_add(children, 'path-selection', from_xml_junos_conf_root__configuration__protocols__bgp__path_selection, child_path_selection)
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_junos_conf_root__configuration__protocols__bgp__group, child_group)
+    child_log_updown = yang.gdata.from_xml_opt_bool(node, 'log-updown')
+    yang.gdata.maybe_add(children, 'log-updown', from_xml_junos_conf_root__configuration__protocols__bgp__log_updown, child_log_updown)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization__hold_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(yang.adata.MNode):
     disable: ?bool
@@ -6072,15 +7127,23 @@ class junos_conf_root__configuration__protocols__isis__interface__ldp_synchroniz
             return junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(disable=n.get_opt_bool('disable'), hold_time=n.get_opt_value('hold-time'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(disable=yang.gdata.from_xml_opt_bool(n, 'disable'), hold_time=yang.gdata.from_xml_opt_value(n, 'hold-time'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization__disable, child_disable)
+    child_hold_time = yang.gdata.from_xml_opt_value(node, 'hold-time')
+    yang.gdata.maybe_add(children, 'hold-time', from_xml_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization__hold_time, child_hold_time)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__level__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__level__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__level__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__level_entry(yang.adata.MNode):
     name: value
@@ -6109,10 +7172,6 @@ class junos_conf_root__configuration__protocols__isis__interface__level_entry(ya
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__level_entry:
         return junos_conf_root__configuration__protocols__isis__interface__level_entry(name=n.get_value('name'), disable=n.get_opt_bool('disable'), metric=n.get_opt_value('metric'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__level_entry:
-        return junos_conf_root__configuration__protocols__isis__interface__level_entry(name=yang.gdata.from_xml_value(n, 'name'), disable=yang.gdata.from_xml_opt_bool(n, 'disable'), metric=yang.gdata.from_xml_opt_value(n, 'metric'))
 
 class junos_conf_root__configuration__protocols__isis__interface__level(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface__level_entry]
@@ -6157,17 +7216,34 @@ class junos_conf_root__configuration__protocols__isis__interface__level(yang.ada
                 res.append(junos_conf_root__configuration__protocols__isis__interface__level_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__isis__interface__level_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__isis__interface__level_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__level_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_value(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__isis__interface__level__name, child_name)
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__isis__interface__level__disable, child_disable)
+    child_metric = yang.gdata.from_xml_opt_value(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_junos_conf_root__configuration__protocols__isis__interface__level__metric, child_metric)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__level(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__isis__interface__level_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__lsp_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__point_to_point(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__passive__remote_node_iso(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__passive__remote_node_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__passive(yang.adata.MNode):
     remote_node_iso: ?str
@@ -6194,23 +7270,47 @@ class junos_conf_root__configuration__protocols__isis__interface__passive(yang.a
             return junos_conf_root__configuration__protocols__isis__interface__passive(remote_node_iso=n.get_opt_str('remote-node-iso'), remote_node_id=n.get_opt_str('remote-node-id'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__interface__passive:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__passive(remote_node_iso=yang.gdata.from_xml_opt_str(n, 'remote-node-iso'), remote_node_id=yang.gdata.from_xml_opt_str(n, 'remote-node-id'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__passive(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_remote_node_iso = yang.gdata.from_xml_opt_str(node, 'remote-node-iso')
+    yang.gdata.maybe_add(children, 'remote-node-iso', from_xml_junos_conf_root__configuration__protocols__isis__interface__passive__remote_node_iso, child_remote_node_iso)
+    child_remote_node_id = yang.gdata.from_xml_opt_str(node, 'remote-node-id')
+    yang.gdata.maybe_add(children, 'remote-node-id', from_xml_junos_conf_root__configuration__protocols__isis__interface__passive__remote_node_id, child_remote_node_id)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__version(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_transmit_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_receive_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__multiplier(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__inline_disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__pdu_size(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__no_adaptation(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval__minimum_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval__threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(yang.adata.MNode):
     minimum_interval: ?value
@@ -6237,13 +7337,17 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(minimum_interval=n.get_opt_value('minimum-interval'), threshold=n.get_opt_value('threshold'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(minimum_interval=yang.gdata.from_xml_opt_value(n, 'minimum-interval'), threshold=yang.gdata.from_xml_opt_value(n, 'threshold'))
-        return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_minimum_interval = yang.gdata.from_xml_opt_value(node, 'minimum-interval')
+    yang.gdata.maybe_add(children, 'minimum-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval__minimum_interval, child_minimum_interval)
+    child_threshold = yang.gdata.from_xml_opt_value(node, 'threshold')
+    yang.gdata.maybe_add(children, 'threshold', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval__threshold, child_threshold)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time__threshold(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(yang.adata.MNode):
     threshold: ?value
@@ -6265,15 +7369,21 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(threshold=n.get_opt_value('threshold'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(threshold=yang.gdata.from_xml_opt_value(n, 'threshold'))
-        return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_threshold = yang.gdata.from_xml_opt_value(node, 'threshold')
+    yang.gdata.maybe_add(children, 'threshold', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time__threshold, child_threshold)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication__key_chain(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication__algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication__loose_check(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication(yang.adata.MNode):
     key_chain: ?str
@@ -6305,13 +7415,19 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication(key_chain=n.get_opt_str('key-chain'), algorithm=n.get_opt_str('algorithm'), loose_check=n.get_opt_bool('loose-check'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication(key_chain=yang.gdata.from_xml_opt_str(n, 'key-chain'), algorithm=yang.gdata.from_xml_opt_str(n, 'algorithm'), loose_check=yang.gdata.from_xml_opt_bool(n, 'loose-check'))
-        return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_key_chain = yang.gdata.from_xml_opt_str(node, 'key-chain')
+    yang.gdata.maybe_add(children, 'key-chain', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication__key_chain, child_key_chain)
+    child_algorithm = yang.gdata.from_xml_opt_str(node, 'algorithm')
+    yang.gdata.maybe_add(children, 'algorithm', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication__algorithm, child_algorithm)
+    child_loose_check = yang.gdata.from_xml_opt_bool(node, 'loose-check')
+    yang.gdata.maybe_add(children, 'loose-check', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication__loose_check, child_loose_check)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo__minimum_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(yang.adata.MNode):
     minimum_interval: ?value
@@ -6333,13 +7449,15 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(minimum_interval=n.get_opt_value('minimum-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(minimum_interval=yang.gdata.from_xml_opt_value(n, 'minimum-interval'))
-        return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_minimum_interval = yang.gdata.from_xml_opt_value(node, 'minimum-interval')
+    yang.gdata.maybe_add(children, 'minimum-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo__minimum_interval, child_minimum_interval)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite__minimum_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(yang.adata.MNode):
     minimum_interval: ?value
@@ -6361,13 +7479,15 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(minimum_interval=n.get_opt_value('minimum-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(minimum_interval=yang.gdata.from_xml_opt_value(n, 'minimum-interval'))
-        return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_minimum_interval = yang.gdata.from_xml_opt_value(node, 'minimum-interval')
+    yang.gdata.maybe_add(children, 'minimum-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite__minimum_interval, child_minimum_interval)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__holddown_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(yang.adata.MNode):
     version: ?str
@@ -6454,12 +7574,38 @@ class junos_conf_root__configuration__protocols__isis__interface__family__bfd_li
             return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(version=n.get_opt_str('version'), minimum_interval=n.get_opt_value('minimum-interval'), minimum_transmit_interval=n.get_opt_value('minimum-transmit-interval'), minimum_receive_interval=n.get_opt_value('minimum-receive-interval'), multiplier=n.get_opt_value('multiplier'), inline_disable=n.get_opt_bool('inline-disable'), pdu_size=n.get_opt_value('pdu-size'), no_adaptation=n.get_opt_bool('no-adaptation'), transmit_interval=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval.from_gdata(n.get_opt_container('transmit-interval')), detection_time=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time.from_gdata(n.get_opt_container('detection-time')), authentication=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication.from_gdata(n.get_opt_container('authentication')), echo=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo.from_gdata(n.get_opt_container('echo')), echo_lite=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite.from_gdata(n.get_opt_container('echo-lite')), holddown_interval=n.get_opt_value('holddown-interval'))
         return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(version=yang.gdata.from_xml_opt_str(n, 'version'), minimum_interval=yang.gdata.from_xml_opt_value(n, 'minimum-interval'), minimum_transmit_interval=yang.gdata.from_xml_opt_value(n, 'minimum-transmit-interval'), minimum_receive_interval=yang.gdata.from_xml_opt_value(n, 'minimum-receive-interval'), multiplier=yang.gdata.from_xml_opt_value(n, 'multiplier'), inline_disable=yang.gdata.from_xml_opt_bool(n, 'inline-disable'), pdu_size=yang.gdata.from_xml_opt_value(n, 'pdu-size'), no_adaptation=yang.gdata.from_xml_opt_bool(n, 'no-adaptation'), transmit_interval=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval.from_xml(yang.gdata.get_xml_opt_child(n, 'transmit-interval')), detection_time=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time.from_xml(yang.gdata.get_xml_opt_child(n, 'detection-time')), authentication=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication.from_xml(yang.gdata.get_xml_opt_child(n, 'authentication')), echo=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo.from_xml(yang.gdata.get_xml_opt_child(n, 'echo')), echo_lite=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite.from_xml(yang.gdata.get_xml_opt_child(n, 'echo-lite')), holddown_interval=yang.gdata.from_xml_opt_value(n, 'holddown-interval'))
-        return junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_version = yang.gdata.from_xml_opt_str(node, 'version')
+    yang.gdata.maybe_add(children, 'version', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__version, child_version)
+    child_minimum_interval = yang.gdata.from_xml_opt_value(node, 'minimum-interval')
+    yang.gdata.maybe_add(children, 'minimum-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_interval, child_minimum_interval)
+    child_minimum_transmit_interval = yang.gdata.from_xml_opt_value(node, 'minimum-transmit-interval')
+    yang.gdata.maybe_add(children, 'minimum-transmit-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_transmit_interval, child_minimum_transmit_interval)
+    child_minimum_receive_interval = yang.gdata.from_xml_opt_value(node, 'minimum-receive-interval')
+    yang.gdata.maybe_add(children, 'minimum-receive-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__minimum_receive_interval, child_minimum_receive_interval)
+    child_multiplier = yang.gdata.from_xml_opt_value(node, 'multiplier')
+    yang.gdata.maybe_add(children, 'multiplier', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__multiplier, child_multiplier)
+    child_inline_disable = yang.gdata.from_xml_opt_bool(node, 'inline-disable')
+    yang.gdata.maybe_add(children, 'inline-disable', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__inline_disable, child_inline_disable)
+    child_pdu_size = yang.gdata.from_xml_opt_value(node, 'pdu-size')
+    yang.gdata.maybe_add(children, 'pdu-size', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__pdu_size, child_pdu_size)
+    child_no_adaptation = yang.gdata.from_xml_opt_bool(node, 'no-adaptation')
+    yang.gdata.maybe_add(children, 'no-adaptation', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__no_adaptation, child_no_adaptation)
+    child_transmit_interval = yang.gdata.from_xml_opt_cnt(node, 'transmit-interval')
+    yang.gdata.maybe_add(children, 'transmit-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__transmit_interval, child_transmit_interval)
+    child_detection_time = yang.gdata.from_xml_opt_cnt(node, 'detection-time')
+    yang.gdata.maybe_add(children, 'detection-time', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__detection_time, child_detection_time)
+    child_authentication = yang.gdata.from_xml_opt_cnt(node, 'authentication')
+    yang.gdata.maybe_add(children, 'authentication', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__authentication, child_authentication)
+    child_echo = yang.gdata.from_xml_opt_cnt(node, 'echo')
+    yang.gdata.maybe_add(children, 'echo', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo, child_echo)
+    child_echo_lite = yang.gdata.from_xml_opt_cnt(node, 'echo-lite')
+    yang.gdata.maybe_add(children, 'echo-lite', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__echo_lite, child_echo_lite)
+    child_holddown_interval = yang.gdata.from_xml_opt_value(node, 'holddown-interval')
+    yang.gdata.maybe_add(children, 'holddown-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection__holddown_interval, child_holddown_interval)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__isis__interface__family_entry(yang.adata.MNode):
     name: str
@@ -6483,10 +7629,6 @@ class junos_conf_root__configuration__protocols__isis__interface__family_entry(y
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface__family_entry:
         return junos_conf_root__configuration__protocols__isis__interface__family_entry(name=n.get_str('name'), bfd_liveness_detection=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection.from_gdata(n.get_opt_container('bfd-liveness-detection')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__interface__family_entry:
-        return junos_conf_root__configuration__protocols__isis__interface__family_entry(name=yang.gdata.from_xml_str(n, 'name'), bfd_liveness_detection=junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection.from_xml(yang.gdata.get_xml_opt_child(n, 'bfd-liveness-detection')))
 
 class junos_conf_root__configuration__protocols__isis__interface__family(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface__family_entry]
@@ -6524,13 +7666,20 @@ class junos_conf_root__configuration__protocols__isis__interface__family(yang.ad
                 res.append(junos_conf_root__configuration__protocols__isis__interface__family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__isis__interface__family_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__isis__interface__family_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__name, child_name)
+    child_bfd_liveness_detection = yang.gdata.from_xml_opt_cnt(node, 'bfd-liveness-detection')
+    yang.gdata.maybe_add(children, 'bfd-liveness-detection', from_xml_junos_conf_root__configuration__protocols__isis__interface__family__bfd_liveness_detection, child_bfd_liveness_detection)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface__family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__isis__interface__family_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adata.MNode):
     name: str
@@ -6590,10 +7739,6 @@ class junos_conf_root__configuration__protocols__isis__interface_entry(yang.adat
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__interface_entry:
         return junos_conf_root__configuration__protocols__isis__interface_entry(name=n.get_str('name'), ldp_synchronization=junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization.from_gdata(n.get_opt_container('ldp-synchronization')), level=junos_conf_root__configuration__protocols__isis__interface__level.from_gdata(n.get_opt_list('level')), lsp_interval=n.get_opt_value('lsp-interval'), point_to_point=n.get_opt_bool('point-to-point'), passive=junos_conf_root__configuration__protocols__isis__interface__passive.from_gdata(n.get_opt_container('passive')), family=junos_conf_root__configuration__protocols__isis__interface__family.from_gdata(n.get_opt_list('family')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__interface_entry:
-        return junos_conf_root__configuration__protocols__isis__interface_entry(name=yang.gdata.from_xml_str(n, 'name'), ldp_synchronization=junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization.from_xml(yang.gdata.get_xml_opt_child(n, 'ldp-synchronization')), level=junos_conf_root__configuration__protocols__isis__interface__level.from_xml(yang.gdata.get_xml_children(n, 'level')), lsp_interval=yang.gdata.from_xml_opt_value(n, 'lsp-interval'), point_to_point=yang.gdata.from_xml_opt_bool(n, 'point-to-point'), passive=junos_conf_root__configuration__protocols__isis__interface__passive.from_xml(yang.gdata.get_xml_opt_child(n, 'passive')), family=junos_conf_root__configuration__protocols__isis__interface__family.from_xml(yang.gdata.get_xml_children(n, 'family')))
-
 class junos_conf_root__configuration__protocols__isis__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__interface_entry]
     mut def __init__(self, elements=[]):
@@ -6630,14 +7775,33 @@ class junos_conf_root__configuration__protocols__isis__interface(yang.adata.MNod
                 res.append(junos_conf_root__configuration__protocols__isis__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__isis__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__isis__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__isis__interface__name, child_name)
+    child_ldp_synchronization = yang.gdata.from_xml_opt_cnt(node, 'ldp-synchronization')
+    yang.gdata.maybe_add(children, 'ldp-synchronization', from_xml_junos_conf_root__configuration__protocols__isis__interface__ldp_synchronization, child_ldp_synchronization)
+    child_level = yang.gdata.from_xml_opt_list(node, 'level')
+    yang.gdata.maybe_add(children, 'level', from_xml_junos_conf_root__configuration__protocols__isis__interface__level, child_level)
+    child_lsp_interval = yang.gdata.from_xml_opt_value(node, 'lsp-interval')
+    yang.gdata.maybe_add(children, 'lsp-interval', from_xml_junos_conf_root__configuration__protocols__isis__interface__lsp_interval, child_lsp_interval)
+    child_point_to_point = yang.gdata.from_xml_opt_bool(node, 'point-to-point')
+    yang.gdata.maybe_add(children, 'point-to-point', from_xml_junos_conf_root__configuration__protocols__isis__interface__point_to_point, child_point_to_point)
+    child_passive = yang.gdata.from_xml_opt_cnt(node, 'passive')
+    yang.gdata.maybe_add(children, 'passive', from_xml_junos_conf_root__configuration__protocols__isis__interface__passive, child_passive)
+    child_family = yang.gdata.from_xml_opt_list(node, 'family')
+    yang.gdata.maybe_add(children, 'family', from_xml_junos_conf_root__configuration__protocols__isis__interface__family, child_family)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__isis__interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
+
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment__hold_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(yang.adata.MNode):
     hold_time: ?value
@@ -6659,14 +7823,18 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__ad
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(hold_time=n.get_opt_value('hold-time'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(hold_time=yang.gdata.from_xml_opt_value(n, 'hold-time'))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_hold_time = yang.gdata.from_xml_opt_value(node, 'hold-time')
+    yang.gdata.maybe_add(children, 'hold-time', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment__hold_time, child_hold_time)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling__encapsulation(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling__decapsulation(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling(yang.adata.MNode):
     encapsulation: ?bool
@@ -6693,14 +7861,20 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__ud
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling(encapsulation=n.get_opt_bool('encapsulation'), decapsulation=n.get_opt_bool('decapsulation'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling(encapsulation=yang.gdata.from_xml_opt_bool(n, 'encapsulation'), decapsulation=yang.gdata.from_xml_opt_bool(n, 'decapsulation'))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_encapsulation = yang.gdata.from_xml_opt_bool(node, 'encapsulation')
+    yang.gdata.maybe_add(children, 'encapsulation', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling__encapsulation, child_encapsulation)
+    child_decapsulation = yang.gdata.from_xml_opt_bool(node, 'decapsulation')
+    yang.gdata.maybe_add(children, 'decapsulation', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling__decapsulation, child_decapsulation)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb__start_label(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb__index_range(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(yang.adata.MNode):
     start_label: ?value
@@ -6727,15 +7901,23 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(start_label=n.get_opt_value('start-label'), index_range=n.get_opt_value('index-range'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(start_label=yang.gdata.from_xml_opt_value(n, 'start-label'), index_range=yang.gdata.from_xml_opt_value(n, 'index-range'))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_start_label = yang.gdata.from_xml_opt_value(node, 'start-label')
+    yang.gdata.maybe_add(children, 'start-label', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb__start_label, child_start_label)
+    child_index_range = yang.gdata.from_xml_opt_value(node, 'index-range')
+    yang.gdata.maybe_add(children, 'index-range', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb__index_range, child_index_range)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__ipv4_index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__ipv6_index(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__index_range(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(yang.adata.MNode):
     ipv4_index: ?value
@@ -6767,27 +7949,61 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__no
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(ipv4_index=n.get_opt_value('ipv4-index'), ipv6_index=n.get_opt_value('ipv6-index'), index_range=n.get_opt_value('index-range'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(ipv4_index=yang.gdata.from_xml_opt_value(n, 'ipv4-index'), ipv6_index=yang.gdata.from_xml_opt_value(n, 'ipv6-index'), index_range=yang.gdata.from_xml_opt_value(n, 'index-range'))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4_index = yang.gdata.from_xml_opt_value(node, 'ipv4-index')
+    yang.gdata.maybe_add(children, 'ipv4-index', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__ipv4_index, child_ipv4_index)
+    child_ipv6_index = yang.gdata.from_xml_opt_value(node, 'ipv6-index')
+    yang.gdata.maybe_add(children, 'ipv6-index', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__ipv6_index, child_ipv6_index)
+    child_index_range = yang.gdata.from_xml_opt_value(node, 'index-range')
+    yang.gdata.maybe_add(children, 'index-range', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment__index_range, child_index_range)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__flex_algorithm(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__use_flex_algorithm_metric_always(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__strict_asla_based_flex_algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__new_capability_subtlv(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__explicit_null(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__mapping_server(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__no_strict_spf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__no_binding_sid_leaking(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__ldp_stitching(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__anycast(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor__psp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor__usp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor__usd(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor(yang.adata.MNode):
     psp: ?bool
@@ -6819,12 +8035,16 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor(psp=n.get_opt_bool('psp'), usp=n.get_opt_bool('usp'), usd=n.get_opt_bool('usd'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor(psp=yang.gdata.from_xml_opt_bool(n, 'psp'), usp=yang.gdata.from_xml_opt_bool(n, 'usp'), usd=yang.gdata.from_xml_opt_bool(n, 'usd'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_psp = yang.gdata.from_xml_opt_bool(node, 'psp')
+    yang.gdata.maybe_add(children, 'psp', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor__psp, child_psp)
+    child_usp = yang.gdata.from_xml_opt_bool(node, 'usp')
+    yang.gdata.maybe_add(children, 'usp', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor__usp, child_usp)
+    child_usd = yang.gdata.from_xml_opt_bool(node, 'usd')
+    yang.gdata.maybe_add(children, 'usd', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor__usd, child_usd)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry(yang.adata.MNode):
     name: str
@@ -6853,10 +8073,6 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry:
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry(name=n.get_str('name'), flavor=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor.from_gdata(n.get_opt_container('flavor')))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry:
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry(name=yang.gdata.from_xml_str(n, 'name'), flavor=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor.from_xml(yang.gdata.get_xml_opt_child(n, 'flavor')))
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry]
@@ -6894,16 +8110,29 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
                 res.append(junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__name, child_name)
+    child_flavor = yang.gdata.from_xml_opt_cnt(node, 'flavor')
+    yang.gdata.maybe_add(children, 'flavor', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid__flavor, child_flavor)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor__psp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor__usp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor__usd(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor(yang.adata.MNode):
     psp: ?bool
@@ -6935,12 +8164,16 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor(psp=n.get_opt_bool('psp'), usp=n.get_opt_bool('usp'), usd=n.get_opt_bool('usd'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor(psp=yang.gdata.from_xml_opt_bool(n, 'psp'), usp=yang.gdata.from_xml_opt_bool(n, 'usp'), usd=yang.gdata.from_xml_opt_bool(n, 'usd'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_psp = yang.gdata.from_xml_opt_bool(node, 'psp')
+    yang.gdata.maybe_add(children, 'psp', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor__psp, child_psp)
+    child_usp = yang.gdata.from_xml_opt_bool(node, 'usp')
+    yang.gdata.maybe_add(children, 'usp', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor__usp, child_usp)
+    child_usd = yang.gdata.from_xml_opt_bool(node, 'usd')
+    yang.gdata.maybe_add(children, 'usd', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor__usd, child_usd)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid(yang.adata.MNode):
     flavor: ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor
@@ -6967,13 +8200,15 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid(flavor=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor.from_gdata(n.get_opt_container('flavor')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid(flavor=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor.from_xml(yang.gdata.get_xml_opt_child(n, 'flavor')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_flavor = yang.gdata.from_xml_opt_cnt(node, 'flavor')
+    yang.gdata.maybe_add(children, 'flavor', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid__flavor, child_flavor)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__micro_node_sid(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry(yang.adata.MNode):
     name: str
@@ -7018,10 +8253,6 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry:
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry(name=n.get_str('name'), anycast=n.get_opt_bool('anycast'), end_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid.from_gdata(n.get_opt_list('end-sid')), dynamic_end_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid.from_gdata(n.get_opt_container('dynamic-end-sid')), micro_node_sid=n.get_opt_bool('micro-node-sid'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry:
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry(name=yang.gdata.from_xml_str(n, 'name'), anycast=yang.gdata.from_xml_opt_bool(n, 'anycast'), end_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid.from_xml(yang.gdata.get_xml_children(n, 'end-sid')), dynamic_end_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid.from_xml(yang.gdata.get_xml_opt_child(n, 'dynamic-end-sid')), micro_node_sid=yang.gdata.from_xml_opt_bool(n, 'micro-node-sid'))
-
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry]
     mut def __init__(self, elements=[]):
@@ -7058,13 +8289,26 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
                 res.append(junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__name, child_name)
+    child_anycast = yang.gdata.from_xml_opt_bool(node, 'anycast')
+    yang.gdata.maybe_add(children, 'anycast', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__anycast, child_anycast)
+    child_end_sid = yang.gdata.from_xml_opt_list(node, 'end-sid')
+    yang.gdata.maybe_add(children, 'end-sid', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__end_sid, child_end_sid)
+    child_dynamic_end_sid = yang.gdata.from_xml_opt_cnt(node, 'dynamic-end-sid')
+    yang.gdata.maybe_add(children, 'dynamic-end-sid', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__dynamic_end_sid, child_dynamic_end_sid)
+    child_micro_node_sid = yang.gdata.from_xml_opt_bool(node, 'micro-node-sid')
+    yang.gdata.maybe_add(children, 'micro-node-sid', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator__micro_node_sid, child_micro_node_sid)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6(yang.adata.MNode):
     locator: junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator
@@ -7086,14 +8330,18 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__sr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6(locator=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator.from_gdata(n.get_opt_list('locator')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6(locator=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator.from_xml(yang.gdata.get_xml_children(n, 'locator')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_locator = yang.gdata.from_xml_opt_list(node, 'locator')
+    yang.gdata.maybe_add(children, 'locator', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6__locator, child_locator)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link__ingress(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link__egress(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link(yang.adata.MNode):
     ingress: ?bool
@@ -7120,14 +8368,20 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link(ingress=n.get_opt_bool('ingress'), egress=n.get_opt_bool('egress'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link(ingress=yang.gdata.from_xml_opt_bool(n, 'ingress'), egress=yang.gdata.from_xml_opt_bool(n, 'egress'))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ingress = yang.gdata.from_xml_opt_bool(node, 'ingress')
+    yang.gdata.maybe_add(children, 'ingress', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link__ingress, child_ingress)
+    child_egress = yang.gdata.from_xml_opt_bool(node, 'egress')
+    yang.gdata.maybe_add(children, 'egress', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link__egress, child_egress)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid__ingress(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid__egress(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid(yang.adata.MNode):
     ingress: ?bool
@@ -7154,13 +8408,17 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid(ingress=n.get_opt_bool('ingress'), egress=n.get_opt_bool('egress'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid(ingress=yang.gdata.from_xml_opt_bool(n, 'ingress'), egress=yang.gdata.from_xml_opt_bool(n, 'egress'))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ingress = yang.gdata.from_xml_opt_bool(node, 'ingress')
+    yang.gdata.maybe_add(children, 'ingress', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid__ingress, child_ingress)
+    child_egress = yang.gdata.from_xml_opt_bool(node, 'egress')
+    yang.gdata.maybe_add(children, 'egress', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid__egress, child_egress)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe__interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(yang.adata.MNode):
     interval: ?value
@@ -7182,12 +8440,12 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(interval=n.get_opt_value('interval'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(interval=yang.gdata.from_xml_opt_value(n, 'interval'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interval = yang.gdata.from_xml_opt_value(node, 'interval')
+    yang.gdata.maybe_add(children, 'interval', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe__interval, child_interval)
+    return yang.gdata.Container(children, presence=True)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats(yang.adata.MNode):
     per_interface_per_member_link: junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link
@@ -7224,13 +8482,19 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__se
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats(per_interface_per_member_link=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link.from_gdata(n.get_opt_container('per-interface-per-member-link')), per_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid.from_gdata(n.get_opt_container('per-sid')), subscribe=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe.from_gdata(n.get_opt_container('subscribe')))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats(per_interface_per_member_link=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link.from_xml(yang.gdata.get_xml_opt_child(n, 'per-interface-per-member-link')), per_sid=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid.from_xml(yang.gdata.get_xml_opt_child(n, 'per-sid')), subscribe=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe.from_xml(yang.gdata.get_xml_opt_child(n, 'subscribe')))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_per_interface_per_member_link = yang.gdata.from_xml_opt_cnt(node, 'per-interface-per-member-link')
+    yang.gdata.maybe_add(children, 'per-interface-per-member-link', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_interface_per_member_link, child_per_interface_per_member_link)
+    child_per_sid = yang.gdata.from_xml_opt_cnt(node, 'per-sid')
+    yang.gdata.maybe_add(children, 'per-sid', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__per_sid, child_per_sid)
+    child_subscribe = yang.gdata.from_xml_opt_cnt(node, 'subscribe')
+    yang.gdata.maybe_add(children, 'subscribe', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats__subscribe, child_subscribe)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity__per_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity(yang.adata.MNode):
     per_interface: ?bool
@@ -7252,14 +8516,18 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__tr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity(per_interface=n.get_opt_bool('per-interface'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity(per_interface=yang.gdata.from_xml_opt_bool(n, 'per-interface'))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_per_interface = yang.gdata.from_xml_opt_bool(node, 'per-interface')
+    yang.gdata.maybe_add(children, 'per-interface', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity__per_interface, child_per_interface)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__congestion_protection(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__auto_bandwidth(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics(yang.adata.MNode):
     statistics_granularity: junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity
@@ -7291,12 +8559,16 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing__tr
             return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics(statistics_granularity=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity.from_gdata(n.get_opt_container('statistics-granularity')), congestion_protection=n.get_opt_bool('congestion-protection'), auto_bandwidth=n.get_opt_str('auto-bandwidth'))
         return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics(statistics_granularity=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity.from_xml(yang.gdata.get_xml_opt_child(n, 'statistics-granularity')), congestion_protection=yang.gdata.from_xml_opt_bool(n, 'congestion-protection'), auto_bandwidth=yang.gdata.from_xml_opt_str(n, 'auto-bandwidth'))
-        return junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_statistics_granularity = yang.gdata.from_xml_opt_cnt(node, 'statistics-granularity')
+    yang.gdata.maybe_add(children, 'statistics-granularity', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__statistics_granularity, child_statistics_granularity)
+    child_congestion_protection = yang.gdata.from_xml_opt_bool(node, 'congestion-protection')
+    yang.gdata.maybe_add(children, 'congestion-protection', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__congestion_protection, child_congestion_protection)
+    child_auto_bandwidth = yang.gdata.from_xml_opt_str(node, 'auto-bandwidth')
+    yang.gdata.maybe_add(children, 'auto-bandwidth', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics__auto_bandwidth, child_auto_bandwidth)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__isis__source_packet_routing(yang.adata.MNode):
     adjacency_segment: junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment
@@ -7396,20 +8668,66 @@ class junos_conf_root__configuration__protocols__isis__source_packet_routing(yan
             return junos_conf_root__configuration__protocols__isis__source_packet_routing(adjacency_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment.from_gdata(n.get_opt_container('adjacency-segment')), udp_tunneling=junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling.from_gdata(n.get_opt_container('udp-tunneling')), srgb=junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb.from_gdata(n.get_opt_container('srgb')), node_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment.from_gdata(n.get_opt_container('node-segment')), flex_algorithm=n.get_opt_values('flex-algorithm'), use_flex_algorithm_metric_always=n.get_opt_bool('use-flex-algorithm-metric-always'), strict_asla_based_flex_algorithm=n.get_opt_bool('strict-asla-based-flex-algorithm'), new_capability_subtlv=n.get_opt_bool('new-capability-subtlv'), explicit_null=n.get_opt_bool('explicit-null'), mapping_server=n.get_opt_str('mapping-server'), no_strict_spf=n.get_opt_bool('no-strict-spf'), no_binding_sid_leaking=n.get_opt_bool('no-binding-sid-leaking'), ldp_stitching=n.get_opt_bool('ldp-stitching'), srv6=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6.from_gdata(n.get_opt_container('srv6')), sensor_based_stats=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats.from_gdata(n.get_opt_container('sensor-based-stats')), traffic_statistics=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics.from_gdata(n.get_opt_container('traffic-statistics')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__isis__source_packet_routing:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis__source_packet_routing(adjacency_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment.from_xml(yang.gdata.get_xml_opt_child(n, 'adjacency-segment')), udp_tunneling=junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling.from_xml(yang.gdata.get_xml_opt_child(n, 'udp-tunneling')), srgb=junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb.from_xml(yang.gdata.get_xml_opt_child(n, 'srgb')), node_segment=junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment.from_xml(yang.gdata.get_xml_opt_child(n, 'node-segment')), flex_algorithm=yang.gdata.from_xml_opt_values(n, 'flex-algorithm'), use_flex_algorithm_metric_always=yang.gdata.from_xml_opt_bool(n, 'use-flex-algorithm-metric-always'), strict_asla_based_flex_algorithm=yang.gdata.from_xml_opt_bool(n, 'strict-asla-based-flex-algorithm'), new_capability_subtlv=yang.gdata.from_xml_opt_bool(n, 'new-capability-subtlv'), explicit_null=yang.gdata.from_xml_opt_bool(n, 'explicit-null'), mapping_server=yang.gdata.from_xml_opt_str(n, 'mapping-server'), no_strict_spf=yang.gdata.from_xml_opt_bool(n, 'no-strict-spf'), no_binding_sid_leaking=yang.gdata.from_xml_opt_bool(n, 'no-binding-sid-leaking'), ldp_stitching=yang.gdata.from_xml_opt_bool(n, 'ldp-stitching'), srv6=junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6.from_xml(yang.gdata.get_xml_opt_child(n, 'srv6')), sensor_based_stats=junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats.from_xml(yang.gdata.get_xml_opt_child(n, 'sensor-based-stats')), traffic_statistics=junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics.from_xml(yang.gdata.get_xml_opt_child(n, 'traffic-statistics')))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_adjacency_segment = yang.gdata.from_xml_opt_cnt(node, 'adjacency-segment')
+    yang.gdata.maybe_add(children, 'adjacency-segment', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__adjacency_segment, child_adjacency_segment)
+    child_udp_tunneling = yang.gdata.from_xml_opt_cnt(node, 'udp-tunneling')
+    yang.gdata.maybe_add(children, 'udp-tunneling', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__udp_tunneling, child_udp_tunneling)
+    child_srgb = yang.gdata.from_xml_opt_cnt(node, 'srgb')
+    yang.gdata.maybe_add(children, 'srgb', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srgb, child_srgb)
+    child_node_segment = yang.gdata.from_xml_opt_cnt(node, 'node-segment')
+    yang.gdata.maybe_add(children, 'node-segment', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__node_segment, child_node_segment)
+    child_flex_algorithm = yang.gdata.from_xml_opt_values(node, 'flex-algorithm')
+    yang.gdata.maybe_add(children, 'flex-algorithm', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__flex_algorithm, child_flex_algorithm)
+    child_use_flex_algorithm_metric_always = yang.gdata.from_xml_opt_bool(node, 'use-flex-algorithm-metric-always')
+    yang.gdata.maybe_add(children, 'use-flex-algorithm-metric-always', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__use_flex_algorithm_metric_always, child_use_flex_algorithm_metric_always)
+    child_strict_asla_based_flex_algorithm = yang.gdata.from_xml_opt_bool(node, 'strict-asla-based-flex-algorithm')
+    yang.gdata.maybe_add(children, 'strict-asla-based-flex-algorithm', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__strict_asla_based_flex_algorithm, child_strict_asla_based_flex_algorithm)
+    child_new_capability_subtlv = yang.gdata.from_xml_opt_bool(node, 'new-capability-subtlv')
+    yang.gdata.maybe_add(children, 'new-capability-subtlv', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__new_capability_subtlv, child_new_capability_subtlv)
+    child_explicit_null = yang.gdata.from_xml_opt_bool(node, 'explicit-null')
+    yang.gdata.maybe_add(children, 'explicit-null', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__explicit_null, child_explicit_null)
+    child_mapping_server = yang.gdata.from_xml_opt_str(node, 'mapping-server')
+    yang.gdata.maybe_add(children, 'mapping-server', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__mapping_server, child_mapping_server)
+    child_no_strict_spf = yang.gdata.from_xml_opt_bool(node, 'no-strict-spf')
+    yang.gdata.maybe_add(children, 'no-strict-spf', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__no_strict_spf, child_no_strict_spf)
+    child_no_binding_sid_leaking = yang.gdata.from_xml_opt_bool(node, 'no-binding-sid-leaking')
+    yang.gdata.maybe_add(children, 'no-binding-sid-leaking', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__no_binding_sid_leaking, child_no_binding_sid_leaking)
+    child_ldp_stitching = yang.gdata.from_xml_opt_bool(node, 'ldp-stitching')
+    yang.gdata.maybe_add(children, 'ldp-stitching', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__ldp_stitching, child_ldp_stitching)
+    child_srv6 = yang.gdata.from_xml_opt_cnt(node, 'srv6')
+    yang.gdata.maybe_add(children, 'srv6', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__srv6, child_srv6)
+    child_sensor_based_stats = yang.gdata.from_xml_opt_cnt(node, 'sensor-based-stats')
+    yang.gdata.maybe_add(children, 'sensor-based-stats', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__sensor_based_stats, child_sensor_based_stats)
+    child_traffic_statistics = yang.gdata.from_xml_opt_cnt(node, 'traffic-statistics')
+    yang.gdata.maybe_add(children, 'traffic-statistics', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing__traffic_statistics, child_traffic_statistics)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level__authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level__authentication_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level__no_hello_authentication(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level__no_csnp_authentication(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level__no_psnp_authentication(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level__wide_metrics_only(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MNode):
     name: value
@@ -7464,10 +8782,6 @@ class junos_conf_root__configuration__protocols__isis__level_entry(yang.adata.MN
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__isis__level_entry:
         return junos_conf_root__configuration__protocols__isis__level_entry(name=n.get_value('name'), disable=n.get_opt_bool('disable'), authentication_key=n.get_opt_str('authentication-key'), authentication_type=n.get_opt_str('authentication-type'), no_hello_authentication=n.get_opt_bool('no-hello-authentication'), no_csnp_authentication=n.get_opt_bool('no-csnp-authentication'), no_psnp_authentication=n.get_opt_bool('no-psnp-authentication'), wide_metrics_only=n.get_opt_bool('wide-metrics-only'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__isis__level_entry:
-        return junos_conf_root__configuration__protocols__isis__level_entry(name=yang.gdata.from_xml_value(n, 'name'), disable=yang.gdata.from_xml_opt_bool(n, 'disable'), authentication_key=yang.gdata.from_xml_opt_str(n, 'authentication-key'), authentication_type=yang.gdata.from_xml_opt_str(n, 'authentication-type'), no_hello_authentication=yang.gdata.from_xml_opt_bool(n, 'no-hello-authentication'), no_csnp_authentication=yang.gdata.from_xml_opt_bool(n, 'no-csnp-authentication'), no_psnp_authentication=yang.gdata.from_xml_opt_bool(n, 'no-psnp-authentication'), wide_metrics_only=yang.gdata.from_xml_opt_bool(n, 'wide-metrics-only'))
-
 class junos_conf_root__configuration__protocols__isis__level(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__isis__level_entry]
     mut def __init__(self, elements=[]):
@@ -7511,14 +8825,35 @@ class junos_conf_root__configuration__protocols__isis__level(yang.adata.MNode):
                 res.append(junos_conf_root__configuration__protocols__isis__level_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__isis__level_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__isis__level_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_value(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__isis__level__name, child_name)
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__isis__level__disable, child_disable)
+    child_authentication_key = yang.gdata.from_xml_opt_str(node, 'authentication-key')
+    yang.gdata.maybe_add(children, 'authentication-key', from_xml_junos_conf_root__configuration__protocols__isis__level__authentication_key, child_authentication_key)
+    child_authentication_type = yang.gdata.from_xml_opt_str(node, 'authentication-type')
+    yang.gdata.maybe_add(children, 'authentication-type', from_xml_junos_conf_root__configuration__protocols__isis__level__authentication_type, child_authentication_type)
+    child_no_hello_authentication = yang.gdata.from_xml_opt_bool(node, 'no-hello-authentication')
+    yang.gdata.maybe_add(children, 'no-hello-authentication', from_xml_junos_conf_root__configuration__protocols__isis__level__no_hello_authentication, child_no_hello_authentication)
+    child_no_csnp_authentication = yang.gdata.from_xml_opt_bool(node, 'no-csnp-authentication')
+    yang.gdata.maybe_add(children, 'no-csnp-authentication', from_xml_junos_conf_root__configuration__protocols__isis__level__no_csnp_authentication, child_no_csnp_authentication)
+    child_no_psnp_authentication = yang.gdata.from_xml_opt_bool(node, 'no-psnp-authentication')
+    yang.gdata.maybe_add(children, 'no-psnp-authentication', from_xml_junos_conf_root__configuration__protocols__isis__level__no_psnp_authentication, child_no_psnp_authentication)
+    child_wide_metrics_only = yang.gdata.from_xml_opt_bool(node, 'wide-metrics-only')
+    yang.gdata.maybe_add(children, 'wide-metrics-only', from_xml_junos_conf_root__configuration__protocols__isis__level__wide_metrics_only, child_wide_metrics_only)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis__level(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__isis__level_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
+
+mut def from_xml_junos_conf_root__configuration__protocols__isis__lsp_lifetime(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
     interface: junos_conf_root__configuration__protocols__isis__interface
@@ -7560,19 +8895,39 @@ class junos_conf_root__configuration__protocols__isis(yang.adata.MNode):
             return junos_conf_root__configuration__protocols__isis(interface=junos_conf_root__configuration__protocols__isis__interface.from_gdata(n.get_opt_list('interface')), source_packet_routing=junos_conf_root__configuration__protocols__isis__source_packet_routing.from_gdata(n.get_opt_container('source-packet-routing')), level=junos_conf_root__configuration__protocols__isis__level.from_gdata(n.get_opt_list('level')), lsp_lifetime=n.get_opt_value('lsp-lifetime'))
         return junos_conf_root__configuration__protocols__isis()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__isis:
-        if n != None:
-            return junos_conf_root__configuration__protocols__isis(interface=junos_conf_root__configuration__protocols__isis__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')), source_packet_routing=junos_conf_root__configuration__protocols__isis__source_packet_routing.from_xml(yang.gdata.get_xml_opt_child(n, 'source-packet-routing')), level=junos_conf_root__configuration__protocols__isis__level.from_xml(yang.gdata.get_xml_children(n, 'level')), lsp_lifetime=yang.gdata.from_xml_opt_value(n, 'lsp-lifetime'))
-        return junos_conf_root__configuration__protocols__isis()
 
+mut def from_xml_junos_conf_root__configuration__protocols__isis(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__protocols__isis__interface, child_interface)
+    child_source_packet_routing = yang.gdata.from_xml_opt_cnt(node, 'source-packet-routing')
+    yang.gdata.maybe_add(children, 'source-packet-routing', from_xml_junos_conf_root__configuration__protocols__isis__source_packet_routing, child_source_packet_routing)
+    child_level = yang.gdata.from_xml_opt_list(node, 'level')
+    yang.gdata.maybe_add(children, 'level', from_xml_junos_conf_root__configuration__protocols__isis__level, child_level)
+    child_lsp_lifetime = yang.gdata.from_xml_opt_value(node, 'lsp-lifetime')
+    yang.gdata.maybe_add(children, 'lsp-lifetime', from_xml_junos_conf_root__configuration__protocols__isis__lsp_lifetime, child_lsp_lifetime)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__filename(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__replace(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__size(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__files(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__no_stamp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__world_readable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__no_world_readable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(yang.adata.MNode):
     filename: ?str
@@ -7624,15 +8979,33 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(y
             return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(filename=n.get_opt_str('filename'), replace=n.get_opt_bool('replace'), size=n.get_opt_str('size'), files=n.get_opt_value('files'), no_stamp=n.get_opt_bool('no-stamp'), world_readable=n.get_opt_bool('world-readable'), no_world_readable=n.get_opt_bool('no-world-readable'))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__ldp__traffic_statistics__file:
-        if n != None:
-            return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(filename=yang.gdata.from_xml_opt_str(n, 'filename'), replace=yang.gdata.from_xml_opt_bool(n, 'replace'), size=yang.gdata.from_xml_opt_str(n, 'size'), files=yang.gdata.from_xml_opt_value(n, 'files'), no_stamp=yang.gdata.from_xml_opt_bool(n, 'no-stamp'), world_readable=yang.gdata.from_xml_opt_bool(n, 'world-readable'), no_world_readable=yang.gdata.from_xml_opt_bool(n, 'no-world-readable'))
-        return junos_conf_root__configuration__protocols__ldp__traffic_statistics__file()
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_filename = yang.gdata.from_xml_opt_str(node, 'filename')
+    yang.gdata.maybe_add(children, 'filename', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__filename, child_filename)
+    child_replace = yang.gdata.from_xml_opt_bool(node, 'replace')
+    yang.gdata.maybe_add(children, 'replace', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__replace, child_replace)
+    child_size = yang.gdata.from_xml_opt_str(node, 'size')
+    yang.gdata.maybe_add(children, 'size', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__size, child_size)
+    child_files = yang.gdata.from_xml_opt_value(node, 'files')
+    yang.gdata.maybe_add(children, 'files', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__files, child_files)
+    child_no_stamp = yang.gdata.from_xml_opt_bool(node, 'no-stamp')
+    yang.gdata.maybe_add(children, 'no-stamp', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__no_stamp, child_no_stamp)
+    child_world_readable = yang.gdata.from_xml_opt_bool(node, 'world-readable')
+    yang.gdata.maybe_add(children, 'world-readable', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__world_readable, child_world_readable)
+    child_no_world_readable = yang.gdata.from_xml_opt_bool(node, 'no-world-readable')
+    yang.gdata.maybe_add(children, 'no-world-readable', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file__no_world_readable, child_no_world_readable)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__sensor_based_stats(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__no_penultimate_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__ldp__traffic_statistics(yang.adata.MNode):
     file: junos_conf_root__configuration__protocols__ldp__traffic_statistics__file
@@ -7669,16 +9042,30 @@ class junos_conf_root__configuration__protocols__ldp__traffic_statistics(yang.ad
             return junos_conf_root__configuration__protocols__ldp__traffic_statistics(file=junos_conf_root__configuration__protocols__ldp__traffic_statistics__file.from_gdata(n.get_opt_container('file')), interval=n.get_opt_value('interval'), sensor_based_stats=n.get_opt_bool('sensor-based-stats'), no_penultimate_hop=n.get_opt_bool('no-penultimate-hop'))
         return junos_conf_root__configuration__protocols__ldp__traffic_statistics()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__ldp__traffic_statistics:
-        if n != None:
-            return junos_conf_root__configuration__protocols__ldp__traffic_statistics(file=junos_conf_root__configuration__protocols__ldp__traffic_statistics__file.from_xml(yang.gdata.get_xml_opt_child(n, 'file')), interval=yang.gdata.from_xml_opt_value(n, 'interval'), sensor_based_stats=yang.gdata.from_xml_opt_bool(n, 'sensor-based-stats'), no_penultimate_hop=yang.gdata.from_xml_opt_bool(n, 'no-penultimate-hop'))
-        return junos_conf_root__configuration__protocols__ldp__traffic_statistics()
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_file = yang.gdata.from_xml_opt_cnt(node, 'file')
+    yang.gdata.maybe_add(children, 'file', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__file, child_file)
+    child_interval = yang.gdata.from_xml_opt_value(node, 'interval')
+    yang.gdata.maybe_add(children, 'interval', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__interval, child_interval)
+    child_sensor_based_stats = yang.gdata.from_xml_opt_bool(node, 'sensor-based-stats')
+    yang.gdata.maybe_add(children, 'sensor-based-stats', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__sensor_based_stats, child_sensor_based_stats)
+    child_no_penultimate_hop = yang.gdata.from_xml_opt_bool(node, 'no-penultimate-hop')
+    yang.gdata.maybe_add(children, 'no-penultimate-hop', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics__no_penultimate_hop, child_no_penultimate_hop)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__preference(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__transport_address__router_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__transport_address__interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__transport_address__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__ldp__transport_address(yang.adata.MNode):
     router_id: ?bool
@@ -7710,18 +9097,34 @@ class junos_conf_root__configuration__protocols__ldp__transport_address(yang.ada
             return junos_conf_root__configuration__protocols__ldp__transport_address(router_id=n.get_opt_bool('router-id'), interface=n.get_opt_bool('interface'), address=n.get_opt_str('address'))
         return junos_conf_root__configuration__protocols__ldp__transport_address()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__ldp__transport_address:
-        if n != None:
-            return junos_conf_root__configuration__protocols__ldp__transport_address(router_id=yang.gdata.from_xml_opt_bool(n, 'router-id'), interface=yang.gdata.from_xml_opt_bool(n, 'interface'), address=yang.gdata.from_xml_opt_str(n, 'address'))
-        return junos_conf_root__configuration__protocols__ldp__transport_address()
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__transport_address(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_router_id = yang.gdata.from_xml_opt_bool(node, 'router-id')
+    yang.gdata.maybe_add(children, 'router-id', from_xml_junos_conf_root__configuration__protocols__ldp__transport_address__router_id, child_router_id)
+    child_interface = yang.gdata.from_xml_opt_bool(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__protocols__ldp__transport_address__interface, child_interface)
+    child_address = yang.gdata.from_xml_opt_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_junos_conf_root__configuration__protocols__ldp__transport_address__address, child_address)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__hello_interval(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__hold_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__link_protection__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__link_protection__dynamic_rsvp_lsp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__ldp__interface__link_protection(yang.adata.MNode):
     disable: ?bool
@@ -7748,15 +9151,23 @@ class junos_conf_root__configuration__protocols__ldp__interface__link_protection
             return junos_conf_root__configuration__protocols__ldp__interface__link_protection(disable=n.get_opt_bool('disable'), dynamic_rsvp_lsp=n.get_opt_bool('dynamic-rsvp-lsp'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?junos_conf_root__configuration__protocols__ldp__interface__link_protection:
-        if n != None:
-            return junos_conf_root__configuration__protocols__ldp__interface__link_protection(disable=yang.gdata.from_xml_opt_bool(n, 'disable'), dynamic_rsvp_lsp=yang.gdata.from_xml_opt_bool(n, 'dynamic-rsvp-lsp'))
-        return None
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__link_protection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__ldp__interface__link_protection__disable, child_disable)
+    child_dynamic_rsvp_lsp = yang.gdata.from_xml_opt_bool(node, 'dynamic-rsvp-lsp')
+    yang.gdata.maybe_add(children, 'dynamic-rsvp-lsp', from_xml_junos_conf_root__configuration__protocols__ldp__interface__link_protection__dynamic_rsvp_lsp, child_dynamic_rsvp_lsp)
+    return yang.gdata.Container(children, presence=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address__router_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address__interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
 
 class junos_conf_root__configuration__protocols__ldp__interface__transport_address(yang.adata.MNode):
     router_id: ?bool
@@ -7788,14 +9199,22 @@ class junos_conf_root__configuration__protocols__ldp__interface__transport_addre
             return junos_conf_root__configuration__protocols__ldp__interface__transport_address(router_id=n.get_opt_bool('router-id'), interface=n.get_opt_bool('interface'), address=n.get_opt_str('address'))
         return junos_conf_root__configuration__protocols__ldp__interface__transport_address()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__ldp__interface__transport_address:
-        if n != None:
-            return junos_conf_root__configuration__protocols__ldp__interface__transport_address(router_id=yang.gdata.from_xml_opt_bool(n, 'router-id'), interface=yang.gdata.from_xml_opt_bool(n, 'interface'), address=yang.gdata.from_xml_opt_str(n, 'address'))
-        return junos_conf_root__configuration__protocols__ldp__interface__transport_address()
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_router_id = yang.gdata.from_xml_opt_bool(node, 'router-id')
+    yang.gdata.maybe_add(children, 'router-id', from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address__router_id, child_router_id)
+    child_interface = yang.gdata.from_xml_opt_bool(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address__interface, child_interface)
+    child_address = yang.gdata.from_xml_opt_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address__address, child_address)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__allow_subnet_mismatch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface__no_allow_subnet_mismatch(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
 class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata.MNode):
     name: str
@@ -7855,10 +9274,6 @@ class junos_conf_root__configuration__protocols__ldp__interface_entry(yang.adata
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__ldp__interface_entry:
         return junos_conf_root__configuration__protocols__ldp__interface_entry(name=n.get_str('name'), disable=n.get_opt_bool('disable'), hello_interval=n.get_opt_value('hello-interval'), hold_time=n.get_opt_value('hold-time'), link_protection=junos_conf_root__configuration__protocols__ldp__interface__link_protection.from_gdata(n.get_opt_container('link-protection')), transport_address=junos_conf_root__configuration__protocols__ldp__interface__transport_address.from_gdata(n.get_opt_container('transport-address')), allow_subnet_mismatch=n.get_opt_bool('allow-subnet-mismatch'), no_allow_subnet_mismatch=n.get_opt_bool('no-allow-subnet-mismatch'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__ldp__interface_entry:
-        return junos_conf_root__configuration__protocols__ldp__interface_entry(name=yang.gdata.from_xml_str(n, 'name'), disable=yang.gdata.from_xml_opt_bool(n, 'disable'), hello_interval=yang.gdata.from_xml_opt_value(n, 'hello-interval'), hold_time=yang.gdata.from_xml_opt_value(n, 'hold-time'), link_protection=junos_conf_root__configuration__protocols__ldp__interface__link_protection.from_xml(yang.gdata.get_xml_opt_child(n, 'link-protection')), transport_address=junos_conf_root__configuration__protocols__ldp__interface__transport_address.from_xml(yang.gdata.get_xml_opt_child(n, 'transport-address')), allow_subnet_mismatch=yang.gdata.from_xml_opt_bool(n, 'allow-subnet-mismatch'), no_allow_subnet_mismatch=yang.gdata.from_xml_opt_bool(n, 'no-allow-subnet-mismatch'))
-
 class junos_conf_root__configuration__protocols__ldp__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__ldp__interface_entry]
     mut def __init__(self, elements=[]):
@@ -7895,13 +9310,32 @@ class junos_conf_root__configuration__protocols__ldp__interface(yang.adata.MNode
                 res.append(junos_conf_root__configuration__protocols__ldp__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__ldp__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__ldp__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__ldp__interface__name, child_name)
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__ldp__interface__disable, child_disable)
+    child_hello_interval = yang.gdata.from_xml_opt_value(node, 'hello-interval')
+    yang.gdata.maybe_add(children, 'hello-interval', from_xml_junos_conf_root__configuration__protocols__ldp__interface__hello_interval, child_hello_interval)
+    child_hold_time = yang.gdata.from_xml_opt_value(node, 'hold-time')
+    yang.gdata.maybe_add(children, 'hold-time', from_xml_junos_conf_root__configuration__protocols__ldp__interface__hold_time, child_hold_time)
+    child_link_protection = yang.gdata.from_xml_opt_cnt(node, 'link-protection')
+    yang.gdata.maybe_add(children, 'link-protection', from_xml_junos_conf_root__configuration__protocols__ldp__interface__link_protection, child_link_protection)
+    child_transport_address = yang.gdata.from_xml_opt_cnt(node, 'transport-address')
+    yang.gdata.maybe_add(children, 'transport-address', from_xml_junos_conf_root__configuration__protocols__ldp__interface__transport_address, child_transport_address)
+    child_allow_subnet_mismatch = yang.gdata.from_xml_opt_bool(node, 'allow-subnet-mismatch')
+    yang.gdata.maybe_add(children, 'allow-subnet-mismatch', from_xml_junos_conf_root__configuration__protocols__ldp__interface__allow_subnet_mismatch, child_allow_subnet_mismatch)
+    child_no_allow_subnet_mismatch = yang.gdata.from_xml_opt_bool(node, 'no-allow-subnet-mismatch')
+    yang.gdata.maybe_add(children, 'no-allow-subnet-mismatch', from_xml_junos_conf_root__configuration__protocols__ldp__interface__no_allow_subnet_mismatch, child_no_allow_subnet_mismatch)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__protocols__ldp__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__ldp__interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
     traffic_statistics: junos_conf_root__configuration__protocols__ldp__traffic_statistics
@@ -7938,22 +9372,48 @@ class junos_conf_root__configuration__protocols__ldp(yang.adata.MNode):
             return junos_conf_root__configuration__protocols__ldp(traffic_statistics=junos_conf_root__configuration__protocols__ldp__traffic_statistics.from_gdata(n.get_opt_container('traffic-statistics')), preference=n.get_opt_value('preference'), transport_address=junos_conf_root__configuration__protocols__ldp__transport_address.from_gdata(n.get_opt_container('transport-address')), interface=junos_conf_root__configuration__protocols__ldp__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__protocols__ldp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__ldp:
-        if n != None:
-            return junos_conf_root__configuration__protocols__ldp(traffic_statistics=junos_conf_root__configuration__protocols__ldp__traffic_statistics.from_xml(yang.gdata.get_xml_opt_child(n, 'traffic-statistics')), preference=yang.gdata.from_xml_opt_value(n, 'preference'), transport_address=junos_conf_root__configuration__protocols__ldp__transport_address.from_xml(yang.gdata.get_xml_opt_child(n, 'transport-address')), interface=junos_conf_root__configuration__protocols__ldp__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')))
-        return junos_conf_root__configuration__protocols__ldp()
 
+mut def from_xml_junos_conf_root__configuration__protocols__ldp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_traffic_statistics = yang.gdata.from_xml_opt_cnt(node, 'traffic-statistics')
+    yang.gdata.maybe_add(children, 'traffic-statistics', from_xml_junos_conf_root__configuration__protocols__ldp__traffic_statistics, child_traffic_statistics)
+    child_preference = yang.gdata.from_xml_opt_value(node, 'preference')
+    yang.gdata.maybe_add(children, 'preference', from_xml_junos_conf_root__configuration__protocols__ldp__preference, child_preference)
+    child_transport_address = yang.gdata.from_xml_opt_cnt(node, 'transport-address')
+    yang.gdata.maybe_add(children, 'transport-address', from_xml_junos_conf_root__configuration__protocols__ldp__transport_address, child_transport_address)
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__protocols__ldp__interface, child_interface)
+    return yang.gdata.Container(children)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__no_propagate_ttl(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__ipv6_tunneling(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__disable(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__srlg(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__always_mark_connection_protection_tlv(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__switch_away_lsps(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__admin_group(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__admin_group_extended(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, user_order=True)
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__static__protection_revert_time(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
 
 class junos_conf_root__configuration__protocols__mpls__interface__static(yang.adata.MNode):
     protection_revert_time: ?value
@@ -7975,12 +9435,12 @@ class junos_conf_root__configuration__protocols__mpls__interface__static(yang.ad
             return junos_conf_root__configuration__protocols__mpls__interface__static(protection_revert_time=n.get_opt_value('protection-revert-time'))
         return junos_conf_root__configuration__protocols__mpls__interface__static()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__mpls__interface__static:
-        if n != None:
-            return junos_conf_root__configuration__protocols__mpls__interface__static(protection_revert_time=yang.gdata.from_xml_opt_value(n, 'protection-revert-time'))
-        return junos_conf_root__configuration__protocols__mpls__interface__static()
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface__static(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_protection_revert_time = yang.gdata.from_xml_opt_value(node, 'protection-revert-time')
+    yang.gdata.maybe_add(children, 'protection-revert-time', from_xml_junos_conf_root__configuration__protocols__mpls__interface__static__protection_revert_time, child_protection_revert_time)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols__mpls__interface_entry(yang.adata.MNode):
     name: str
@@ -8029,10 +9489,6 @@ class junos_conf_root__configuration__protocols__mpls__interface_entry(yang.adat
     mut def from_gdata(n: yang.gdata.Node) -> junos_conf_root__configuration__protocols__mpls__interface_entry:
         return junos_conf_root__configuration__protocols__mpls__interface_entry(name=n.get_str('name'), disable=n.get_opt_bool('disable'), srlg=n.get_opt_strs('srlg'), always_mark_connection_protection_tlv=n.get_opt_bool('always-mark-connection-protection-tlv'), switch_away_lsps=n.get_opt_bool('switch-away-lsps'), admin_group=n.get_opt_strs('admin-group'), admin_group_extended=n.get_opt_strs('admin-group-extended'), static=junos_conf_root__configuration__protocols__mpls__interface__static.from_gdata(n.get_opt_container('static')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> junos_conf_root__configuration__protocols__mpls__interface_entry:
-        return junos_conf_root__configuration__protocols__mpls__interface_entry(name=yang.gdata.from_xml_str(n, 'name'), disable=yang.gdata.from_xml_opt_bool(n, 'disable'), srlg=yang.gdata.from_xml_opt_strs(n, 'srlg'), always_mark_connection_protection_tlv=yang.gdata.from_xml_opt_bool(n, 'always-mark-connection-protection-tlv'), switch_away_lsps=yang.gdata.from_xml_opt_bool(n, 'switch-away-lsps'), admin_group=yang.gdata.from_xml_opt_strs(n, 'admin-group'), admin_group_extended=yang.gdata.from_xml_opt_strs(n, 'admin-group-extended'), static=junos_conf_root__configuration__protocols__mpls__interface__static.from_xml(yang.gdata.get_xml_opt_child(n, 'static')))
-
 class junos_conf_root__configuration__protocols__mpls__interface(yang.adata.MNode):
     elements: list[junos_conf_root__configuration__protocols__mpls__interface_entry]
     mut def __init__(self, elements=[]):
@@ -8069,13 +9525,32 @@ class junos_conf_root__configuration__protocols__mpls__interface(yang.adata.MNod
                 res.append(junos_conf_root__configuration__protocols__mpls__interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[junos_conf_root__configuration__protocols__mpls__interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(junos_conf_root__configuration__protocols__mpls__interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_junos_conf_root__configuration__protocols__mpls__interface__name, child_name)
+    child_disable = yang.gdata.from_xml_opt_bool(node, 'disable')
+    yang.gdata.maybe_add(children, 'disable', from_xml_junos_conf_root__configuration__protocols__mpls__interface__disable, child_disable)
+    child_srlg = yang.gdata.from_xml_opt_strs(node, 'srlg')
+    yang.gdata.maybe_add(children, 'srlg', from_xml_junos_conf_root__configuration__protocols__mpls__interface__srlg, child_srlg)
+    child_always_mark_connection_protection_tlv = yang.gdata.from_xml_opt_bool(node, 'always-mark-connection-protection-tlv')
+    yang.gdata.maybe_add(children, 'always-mark-connection-protection-tlv', from_xml_junos_conf_root__configuration__protocols__mpls__interface__always_mark_connection_protection_tlv, child_always_mark_connection_protection_tlv)
+    child_switch_away_lsps = yang.gdata.from_xml_opt_bool(node, 'switch-away-lsps')
+    yang.gdata.maybe_add(children, 'switch-away-lsps', from_xml_junos_conf_root__configuration__protocols__mpls__interface__switch_away_lsps, child_switch_away_lsps)
+    child_admin_group = yang.gdata.from_xml_opt_strs(node, 'admin-group')
+    yang.gdata.maybe_add(children, 'admin-group', from_xml_junos_conf_root__configuration__protocols__mpls__interface__admin_group, child_admin_group)
+    child_admin_group_extended = yang.gdata.from_xml_opt_strs(node, 'admin-group-extended')
+    yang.gdata.maybe_add(children, 'admin-group-extended', from_xml_junos_conf_root__configuration__protocols__mpls__interface__admin_group_extended, child_admin_group_extended)
+    child_static = yang.gdata.from_xml_opt_cnt(node, 'static')
+    yang.gdata.maybe_add(children, 'static', from_xml_junos_conf_root__configuration__protocols__mpls__interface__static, child_static)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_junos_conf_root__configuration__protocols__mpls__interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_junos_conf_root__configuration__protocols__mpls__interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 class junos_conf_root__configuration__protocols__mpls(yang.adata.MNode):
     no_propagate_ttl: ?bool
@@ -8107,12 +9582,16 @@ class junos_conf_root__configuration__protocols__mpls(yang.adata.MNode):
             return junos_conf_root__configuration__protocols__mpls(no_propagate_ttl=n.get_opt_bool('no-propagate-ttl'), ipv6_tunneling=n.get_opt_bool('ipv6-tunneling'), interface=junos_conf_root__configuration__protocols__mpls__interface.from_gdata(n.get_opt_list('interface')))
         return junos_conf_root__configuration__protocols__mpls()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols__mpls:
-        if n != None:
-            return junos_conf_root__configuration__protocols__mpls(no_propagate_ttl=yang.gdata.from_xml_opt_bool(n, 'no-propagate-ttl'), ipv6_tunneling=yang.gdata.from_xml_opt_bool(n, 'ipv6-tunneling'), interface=junos_conf_root__configuration__protocols__mpls__interface.from_xml(yang.gdata.get_xml_children(n, 'interface')))
-        return junos_conf_root__configuration__protocols__mpls()
 
+mut def from_xml_junos_conf_root__configuration__protocols__mpls(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_no_propagate_ttl = yang.gdata.from_xml_opt_bool(node, 'no-propagate-ttl')
+    yang.gdata.maybe_add(children, 'no-propagate-ttl', from_xml_junos_conf_root__configuration__protocols__mpls__no_propagate_ttl, child_no_propagate_ttl)
+    child_ipv6_tunneling = yang.gdata.from_xml_opt_bool(node, 'ipv6-tunneling')
+    yang.gdata.maybe_add(children, 'ipv6-tunneling', from_xml_junos_conf_root__configuration__protocols__mpls__ipv6_tunneling, child_ipv6_tunneling)
+    child_interface = yang.gdata.from_xml_opt_list(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_junos_conf_root__configuration__protocols__mpls__interface, child_interface)
+    return yang.gdata.Container(children)
 
 class junos_conf_root__configuration__protocols(yang.adata.MNode):
     bgp: junos_conf_root__configuration__protocols__bgp
@@ -8149,12 +9628,18 @@ class junos_conf_root__configuration__protocols(yang.adata.MNode):
             return junos_conf_root__configuration__protocols(bgp=junos_conf_root__configuration__protocols__bgp.from_gdata(n.get_opt_container('bgp')), isis=junos_conf_root__configuration__protocols__isis.from_gdata(n.get_opt_container('isis')), ldp=junos_conf_root__configuration__protocols__ldp.from_gdata(n.get_opt_container('ldp')), mpls=junos_conf_root__configuration__protocols__mpls.from_gdata(n.get_opt_container('mpls')))
         return junos_conf_root__configuration__protocols()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration__protocols:
-        if n != None:
-            return junos_conf_root__configuration__protocols(bgp=junos_conf_root__configuration__protocols__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')), isis=junos_conf_root__configuration__protocols__isis.from_xml(yang.gdata.get_xml_opt_child(n, 'isis')), ldp=junos_conf_root__configuration__protocols__ldp.from_xml(yang.gdata.get_xml_opt_child(n, 'ldp')), mpls=junos_conf_root__configuration__protocols__mpls.from_xml(yang.gdata.get_xml_opt_child(n, 'mpls')))
-        return junos_conf_root__configuration__protocols()
 
+mut def from_xml_junos_conf_root__configuration__protocols(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_junos_conf_root__configuration__protocols__bgp, child_bgp)
+    child_isis = yang.gdata.from_xml_opt_cnt(node, 'isis')
+    yang.gdata.maybe_add(children, 'isis', from_xml_junos_conf_root__configuration__protocols__isis, child_isis)
+    child_ldp = yang.gdata.from_xml_opt_cnt(node, 'ldp')
+    yang.gdata.maybe_add(children, 'ldp', from_xml_junos_conf_root__configuration__protocols__ldp, child_ldp)
+    child_mpls = yang.gdata.from_xml_opt_cnt(node, 'mpls')
+    yang.gdata.maybe_add(children, 'mpls', from_xml_junos_conf_root__configuration__protocols__mpls, child_mpls)
+    return yang.gdata.Container(children, ns='http://yang.juniper.net/junos/conf/protocols', module='junos-conf-protocols')
 
 class junos_conf_root__configuration(yang.adata.MNode):
     rcsid: ?str
@@ -8211,12 +9696,26 @@ class junos_conf_root__configuration(yang.adata.MNode):
             return junos_conf_root__configuration(rcsid=n.get_opt_str('rcsid'), version=n.get_opt_str('version'), system=junos_conf_root__configuration__system.from_gdata(n.get_opt_container('system')), interfaces=junos_conf_root__configuration__interfaces.from_gdata(n.get_opt_container('interfaces')), routing_instances=junos_conf_root__configuration__routing_instances.from_gdata(n.get_opt_container('routing-instances')), groups=junos_conf_root__configuration__groups.from_gdata(n.get_opt_list('groups')), routing_options=junos_conf_root__configuration__routing_options.from_gdata(n.get_opt_container('routing-options')), protocols=junos_conf_root__configuration__protocols.from_gdata(n.get_opt_container('protocols')))
         return junos_conf_root__configuration()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> junos_conf_root__configuration:
-        if n != None:
-            return junos_conf_root__configuration(rcsid=yang.gdata.from_xml_opt_str(n, 'rcsid'), version=yang.gdata.from_xml_opt_str(n, 'version'), system=junos_conf_root__configuration__system.from_xml(yang.gdata.get_xml_opt_child(n, 'system')), interfaces=junos_conf_root__configuration__interfaces.from_xml(yang.gdata.get_xml_opt_child(n, 'interfaces')), routing_instances=junos_conf_root__configuration__routing_instances.from_xml(yang.gdata.get_xml_opt_child(n, 'routing-instances')), groups=junos_conf_root__configuration__groups.from_xml(yang.gdata.get_xml_children(n, 'groups')), routing_options=junos_conf_root__configuration__routing_options.from_xml(yang.gdata.get_xml_opt_child(n, 'routing-options')), protocols=junos_conf_root__configuration__protocols.from_xml(yang.gdata.get_xml_opt_child(n, 'protocols', 'http://yang.juniper.net/junos/conf/protocols')))
-        return junos_conf_root__configuration()
 
+mut def from_xml_junos_conf_root__configuration(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rcsid = yang.gdata.from_xml_opt_str(node, 'rcsid')
+    yang.gdata.maybe_add(children, 'rcsid', from_xml_junos_conf_root__configuration__rcsid, child_rcsid)
+    child_version = yang.gdata.from_xml_opt_str(node, 'version')
+    yang.gdata.maybe_add(children, 'version', from_xml_junos_conf_root__configuration__version, child_version)
+    child_system = yang.gdata.from_xml_opt_cnt(node, 'system')
+    yang.gdata.maybe_add(children, 'system', from_xml_junos_conf_root__configuration__system, child_system)
+    child_interfaces = yang.gdata.from_xml_opt_cnt(node, 'interfaces')
+    yang.gdata.maybe_add(children, 'interfaces', from_xml_junos_conf_root__configuration__interfaces, child_interfaces)
+    child_routing_instances = yang.gdata.from_xml_opt_cnt(node, 'routing-instances')
+    yang.gdata.maybe_add(children, 'routing-instances', from_xml_junos_conf_root__configuration__routing_instances, child_routing_instances)
+    child_groups = yang.gdata.from_xml_opt_list(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_junos_conf_root__configuration__groups, child_groups)
+    child_routing_options = yang.gdata.from_xml_opt_cnt(node, 'routing-options')
+    yang.gdata.maybe_add(children, 'routing-options', from_xml_junos_conf_root__configuration__routing_options, child_routing_options)
+    child_protocols = yang.gdata.from_xml_opt_cnt(node, 'protocols', 'http://yang.juniper.net/junos/conf/protocols')
+    yang.gdata.maybe_add(children, 'protocols', from_xml_junos_conf_root__configuration__protocols, child_protocols)
+    return yang.gdata.Container(children, ns='http://yang.juniper.net/junos/conf/root', module='junos-conf-root')
 
 class root(yang.adata.MNode):
     configuration: junos_conf_root__configuration
@@ -8238,12 +9737,12 @@ class root(yang.adata.MNode):
             return root(configuration=junos_conf_root__configuration.from_gdata(n.get_opt_container('configuration')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(configuration=junos_conf_root__configuration.from_xml(yang.gdata.get_xml_opt_child(n, 'configuration', 'http://yang.juniper.net/junos/conf/root')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_configuration = yang.gdata.from_xml_opt_cnt(node, 'configuration', 'http://yang.juniper.net/junos/conf/root')
+    yang.gdata.maybe_add(children, 'configuration', from_xml_junos_conf_root__configuration, child_configuration)
+    return yang.gdata.Container(children)
 
 schema_namespaces: set[str] = {
     'http://yang.juniper.net/junos/conf/protocols',

--- a/src/respnet/layers/base_0.act
+++ b/src/respnet/layers/base_0.act
@@ -12,6 +12,10 @@ from respnet.layers.y_0 import netinfra__netinfra__router_entry
 from respnet.layers.y_0 import netinfra__netinfra__backbone_link_entry
 from respnet.layers.y_0 import ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry
 from respnet.layers.y_0 import ietf_l3vpn_svc__l3vpn_svc__sites__site_entry
+from respnet.layers.y_0 import from_xml_netinfra__netinfra__router_element
+from respnet.layers.y_0 import from_xml_netinfra__netinfra__backbone_link_element
+from respnet.layers.y_0 import from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element
+from respnet.layers.y_0 import from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site_element
 from respnet.layers.y_1_loose import root as output_root
 
 def o_root():
@@ -37,7 +41,8 @@ class Router(ttt.TransformFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = netinfra__netinfra__router_entry.from_xml(i)
+        gdata_input = from_xml_netinfra__netinfra__router_element(i)
+        modeled_input = netinfra__netinfra__router_entry.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()
 
 class BBLink(ttt.TransformFunction):
@@ -59,7 +64,8 @@ class BBLink(ttt.TransformFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = netinfra__netinfra__backbone_link_entry.from_xml(i)
+        gdata_input = from_xml_netinfra__netinfra__backbone_link_element(i)
+        modeled_input = netinfra__netinfra__backbone_link_entry.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()
 
 class L3VpnVpnService(ttt.TransformFunction):
@@ -81,7 +87,8 @@ class L3VpnVpnService(ttt.TransformFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_xml(i)
+        gdata_input = from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(i)
+        modeled_input = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()
 
 class L3VpnSite(ttt.TransformFunction):
@@ -103,5 +110,6 @@ class L3VpnSite(ttt.TransformFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_xml(i)
+        gdata_input = from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(i)
+        modeled_input = ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()

--- a/src/respnet/layers/base_1.act
+++ b/src/respnet/layers/base_1.act
@@ -12,6 +12,10 @@ from respnet.layers.y_1 import netinfra_inter__netinfra__router_entry
 from respnet.layers.y_1 import netinfra_inter__netinfra__backbone_link_entry
 from respnet.layers.y_1 import netinfra_inter__netinfra__ibgp_fullmesh_entry
 from respnet.layers.y_1 import l3vpn_inter__l3vpns__l3vpn_entry
+from respnet.layers.y_1 import from_xml_netinfra_inter__netinfra__router_element
+from respnet.layers.y_1 import from_xml_netinfra_inter__netinfra__backbone_link_element
+from respnet.layers.y_1 import from_xml_netinfra_inter__netinfra__ibgp_fullmesh_element
+from respnet.layers.y_1 import from_xml_l3vpn_inter__l3vpns__l3vpn_element
 from respnet.layers.y_2_loose import root as output_root
 
 def o_root():
@@ -37,7 +41,8 @@ class Router(ttt.TransformFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = netinfra_inter__netinfra__router_entry.from_xml(i)
+        gdata_input = from_xml_netinfra_inter__netinfra__router_element(i)
+        modeled_input = netinfra_inter__netinfra__router_entry.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()
 
 class BBLink(ttt.TransformFunction):
@@ -59,7 +64,8 @@ class BBLink(ttt.TransformFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = netinfra_inter__netinfra__backbone_link_entry.from_xml(i)
+        gdata_input = from_xml_netinfra_inter__netinfra__backbone_link_element(i)
+        modeled_input = netinfra_inter__netinfra__backbone_link_entry.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()
 
 class IbgpFullmesh(ttt.TransformFunction):
@@ -81,7 +87,8 @@ class IbgpFullmesh(ttt.TransformFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = netinfra_inter__netinfra__ibgp_fullmesh_entry.from_xml(i)
+        gdata_input = from_xml_netinfra_inter__netinfra__ibgp_fullmesh_element(i)
+        modeled_input = netinfra_inter__netinfra__ibgp_fullmesh_entry.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()
 
 class L3Vpn(ttt.TransformFunction):
@@ -103,5 +110,6 @@ class L3Vpn(ttt.TransformFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = l3vpn_inter__l3vpns__l3vpn_entry.from_xml(i)
+        gdata_input = from_xml_l3vpn_inter__l3vpns__l3vpn_element(i)
+        modeled_input = l3vpn_inter__l3vpns__l3vpn_entry.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()

--- a/src/respnet/layers/base_2.act
+++ b/src/respnet/layers/base_2.act
@@ -14,6 +14,12 @@ from respnet.layers.y_2 import orchestron_rfs__rfs__ibgp_neighbor_entry
 from respnet.layers.y_2 import orchestron_rfs__rfs__vrf_entry
 from respnet.layers.y_2 import orchestron_rfs__rfs__vrf_interface_entry
 from respnet.layers.y_2 import orchestron_rfs__rfs__ebgp_customer_entry
+from respnet.layers.y_2 import from_xml_orchestron_rfs__rfs__base_config_element
+from respnet.layers.y_2 import from_xml_orchestron_rfs__rfs__backbone_interface_element
+from respnet.layers.y_2 import from_xml_orchestron_rfs__rfs__ibgp_neighbor_element
+from respnet.layers.y_2 import from_xml_orchestron_rfs__rfs__vrf_element
+from respnet.layers.y_2 import from_xml_orchestron_rfs__rfs__vrf_interface_element
+from respnet.layers.y_2 import from_xml_orchestron_rfs__rfs__ebgp_customer_element
 from respnet.layers.y_3_loose import root as output_root
 
 def o_root():
@@ -39,7 +45,8 @@ class BaseConfig(ttt.RFSFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = orchestron_rfs__rfs__base_config_entry.from_xml(i)
+        gdata_input = from_xml_orchestron_rfs__rfs__base_config_element(i)
+        modeled_input = orchestron_rfs__rfs__base_config_entry.from_gdata(gdata_input)
         return self.transform(modeled_input, device_info).to_gdata()
 
 class BBInterface(ttt.RFSFunction):
@@ -61,7 +68,8 @@ class BBInterface(ttt.RFSFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = orchestron_rfs__rfs__backbone_interface_entry.from_xml(i)
+        gdata_input = from_xml_orchestron_rfs__rfs__backbone_interface_element(i)
+        modeled_input = orchestron_rfs__rfs__backbone_interface_entry.from_gdata(gdata_input)
         return self.transform(modeled_input, device_info).to_gdata()
 
 class IbgpNeighbor(ttt.RFSFunction):
@@ -83,7 +91,8 @@ class IbgpNeighbor(ttt.RFSFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = orchestron_rfs__rfs__ibgp_neighbor_entry.from_xml(i)
+        gdata_input = from_xml_orchestron_rfs__rfs__ibgp_neighbor_element(i)
+        modeled_input = orchestron_rfs__rfs__ibgp_neighbor_entry.from_gdata(gdata_input)
         return self.transform(modeled_input, device_info).to_gdata()
 
 class Vrf(ttt.RFSFunction):
@@ -105,7 +114,8 @@ class Vrf(ttt.RFSFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = orchestron_rfs__rfs__vrf_entry.from_xml(i)
+        gdata_input = from_xml_orchestron_rfs__rfs__vrf_element(i)
+        modeled_input = orchestron_rfs__rfs__vrf_entry.from_gdata(gdata_input)
         return self.transform(modeled_input, device_info).to_gdata()
 
 class VrfInterface(ttt.RFSFunction):
@@ -127,7 +137,8 @@ class VrfInterface(ttt.RFSFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = orchestron_rfs__rfs__vrf_interface_entry.from_xml(i)
+        gdata_input = from_xml_orchestron_rfs__rfs__vrf_interface_element(i)
+        modeled_input = orchestron_rfs__rfs__vrf_interface_entry.from_gdata(gdata_input)
         return self.transform(modeled_input, device_info).to_gdata()
 
 class EbgpCustomer(ttt.RFSFunction):
@@ -149,5 +160,6 @@ class EbgpCustomer(ttt.RFSFunction):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
-        modeled_input = orchestron_rfs__rfs__ebgp_customer_entry.from_xml(i)
+        gdata_input = from_xml_orchestron_rfs__rfs__ebgp_customer_element(i)
+        modeled_input = orchestron_rfs__rfs__ebgp_customer_entry.from_gdata(gdata_input)
         return self.transform(modeled_input, device_info).to_gdata()

--- a/src/respnet/layers/t_0.act
+++ b/src/respnet/layers/t_0.act
@@ -9,11 +9,6 @@ import orchestron.ttt as ttt
 import yang.adata
 import yang.gdata
 
-from respnet.layers.y_0 import netinfra__netinfra__router_entry
-from respnet.layers.y_0 import netinfra__netinfra__backbone_link_entry
-from respnet.layers.y_0 import ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry
-from respnet.layers.y_0 import ietf_l3vpn_svc__l3vpn_svc__sites__site_entry
-
 import respnet.cfs
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:

--- a/src/respnet/layers/t_1.act
+++ b/src/respnet/layers/t_1.act
@@ -9,11 +9,6 @@ import orchestron.ttt as ttt
 import yang.adata
 import yang.gdata
 
-from respnet.layers.y_1 import netinfra_inter__netinfra__router_entry
-from respnet.layers.y_1 import netinfra_inter__netinfra__backbone_link_entry
-from respnet.layers.y_1 import netinfra_inter__netinfra__ibgp_fullmesh_entry
-from respnet.layers.y_1 import l3vpn_inter__l3vpns__l3vpn_entry
-
 import respnet.inter
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:

--- a/src/respnet/layers/t_2.act
+++ b/src/respnet/layers/t_2.act
@@ -9,13 +9,6 @@ import orchestron.ttt as ttt
 import yang.adata
 import yang.gdata
 
-from respnet.layers.y_2 import orchestron_rfs__rfs__base_config_entry
-from respnet.layers.y_2 import orchestron_rfs__rfs__backbone_interface_entry
-from respnet.layers.y_2 import orchestron_rfs__rfs__ibgp_neighbor_entry
-from respnet.layers.y_2 import orchestron_rfs__rfs__vrf_entry
-from respnet.layers.y_2 import orchestron_rfs__rfs__vrf_interface_entry
-from respnet.layers.y_2 import orchestron_rfs__rfs__ebgp_customer_entry
-
 import respnet.rfs
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:

--- a/src/respnet/layers/t_3.act
+++ b/src/respnet/layers/t_3.act
@@ -11,7 +11,6 @@ import yang.gdata
 
 
 
-
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
     r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler))}, ns='http://orchestron.org/yang/orchestron-device.yang')}, ns='')
     return r

--- a/src/respnet/layers/y_0.act
+++ b/src/respnet/layers/y_0.act
@@ -10,16 +10,31 @@ import yang.gdata
 mut def from_json_netinfra__netinfra__router__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra__netinfra__router__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__router__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_netinfra__netinfra__router__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 mut def from_json_netinfra__netinfra__router__role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra__netinfra__router__role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__router__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_netinfra__netinfra__router__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_netinfra__netinfra__router__mock(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_netinfra__netinfra__router__mock(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 class netinfra__netinfra__router_entry(yang.adata.MNode):
@@ -60,10 +75,6 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
         return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), role=n.get_opt_str('role'), asn=n.get_int('asn'), mock=n.get_opt_str('mock'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra__netinfra__router_entry:
-        return netinfra__netinfra__router_entry(name=yang.gdata.from_xml_str(n, 'name'), id=yang.gdata.from_xml_int(n, 'id'), role=yang.gdata.from_xml_opt_str(n, 'role'), asn=yang.gdata.from_xml_int(n, 'asn'), mock=yang.gdata.from_xml_opt_str(n, 'mock'))
-
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -100,13 +111,26 @@ class netinfra__netinfra__router(yang.adata.MNode):
                 res.append(netinfra__netinfra__router_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra__netinfra__router_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra__netinfra__router_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra__netinfra__router_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_netinfra__netinfra__router__name, child_name)
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_netinfra__netinfra__router__id, child_id)
+    child_role = yang.gdata.from_xml_opt_str(node, 'role')
+    yang.gdata.maybe_add(children, 'role', from_xml_netinfra__netinfra__router__role, child_role)
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_netinfra__netinfra__router__asn, child_asn)
+    child_mock = yang.gdata.from_xml_opt_str(node, 'mock')
+    yang.gdata.maybe_add(children, 'mock', from_xml_netinfra__netinfra__router__mock, child_mock)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_netinfra__netinfra__router(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra__netinfra__router_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_netinfra__netinfra__router_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -185,13 +209,25 @@ mut def from_json_netinfra__netinfra__router(jd: list[dict[str, ?value]]) -> yan
 mut def from_json_netinfra__netinfra__backbone_link__left_router(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra__netinfra__backbone_link__left_router(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__backbone_link__left_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra__netinfra__backbone_link__left_interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_netinfra__netinfra__backbone_link__right_router(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra__netinfra__backbone_link__right_router(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__backbone_link__right_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra__netinfra__backbone_link__right_interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
@@ -226,10 +262,6 @@ class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__backbone_link_entry:
         return netinfra__netinfra__backbone_link_entry(left_router=n.get_str('left-router'), left_interface=n.get_str('left-interface'), right_router=n.get_str('right-router'), right_interface=n.get_str('right-interface'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra__netinfra__backbone_link_entry:
-        return netinfra__netinfra__backbone_link_entry(left_router=yang.gdata.from_xml_str(n, 'left-router'), left_interface=yang.gdata.from_xml_str(n, 'left-interface'), right_router=yang.gdata.from_xml_str(n, 'right-router'), right_interface=yang.gdata.from_xml_str(n, 'right-interface'))
 
 class netinfra__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra__netinfra__backbone_link_entry]
@@ -276,13 +308,24 @@ class netinfra__netinfra__backbone_link(yang.adata.MNode):
                 res.append(netinfra__netinfra__backbone_link_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra__netinfra__backbone_link_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra__netinfra__backbone_link_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra__netinfra__backbone_link_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_left_router = yang.gdata.from_xml_str(node, 'left-router')
+    yang.gdata.maybe_add(children, 'left-router', from_xml_netinfra__netinfra__backbone_link__left_router, child_left_router)
+    child_left_interface = yang.gdata.from_xml_str(node, 'left-interface')
+    yang.gdata.maybe_add(children, 'left-interface', from_xml_netinfra__netinfra__backbone_link__left_interface, child_left_interface)
+    child_right_router = yang.gdata.from_xml_str(node, 'right-router')
+    yang.gdata.maybe_add(children, 'right-router', from_xml_netinfra__netinfra__backbone_link__right_router, child_right_router)
+    child_right_interface = yang.gdata.from_xml_str(node, 'right-interface')
+    yang.gdata.maybe_add(children, 'right-interface', from_xml_netinfra__netinfra__backbone_link__right_interface, child_right_interface)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_left_router), yang.gdata.yang_str(child_left_interface), yang.gdata.yang_str(child_right_router), yang.gdata.yang_str(child_right_interface)])
+
+mut def from_xml_netinfra__netinfra__backbone_link(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra__netinfra__backbone_link_element(e))
+    return yang.gdata.List(keys=['left-router', 'left-interface', 'right-router', 'right-interface'], elements=elements)
 
 mut def from_json_path_netinfra__netinfra__backbone_link_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -376,12 +419,14 @@ class netinfra__netinfra(yang.adata.MNode):
             return netinfra__netinfra(router=netinfra__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')))
         return netinfra__netinfra()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> netinfra__netinfra:
-        if n != None:
-            return netinfra__netinfra(router=netinfra__netinfra__router.from_xml(yang.gdata.get_xml_children(n, 'router')), backbone_link=netinfra__netinfra__backbone_link.from_xml(yang.gdata.get_xml_children(n, 'backbone-link')))
-        return netinfra__netinfra()
 
+mut def from_xml_netinfra__netinfra(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_router = yang.gdata.from_xml_opt_list(node, 'router')
+    yang.gdata.maybe_add(children, 'router', from_xml_netinfra__netinfra__router, child_router)
+    child_backbone_link = yang.gdata.from_xml_opt_list(node, 'backbone-link')
+    yang.gdata.maybe_add(children, 'backbone-link', from_xml_netinfra__netinfra__backbone_link, child_backbone_link)
+    return yang.gdata.Container(children, ns='http://example.com/netinfra', module='netinfra')
 
 mut def from_json_path_netinfra__netinfra(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -414,6 +459,9 @@ mut def from_json_netinfra__netinfra(jd: dict[str, ?value]) -> yang.gdata.Contai
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -431,10 +479,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(id=n.get_str('id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(id=yang.gdata.from_xml_str(n, 'id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]
@@ -472,13 +516,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -541,6 +590,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -558,10 +610,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(id=n.get_str('id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(id=yang.gdata.from_xml_str(n, 'id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]
@@ -599,13 +647,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -668,6 +721,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -685,10 +741,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(id=n.get_str('id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(id=yang.gdata.from_xml_str(n, 'id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]
@@ -726,13 +778,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -795,6 +852,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -812,10 +872,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(id=n.get_str('id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(id=yang.gdata.from_xml_str(n, 'id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]
@@ -853,13 +909,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -954,12 +1015,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(cloud_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier.from_gdata(n.get_opt_list('cloud-identifier')), encryption_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier.from_gdata(n.get_opt_list('encryption-profile-identifier')), qos_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier.from_gdata(n.get_opt_list('qos-profile-identifier')), bfd_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier.from_gdata(n.get_opt_list('bfd-profile-identifier')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(cloud_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier.from_xml(yang.gdata.get_xml_children(n, 'cloud-identifier')), encryption_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier.from_xml(yang.gdata.get_xml_children(n, 'encryption-profile-identifier')), qos_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier.from_xml(yang.gdata.get_xml_children(n, 'qos-profile-identifier')), bfd_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier.from_xml(yang.gdata.get_xml_children(n, 'bfd-profile-identifier')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cloud_identifier = yang.gdata.from_xml_opt_list(node, 'cloud-identifier')
+    yang.gdata.maybe_add(children, 'cloud-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier, child_cloud_identifier)
+    child_encryption_profile_identifier = yang.gdata.from_xml_opt_list(node, 'encryption-profile-identifier')
+    yang.gdata.maybe_add(children, 'encryption-profile-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier, child_encryption_profile_identifier)
+    child_qos_profile_identifier = yang.gdata.from_xml_opt_list(node, 'qos-profile-identifier')
+    yang.gdata.maybe_add(children, 'qos-profile-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier, child_qos_profile_identifier)
+    child_bfd_profile_identifier = yang.gdata.from_xml_opt_list(node, 'bfd-profile-identifier')
+    yang.gdata.maybe_add(children, 'bfd-profile-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier, child_bfd_profile_identifier)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1019,12 +1086,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(valid_provider_identifiers=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_gdata(n.get_opt_container('valid-provider-identifiers')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(valid_provider_identifiers=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_xml(yang.gdata.get_xml_opt_child(n, 'valid-provider-identifiers')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_valid_provider_identifiers = yang.gdata.from_xml_opt_cnt(node, 'valid-provider-identifiers')
+    yang.gdata.maybe_add(children, 'valid-provider-identifiers', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers, child_valid_provider_identifiers)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1052,28 +1119,55 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(jd: dict[str, ?value])
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__customer_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__customer_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_service_topology(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_service_topology(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__cloud_identifier(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__cloud_identifier(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_any(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_any(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_site(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('leafref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_site(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('leafref', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__deny_site(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__deny_site(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__nat44_customer_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__nat44_customer_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(yang.adata.MNode):
@@ -1101,12 +1195,14 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(enabled=n.get_opt_bool('enabled'), nat44_customer_address=n.get_opt_str('nat44-customer-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), nat44_customer_address=yang.gdata.from_xml_opt_str(n, 'nat44-customer-address'))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__enabled, child_enabled)
+    child_nat44_customer_address = yang.gdata.from_xml_opt_str(node, 'nat44-customer-address')
+    yang.gdata.maybe_add(children, 'nat44-customer-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__nat44_customer_address, child_nat44_customer_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1154,12 +1250,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(nat44=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_gdata(n.get_opt_container('nat44')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(nat44=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_xml(yang.gdata.get_xml_opt_child(n, 'nat44')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_nat44 = yang.gdata.from_xml_opt_cnt(node, 'nat44')
+    yang.gdata.maybe_add(children, 'nat44', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44, child_nat44)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1218,10 +1314,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry(cloud_identifier=n.get_str('cloud-identifier'), permit_any=n.get_opt_bool('permit-any'), permit_site=n.get_opt_strs('permit-site'), deny_site=n.get_opt_strs('deny-site'), address_translation=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation.from_gdata(n.get_opt_container('address-translation')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry(cloud_identifier=yang.gdata.from_xml_str(n, 'cloud-identifier'), permit_any=yang.gdata.from_xml_opt_bool(n, 'permit-any'), permit_site=yang.gdata.from_xml_opt_strs(n, 'permit-site'), deny_site=yang.gdata.from_xml_opt_strs(n, 'deny-site'), address_translation=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation.from_xml(yang.gdata.get_xml_opt_child(n, 'address-translation')))
-
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]
     mut def __init__(self, elements=[]):
@@ -1258,13 +1350,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_cloud_identifier = yang.gdata.from_xml_str(node, 'cloud-identifier')
+    yang.gdata.maybe_add(children, 'cloud-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__cloud_identifier, child_cloud_identifier)
+    child_permit_any = yang.gdata.from_xml_opt_bool(node, 'permit-any')
+    yang.gdata.maybe_add(children, 'permit-any', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_any, child_permit_any)
+    child_permit_site = yang.gdata.from_xml_opt_strs(node, 'permit-site')
+    yang.gdata.maybe_add(children, 'permit-site', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_site, child_permit_site)
+    child_deny_site = yang.gdata.from_xml_opt_strs(node, 'deny-site')
+    yang.gdata.maybe_add(children, 'deny-site', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__deny_site, child_deny_site)
+    child_address_translation = yang.gdata.from_xml_opt_cnt(node, 'address-translation')
+    yang.gdata.maybe_add(children, 'address-translation', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation, child_address_translation)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_cloud_identifier)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_element(e))
+    return yang.gdata.List(keys=['cloud-identifier'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1360,12 +1465,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(cloud_access=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access.from_gdata(n.get_opt_list('cloud-access')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(cloud_access=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access.from_xml(yang.gdata.get_xml_children(n, 'cloud-access')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cloud_access = yang.gdata.from_xml_opt_list(node, 'cloud-access')
+    yang.gdata.maybe_add(children, 'cloud-access', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access, child_cloud_access)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1393,7 +1498,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_ac
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors__tree_flavor(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors__tree_flavor(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('identityref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(yang.adata.MNode):
@@ -1414,12 +1525,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(tree_flavor=n.get_opt_strs('tree-flavor'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(tree_flavor=yang.gdata.from_xml_opt_strs(n, 'tree-flavor'))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_tree_flavor = yang.gdata.from_xml_opt_strs(node, 'tree-flavor')
+    yang.gdata.maybe_add(children, 'tree-flavor', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors__tree_flavor, child_tree_flavor)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1446,13 +1557,25 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__rp_redundancy(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__rp_redundancy(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__optimal_traffic_delivery(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__optimal_traffic_delivery(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(yang.adata.MNode):
@@ -1485,12 +1608,16 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(enabled=n.get_opt_bool('enabled'), rp_redundancy=n.get_opt_bool('rp-redundancy'), optimal_traffic_delivery=n.get_opt_bool('optimal-traffic-delivery'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), rp_redundancy=yang.gdata.from_xml_opt_bool(n, 'rp-redundancy'), optimal_traffic_delivery=yang.gdata.from_xml_opt_bool(n, 'optimal-traffic-delivery'))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__enabled, child_enabled)
+    child_rp_redundancy = yang.gdata.from_xml_opt_bool(node, 'rp-redundancy')
+    yang.gdata.maybe_add(children, 'rp-redundancy', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__rp_redundancy, child_rp_redundancy)
+    child_optimal_traffic_delivery = yang.gdata.from_xml_opt_bool(node, 'optimal-traffic-delivery')
+    yang.gdata.maybe_add(children, 'optimal-traffic-delivery', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__optimal_traffic_delivery, child_optimal_traffic_delivery)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1525,16 +1652,31 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__rp_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__rp_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_start(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_start(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_end(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_end(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(yang.adata.MNode):
@@ -1569,10 +1711,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(id=n.get_int('id'), group_address=n.get_opt_str('group-address'), group_start=n.get_opt_str('group-start'), group_end=n.get_opt_str('group-end'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(id=yang.gdata.from_xml_int(n, 'id'), group_address=yang.gdata.from_xml_opt_str(n, 'group-address'), group_start=yang.gdata.from_xml_opt_str(n, 'group-start'), group_end=yang.gdata.from_xml_opt_str(n, 'group-end'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]
@@ -1610,13 +1748,24 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__id, child_id)
+    child_group_address = yang.gdata.from_xml_opt_str(node, 'group-address')
+    yang.gdata.maybe_add(children, 'group-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_address, child_group_address)
+    child_group_start = yang.gdata.from_xml_opt_str(node, 'group-start')
+    yang.gdata.maybe_add(children, 'group-start', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_start, child_group_start)
+    child_group_end = yang.gdata.from_xml_opt_str(node, 'group-end')
+    yang.gdata.maybe_add(children, 'group-end', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_end, child_group_end)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1708,12 +1857,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(group=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(group=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group, child_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1771,10 +1920,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry(id=n.get_int('id'), provider_managed=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed.from_gdata(n.get_opt_container('provider-managed')), rp_address=n.get_str('rp-address'), groups=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups.from_gdata(n.get_opt_container('groups')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry(id=yang.gdata.from_xml_int(n, 'id'), provider_managed=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed.from_xml(yang.gdata.get_xml_opt_child(n, 'provider-managed')), rp_address=yang.gdata.from_xml_str(n, 'rp-address'), groups=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups.from_xml(yang.gdata.get_xml_opt_child(n, 'groups')))
-
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]
     mut def __init__(self, elements=[]):
@@ -1811,13 +1956,24 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__id, child_id)
+    child_provider_managed = yang.gdata.from_xml_opt_cnt(node, 'provider-managed')
+    yang.gdata.maybe_add(children, 'provider-managed', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed, child_provider_managed)
+    child_rp_address = yang.gdata.from_xml_str(node, 'rp-address')
+    yang.gdata.maybe_add(children, 'rp-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__rp_address, child_rp_address)
+    child_groups = yang.gdata.from_xml_opt_cnt(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups, child_groups)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1909,12 +2065,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(rp_group_mapping=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping.from_gdata(n.get_opt_list('rp-group-mapping')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(rp_group_mapping=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping.from_xml(yang.gdata.get_xml_children(n, 'rp-group-mapping')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rp_group_mapping = yang.gdata.from_xml_opt_list(node, 'rp-group-mapping')
+    yang.gdata.maybe_add(children, 'rp-group-mapping', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping, child_rp_group_mapping)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1942,7 +2098,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__rp_discovery_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__rp_discovery_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates__bsr_candidate_address(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates__bsr_candidate_address(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(yang.adata.MNode):
@@ -1963,12 +2125,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(bsr_candidate_address=n.get_opt_strs('bsr-candidate-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(bsr_candidate_address=yang.gdata.from_xml_opt_strs(n, 'bsr-candidate-address'))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bsr_candidate_address = yang.gdata.from_xml_opt_strs(node, 'bsr-candidate-address')
+    yang.gdata.maybe_add(children, 'bsr-candidate-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates__bsr_candidate_address, child_bsr_candidate_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2017,12 +2179,14 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(rp_discovery_type=n.get_opt_str('rp-discovery-type'), bsr_candidates=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_gdata(n.get_opt_container('bsr-candidates')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(rp_discovery_type=yang.gdata.from_xml_opt_str(n, 'rp-discovery-type'), bsr_candidates=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_xml(yang.gdata.get_xml_opt_child(n, 'bsr-candidates')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rp_discovery_type = yang.gdata.from_xml_opt_str(node, 'rp-discovery-type')
+    yang.gdata.maybe_add(children, 'rp-discovery-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__rp_discovery_type, child_rp_discovery_type)
+    child_bsr_candidates = yang.gdata.from_xml_opt_cnt(node, 'bsr-candidates')
+    yang.gdata.maybe_add(children, 'bsr-candidates', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates, child_bsr_candidates)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2076,12 +2240,14 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(rp_group_mappings=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_gdata(n.get_opt_container('rp-group-mappings')), rp_discovery=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_gdata(n.get_opt_container('rp-discovery')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(rp_group_mappings=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_xml(yang.gdata.get_xml_opt_child(n, 'rp-group-mappings')), rp_discovery=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_xml(yang.gdata.get_xml_opt_child(n, 'rp-discovery')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rp_group_mappings = yang.gdata.from_xml_opt_cnt(node, 'rp-group-mappings')
+    yang.gdata.maybe_add(children, 'rp-group-mappings', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings, child_rp_group_mappings)
+    child_rp_discovery = yang.gdata.from_xml_opt_cnt(node, 'rp-discovery')
+    yang.gdata.maybe_add(children, 'rp-discovery', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery, child_rp_discovery)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2141,12 +2307,16 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(enabled=n.get_opt_bool('enabled'), customer_tree_flavors=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_gdata(n.get_opt_container('customer-tree-flavors')), rp=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_gdata(n.get_opt_container('rp')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), customer_tree_flavors=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-tree-flavors')), rp=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_xml(yang.gdata.get_xml_opt_child(n, 'rp')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__enabled, child_enabled)
+    child_customer_tree_flavors = yang.gdata.from_xml_opt_cnt(node, 'customer-tree-flavors')
+    yang.gdata.maybe_add(children, 'customer-tree-flavors', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors, child_customer_tree_flavors)
+    child_rp = yang.gdata.from_xml_opt_cnt(node, 'rp')
+    yang.gdata.maybe_add(children, 'rp', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp, child_rp)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2183,10 +2353,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__carrierscarrier(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__carrierscarrier(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__local_sites_role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__local_sites_role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(yang.adata.MNode):
@@ -2211,10 +2390,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(vpn_id=n.get_str('vpn-id'), local_sites_role=n.get_opt_str('local-sites-role'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(vpn_id=yang.gdata.from_xml_str(n, 'vpn-id'), local_sites_role=yang.gdata.from_xml_opt_str(n, 'local-sites-role'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]
@@ -2252,13 +2427,20 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_id = yang.gdata.from_xml_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__vpn_id, child_vpn_id)
+    child_local_sites_role = yang.gdata.from_xml_opt_str(node, 'local-sites-role')
+    yang.gdata.maybe_add(children, 'local-sites-role', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__local_sites_role, child_local_sites_role)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_element(e))
+    return yang.gdata.List(keys=['vpn-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2342,12 +2524,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(extranet_vpn=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn.from_gdata(n.get_opt_list('extranet-vpn')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(extranet_vpn=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn.from_xml(yang.gdata.get_xml_children(n, 'extranet-vpn')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_extranet_vpn = yang.gdata.from_xml_opt_list(node, 'extranet-vpn')
+    yang.gdata.maybe_add(children, 'extranet-vpn', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn, child_extranet_vpn)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2420,10 +2602,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(vpn_id=n.get_str('vpn-id'), customer_name=n.get_opt_str('customer-name'), vpn_service_topology=n.get_opt_str('vpn-service-topology'), cloud_accesses=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses.from_gdata(n.get_opt_container('cloud-accesses')), multicast=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast.from_gdata(n.get_opt_container('multicast')), carrierscarrier=n.get_opt_bool('carrierscarrier'), extranet_vpns=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns.from_gdata(n.get_opt_container('extranet-vpns')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(vpn_id=yang.gdata.from_xml_str(n, 'vpn-id'), customer_name=yang.gdata.from_xml_opt_str(n, 'customer-name'), vpn_service_topology=yang.gdata.from_xml_opt_str(n, 'vpn-service-topology'), cloud_accesses=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses.from_xml(yang.gdata.get_xml_opt_child(n, 'cloud-accesses')), multicast=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')), carrierscarrier=yang.gdata.from_xml_opt_bool(n, 'carrierscarrier'), extranet_vpns=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns.from_xml(yang.gdata.get_xml_opt_child(n, 'extranet-vpns')))
-
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]
     mut def __init__(self, elements=[]):
@@ -2460,13 +2638,30 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(yang.adata.MNode):
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_id = yang.gdata.from_xml_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_id, child_vpn_id)
+    child_customer_name = yang.gdata.from_xml_opt_str(node, 'customer-name')
+    yang.gdata.maybe_add(children, 'customer-name', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__customer_name, child_customer_name)
+    child_vpn_service_topology = yang.gdata.from_xml_opt_str(node, 'vpn-service-topology')
+    yang.gdata.maybe_add(children, 'vpn-service-topology', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_service_topology, child_vpn_service_topology)
+    child_cloud_accesses = yang.gdata.from_xml_opt_cnt(node, 'cloud-accesses')
+    yang.gdata.maybe_add(children, 'cloud-accesses', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses, child_cloud_accesses)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast, child_multicast)
+    child_carrierscarrier = yang.gdata.from_xml_opt_bool(node, 'carrierscarrier')
+    yang.gdata.maybe_add(children, 'carrierscarrier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__carrierscarrier, child_carrierscarrier)
+    child_extranet_vpns = yang.gdata.from_xml_opt_cnt(node, 'extranet-vpns')
+    yang.gdata.maybe_add(children, 'extranet-vpns', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns, child_extranet_vpns)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(e))
+    return yang.gdata.List(keys=['vpn-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2570,12 +2765,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services(vpn_service=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service.from_gdata(n.get_opt_list('vpn-service')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services(vpn_service=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service.from_xml(yang.gdata.get_xml_children(n, 'vpn-service')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vpn_service = yang.gdata.from_xml_opt_list(node, 'vpn-service')
+    yang.gdata.maybe_add(children, 'vpn-service', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service, child_vpn_service)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2603,28 +2798,55 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services(jd: dict[str, ?value])
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_start(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_start(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_stop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_stop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__location_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__location_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__postal_code(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__postal_code(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__state(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__state(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__city(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__city(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__country_code(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__country_code(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.adata.MNode):
@@ -2670,10 +2892,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.ada
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(location_id=n.get_str('location-id'), address=n.get_opt_str('address'), postal_code=n.get_opt_str('postal-code'), state=n.get_opt_str('state'), city=n.get_opt_str('city'), country_code=n.get_opt_str('country-code'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(location_id=yang.gdata.from_xml_str(n, 'location-id'), address=yang.gdata.from_xml_opt_str(n, 'address'), postal_code=yang.gdata.from_xml_opt_str(n, 'postal-code'), state=yang.gdata.from_xml_opt_str(n, 'state'), city=yang.gdata.from_xml_opt_str(n, 'city'), country_code=yang.gdata.from_xml_opt_str(n, 'country-code'))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]
     mut def __init__(self, elements=[]):
@@ -2710,13 +2928,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(yang.adata.MNo
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_location_id = yang.gdata.from_xml_str(node, 'location-id')
+    yang.gdata.maybe_add(children, 'location-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__location_id, child_location_id)
+    child_address = yang.gdata.from_xml_opt_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__address, child_address)
+    child_postal_code = yang.gdata.from_xml_opt_str(node, 'postal-code')
+    yang.gdata.maybe_add(children, 'postal-code', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__postal_code, child_postal_code)
+    child_state = yang.gdata.from_xml_opt_str(node, 'state')
+    yang.gdata.maybe_add(children, 'state', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__state, child_state)
+    child_city = yang.gdata.from_xml_opt_str(node, 'city')
+    yang.gdata.maybe_add(children, 'city', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__city, child_city)
+    child_country_code = yang.gdata.from_xml_opt_str(node, 'country-code')
+    yang.gdata.maybe_add(children, 'country-code', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__country_code, child_country_code)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_location_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_element(e))
+    return yang.gdata.List(keys=['location-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2816,12 +3049,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(location=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location.from_gdata(n.get_opt_list('location')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(location=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location.from_xml(yang.gdata.get_xml_children(n, 'location')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_location = yang.gdata.from_xml_opt_list(node, 'location')
+    yang.gdata.maybe_add(children, 'location', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location, child_location)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2849,13 +3082,25 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(jd: dict[str
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__device_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__device_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__location(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__location(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address_family(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address_family(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.adata.MNode):
@@ -2883,12 +3128,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(address_family=n.get_opt_str('address-family'), address=n.get_str('address'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(address_family=yang.gdata.from_xml_opt_str(n, 'address-family'), address=yang.gdata.from_xml_str(n, 'address'))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_str(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address_family, child_address_family)
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address, child_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2944,10 +3191,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.M
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(device_id=n.get_str('device-id'), location=n.get_str('location'), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management.from_gdata(n.get_container('management')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(device_id=yang.gdata.from_xml_str(n, 'device-id'), location=yang.gdata.from_xml_str(n, 'location'), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management.from_xml(yang.gdata.get_xml_child(n, 'management')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -2984,13 +3227,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(yang.adata.MNode):
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_device_id = yang.gdata.from_xml_str(node, 'device-id')
+    yang.gdata.maybe_add(children, 'device-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__device_id, child_device_id)
+    child_location = yang.gdata.from_xml_str(node, 'location')
+    yang.gdata.maybe_add(children, 'location', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__location, child_location)
+    child_management = yang.gdata.from_xml_cnt(node, 'management')
+    yang.gdata.maybe_add(children, 'management', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management, child_management)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_device_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_element(e))
+    return yang.gdata.List(keys=['device-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3078,12 +3330,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(device=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device.from_gdata(n.get_opt_list('device')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(device=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device.from_xml(yang.gdata.get_xml_children(n, 'device')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_device = yang.gdata.from_xml_opt_list(node, 'device')
+    yang.gdata.maybe_add(children, 'device', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device, child_device)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3111,6 +3363,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(jd: dict[str, 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(yang.adata.MNode):
     group_id: str
 
@@ -3128,10 +3383,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(group_id=n.get_str('group-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]
@@ -3169,13 +3420,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(yang
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group__group_id, child_group_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3255,12 +3511,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group, child_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3305,12 +3561,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_gdata(n.get_opt_container('groups')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_xml(yang.gdata.get_xml_opt_child(n, 'groups')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_groups = yang.gdata.from_xml_opt_cnt(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups, child_groups)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3338,6 +3594,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(jd: dic
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__management__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
     type: str
 
@@ -3358,12 +3617,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__management(type=n.get_str('type'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__management:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__management(type=yang.gdata.from_xml_str(n, 'type'))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_type = yang.gdata.from_xml_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management__type, child_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__management(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3390,19 +3649,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__management(jd: dict[st
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__vpn_policy_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__vpn_policy_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__lan_tag(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__lan_tag(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv4_lan_prefix(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv4_lan_prefix(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv6_lan_prefix(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv6_lan_prefix(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(yang.adata.MNode):
@@ -3431,10 +3708,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(type=n.get_str('type'), lan_tag=n.get_opt_strs('lan-tag'), ipv4_lan_prefix=n.get_opt_strs('ipv4-lan-prefix'), ipv6_lan_prefix=n.get_opt_strs('ipv6-lan-prefix'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(type=yang.gdata.from_xml_str(n, 'type'), lan_tag=yang.gdata.from_xml_opt_strs(n, 'lan-tag'), ipv4_lan_prefix=yang.gdata.from_xml_opt_strs(n, 'ipv4-lan-prefix'), ipv6_lan_prefix=yang.gdata.from_xml_opt_strs(n, 'ipv6-lan-prefix'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]
@@ -3472,13 +3745,24 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_type = yang.gdata.from_xml_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__type, child_type)
+    child_lan_tag = yang.gdata.from_xml_opt_strs(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__lan_tag, child_lan_tag)
+    child_ipv4_lan_prefix = yang.gdata.from_xml_opt_strs(node, 'ipv4-lan-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-lan-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv4_lan_prefix, child_ipv4_lan_prefix)
+    child_ipv6_lan_prefix = yang.gdata.from_xml_opt_strs(node, 'ipv6-lan-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-lan-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv6_lan_prefix, child_ipv6_lan_prefix)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_element(e))
+    return yang.gdata.List(keys=['type'], elements=elements, user_order=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3570,12 +3854,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(filter=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter.from_gdata(n.get_opt_list('filter')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(filter=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter.from_xml(yang.gdata.get_xml_children(n, 'filter')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_filter = yang.gdata.from_xml_opt_list(node, 'filter')
+    yang.gdata.maybe_add(children, 'filter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter, child_filter)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3603,7 +3887,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__site_role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__site_role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(yang.adata.MNode):
@@ -3628,10 +3918,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(vpn_id=n.get_str('vpn-id'), site_role=n.get_opt_str('site-role'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(vpn_id=yang.gdata.from_xml_str(n, 'vpn-id'), site_role=yang.gdata.from_xml_opt_str(n, 'site-role'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]
@@ -3669,13 +3955,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_id = yang.gdata.from_xml_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__vpn_id, child_vpn_id)
+    child_site_role = yang.gdata.from_xml_opt_str(node, 'site-role')
+    yang.gdata.maybe_add(children, 'site-role', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__site_role, child_site_role)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_element(e))
+    return yang.gdata.List(keys=['vpn-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3767,10 +4060,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry(id=n.get_str('id'), filters=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters.from_gdata(n.get_opt_container('filters')), vpn=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn.from_gdata(n.get_opt_list('vpn')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry(id=yang.gdata.from_xml_str(n, 'id'), filters=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters.from_xml(yang.gdata.get_xml_opt_child(n, 'filters')), vpn=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn.from_xml(yang.gdata.get_xml_children(n, 'vpn')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]
     mut def __init__(self, elements=[]):
@@ -3807,13 +4096,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__id, child_id)
+    child_filters = yang.gdata.from_xml_opt_cnt(node, 'filters')
+    yang.gdata.maybe_add(children, 'filters', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters, child_filters)
+    child_vpn = yang.gdata.from_xml_opt_list(node, 'vpn')
+    yang.gdata.maybe_add(children, 'vpn', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn, child_vpn)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3904,10 +4202,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yan
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(vpn_policy_id=n.get_str('vpn-policy-id'), entries=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries.from_gdata(n.get_opt_list('entries')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(vpn_policy_id=yang.gdata.from_xml_str(n, 'vpn-policy-id'), entries=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries.from_xml(yang.gdata.get_xml_children(n, 'entries')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]
     mut def __init__(self, elements=[]):
@@ -3944,13 +4238,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(yang.adat
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_policy_id = yang.gdata.from_xml_str(node, 'vpn-policy-id')
+    yang.gdata.maybe_add(children, 'vpn-policy-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__vpn_policy_id, child_vpn_policy_id)
+    child_entries = yang.gdata.from_xml_opt_list(node, 'entries')
+    yang.gdata.maybe_add(children, 'entries', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries, child_entries)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_policy_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_element(e))
+    return yang.gdata.List(keys=['vpn-policy-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -4034,12 +4335,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(vpn_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy.from_gdata(n.get_opt_list('vpn-policy')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(vpn_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy.from_xml(yang.gdata.get_xml_children(n, 'vpn-policy')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vpn_policy = yang.gdata.from_xml_opt_list(node, 'vpn-policy')
+    yang.gdata.maybe_add(children, 'vpn-policy', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy, child_vpn_policy)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4067,10 +4368,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(jd: dict[
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_vpn_flavor(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_vpn_flavor(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__af(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__af(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__maximum_routes(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__maximum_routes(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(yang.adata.MNode):
@@ -4095,10 +4405,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_ent
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(af=n.get_str('af'), maximum_routes=n.get_opt_int('maximum-routes'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(af=yang.gdata.from_xml_str(n, 'af'), maximum_routes=yang.gdata.from_xml_opt_int(n, 'maximum-routes'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]
@@ -4136,13 +4442,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(yan
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af = yang.gdata.from_xml_str(node, 'af')
+    yang.gdata.maybe_add(children, 'af', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__af, child_af)
+    child_maximum_routes = yang.gdata.from_xml_opt_int(node, 'maximum-routes')
+    yang.gdata.maybe_add(children, 'maximum-routes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__maximum_routes, child_maximum_routes)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_element(e))
+    return yang.gdata.List(keys=['af'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -4226,12 +4539,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family.from_gdata(n.get_opt_list('address-family')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4272,12 +4585,10 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adat
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4300,16 +4611,31 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authenticati
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__layer(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__layer(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__profile_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__profile_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__algorithm(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__preshared_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__preshared_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(yang.adata.MNode):
@@ -4342,12 +4668,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(profile_name=yang.gdata.from_xml_opt_str(n, 'profile-name'), algorithm=yang.gdata.from_xml_opt_str(n, 'algorithm'), preshared_key=yang.gdata.from_xml_opt_str(n, 'preshared-key'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_profile_name = yang.gdata.from_xml_opt_str(node, 'profile-name')
+    yang.gdata.maybe_add(children, 'profile-name', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__profile_name, child_profile_name)
+    child_algorithm = yang.gdata.from_xml_opt_str(node, 'algorithm')
+    yang.gdata.maybe_add(children, 'algorithm', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__algorithm, child_algorithm)
+    child_preshared_key = yang.gdata.from_xml_opt_str(node, 'preshared-key')
+    yang.gdata.maybe_add(children, 'preshared-key', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__preshared_key, child_preshared_key)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4409,12 +4739,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_gdata(n.get_opt_container('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), layer=yang.gdata.from_xml_opt_str(n, 'layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_xml(yang.gdata.get_xml_opt_child(n, 'encryption-profile')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__enabled, child_enabled)
+    child_layer = yang.gdata.from_xml_opt_str(node, 'layer')
+    yang.gdata.maybe_add(children, 'layer', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__layer, child_layer)
+    child_encryption_profile = yang.gdata.from_xml_opt_cnt(node, 'encryption-profile')
+    yang.gdata.maybe_add(children, 'encryption-profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile, child_encryption_profile)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4472,12 +4806,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_gdata(n.get_opt_container('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_gdata(n.get_opt_container('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_xml(yang.gdata.get_xml_opt_child(n, 'authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_xml(yang.gdata.get_xml_opt_child(n, 'encryption')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__security()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_authentication = yang.gdata.from_xml_opt_cnt(node, 'authentication')
+    yang.gdata.maybe_add(children, 'authentication', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication, child_authentication)
+    child_encryption = yang.gdata.from_xml_opt_cnt(node, 'encryption')
+    yang.gdata.maybe_add(children, 'encryption', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption, child_encryption)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__security(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4510,34 +4846,67 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security(jd: dict[str,
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dscp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dscp(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dot1p(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dot1p(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__target_sites(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__target_sites(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(yang.adata.MNode):
@@ -4565,12 +4934,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=yang.gdata.from_xml_opt_int(n, 'lower-port'), upper_port=yang.gdata.from_xml_opt_int(n, 'upper-port'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_lower_port = yang.gdata.from_xml_opt_int(node, 'lower-port')
+    yang.gdata.maybe_add(children, 'lower-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port, child_lower_port)
+    child_upper_port = yang.gdata.from_xml_opt_int(node, 'upper-port')
+    yang.gdata.maybe_add(children, 'upper-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port, child_upper_port)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4601,10 +4972,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(yang.adata.MNode):
@@ -4632,12 +5012,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=yang.gdata.from_xml_opt_int(n, 'lower-port'), upper_port=yang.gdata.from_xml_opt_int(n, 'upper-port'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_lower_port = yang.gdata.from_xml_opt_int(node, 'lower-port')
+    yang.gdata.maybe_add(children, 'lower-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port, child_lower_port)
+    child_upper_port = yang.gdata.from_xml_opt_int(node, 'upper-port')
+    yang.gdata.maybe_add(children, 'upper-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port, child_upper_port)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4666,6 +5048,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
     return yang.gdata.Container(children)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__protocol_field(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__protocol_field(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(yang.adata.MNode):
@@ -4741,12 +5126,34 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_container('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_container('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(dscp=yang.gdata.from_xml_opt_int(n, 'dscp'), dot1p=yang.gdata.from_xml_opt_int(n, 'dot1p'), ipv4_src_prefix=yang.gdata.from_xml_opt_str(n, 'ipv4-src-prefix'), ipv6_src_prefix=yang.gdata.from_xml_opt_str(n, 'ipv6-src-prefix'), ipv4_dst_prefix=yang.gdata.from_xml_opt_str(n, 'ipv4-dst-prefix'), ipv6_dst_prefix=yang.gdata.from_xml_opt_str(n, 'ipv6-dst-prefix'), l4_src_port=yang.gdata.from_xml_opt_int(n, 'l4-src-port'), target_sites=yang.gdata.from_xml_opt_strs(n, 'target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_xml(yang.gdata.get_xml_opt_child(n, 'l4-src-port-range')), l4_dst_port=yang.gdata.from_xml_opt_int(n, 'l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_xml(yang.gdata.get_xml_opt_child(n, 'l4-dst-port-range')), protocol_field=yang.gdata.from_xml_opt_value(n, 'protocol-field'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_dscp = yang.gdata.from_xml_opt_int(node, 'dscp')
+    yang.gdata.maybe_add(children, 'dscp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dscp, child_dscp)
+    child_dot1p = yang.gdata.from_xml_opt_int(node, 'dot1p')
+    yang.gdata.maybe_add(children, 'dot1p', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dot1p, child_dot1p)
+    child_ipv4_src_prefix = yang.gdata.from_xml_opt_str(node, 'ipv4-src-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-src-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix, child_ipv4_src_prefix)
+    child_ipv6_src_prefix = yang.gdata.from_xml_opt_str(node, 'ipv6-src-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-src-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix, child_ipv6_src_prefix)
+    child_ipv4_dst_prefix = yang.gdata.from_xml_opt_str(node, 'ipv4-dst-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-dst-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix, child_ipv4_dst_prefix)
+    child_ipv6_dst_prefix = yang.gdata.from_xml_opt_str(node, 'ipv6-dst-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-dst-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix, child_ipv6_dst_prefix)
+    child_l4_src_port = yang.gdata.from_xml_opt_int(node, 'l4-src-port')
+    yang.gdata.maybe_add(children, 'l4-src-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port, child_l4_src_port)
+    child_target_sites = yang.gdata.from_xml_opt_strs(node, 'target-sites')
+    yang.gdata.maybe_add(children, 'target-sites', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__target_sites, child_target_sites)
+    child_l4_src_port_range = yang.gdata.from_xml_opt_cnt(node, 'l4-src-port-range')
+    yang.gdata.maybe_add(children, 'l4-src-port-range', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range, child_l4_src_port_range)
+    child_l4_dst_port = yang.gdata.from_xml_opt_int(node, 'l4-dst-port')
+    yang.gdata.maybe_add(children, 'l4-dst-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port, child_l4_dst_port)
+    child_l4_dst_port_range = yang.gdata.from_xml_opt_cnt(node, 'l4-dst-port-range')
+    yang.gdata.maybe_add(children, 'l4-dst-port-range', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range, child_l4_dst_port_range)
+    child_protocol_field = yang.gdata.from_xml_opt_value(node, 'protocol-field')
+    yang.gdata.maybe_add(children, 'protocol-field', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__protocol_field, child_protocol_field)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4819,7 +5226,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_application(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_application(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__target_class_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__target_class_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(yang.adata.MNode):
@@ -4854,10 +5267,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(id=n.get_str('id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow.from_gdata(n.get_opt_container('match-flow')), match_application=n.get_opt_str('match-application'), target_class_id=n.get_opt_str('target-class-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(id=yang.gdata.from_xml_str(n, 'id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow.from_xml(yang.gdata.get_xml_opt_child(n, 'match-flow')), match_application=yang.gdata.from_xml_opt_str(n, 'match-application'), target_class_id=yang.gdata.from_xml_opt_str(n, 'target-class-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]
@@ -4895,13 +5304,24 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__id, child_id)
+    child_match_flow = yang.gdata.from_xml_opt_cnt(node, 'match-flow')
+    yang.gdata.maybe_add(children, 'match-flow', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow, child_match_flow)
+    child_match_application = yang.gdata.from_xml_opt_str(node, 'match-application')
+    yang.gdata.maybe_add(children, 'match-application', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_application, child_match_application)
+    child_target_class_id = yang.gdata.from_xml_opt_str(node, 'target-class-id')
+    yang.gdata.maybe_add(children, 'target-class-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__target_class_id, child_target_class_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements, user_order=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -4993,12 +5413,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule.from_xml(yang.gdata.get_xml_children(n, 'rule')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rule = yang.gdata.from_xml_opt_list(node, 'rule')
+    yang.gdata.maybe_add(children, 'rule', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule, child_rule)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5026,19 +5446,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__profile(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__profile(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__class_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__class_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__direction(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__direction(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__rate_limit(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('decimal64', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__rate_limit(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('decimal64', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__use_lowest_latency(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__use_lowest_latency(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__latency_boundary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__latency_boundary(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(yang.adata.MNode):
@@ -5066,12 +5504,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_bool('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(use_lowest_latency=yang.gdata.from_xml_opt_bool(n, 'use-lowest-latency'), latency_boundary=yang.gdata.from_xml_opt_int(n, 'latency-boundary'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_use_lowest_latency = yang.gdata.from_xml_opt_bool(node, 'use-lowest-latency')
+    yang.gdata.maybe_add(children, 'use-lowest-latency', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__use_lowest_latency, child_use_lowest_latency)
+    child_latency_boundary = yang.gdata.from_xml_opt_int(node, 'latency-boundary')
+    yang.gdata.maybe_add(children, 'latency-boundary', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__latency_boundary, child_latency_boundary)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5102,7 +5542,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_prof
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__latency_boundary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__latency_boundary(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(yang.adata.MNode):
@@ -5130,12 +5576,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_bool('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=yang.gdata.from_xml_opt_bool(n, 'use-lowest-jitter'), latency_boundary=yang.gdata.from_xml_opt_int(n, 'latency-boundary'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_use_lowest_jitter = yang.gdata.from_xml_opt_bool(node, 'use-lowest-jitter')
+    yang.gdata.maybe_add(children, 'use-lowest-jitter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter, child_use_lowest_jitter)
+    child_latency_boundary = yang.gdata.from_xml_opt_int(node, 'latency-boundary')
+    yang.gdata.maybe_add(children, 'latency-boundary', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__latency_boundary, child_latency_boundary)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5166,7 +5614,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_prof
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('decimal64', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('decimal64', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__end_to_end(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__end_to_end(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(yang.adata.MNode):
@@ -5194,12 +5648,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_float('guaranteed-bw-percent'), end_to_end=n.get_opt_bool('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=yang.gdata.from_xml_float(n, 'guaranteed-bw-percent'), end_to_end=yang.gdata.from_xml_opt_bool(n, 'end-to-end'))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_guaranteed_bw_percent = yang.gdata.from_xml_float(node, 'guaranteed-bw-percent')
+    yang.gdata.maybe_add(children, 'guaranteed-bw-percent', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent, child_guaranteed_bw_percent)
+    child_end_to_end = yang.gdata.from_xml_opt_bool(node, 'end-to-end')
+    yang.gdata.maybe_add(children, 'end-to-end', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__end_to_end, child_end_to_end)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5270,10 +5726,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry(class_id=n.get_str('class-id'), direction=n.get_opt_str('direction'), rate_limit=n.get_opt_float('rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency.from_gdata(n.get_opt_container('latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter.from_gdata(n.get_opt_container('jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth.from_gdata(n.get_container('bandwidth')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry(class_id=yang.gdata.from_xml_str(n, 'class-id'), direction=yang.gdata.from_xml_opt_str(n, 'direction'), rate_limit=yang.gdata.from_xml_opt_float(n, 'rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency.from_xml(yang.gdata.get_xml_opt_child(n, 'latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter.from_xml(yang.gdata.get_xml_opt_child(n, 'jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth.from_xml(yang.gdata.get_xml_child(n, 'bandwidth')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]
     mut def __init__(self, elements=[]):
@@ -5310,13 +5762,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_class_id = yang.gdata.from_xml_str(node, 'class-id')
+    yang.gdata.maybe_add(children, 'class-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__class_id, child_class_id)
+    child_direction = yang.gdata.from_xml_opt_str(node, 'direction')
+    yang.gdata.maybe_add(children, 'direction', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__direction, child_direction)
+    child_rate_limit = yang.gdata.from_xml_opt_float(node, 'rate-limit')
+    yang.gdata.maybe_add(children, 'rate-limit', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__rate_limit, child_rate_limit)
+    child_latency = yang.gdata.from_xml_opt_cnt(node, 'latency')
+    yang.gdata.maybe_add(children, 'latency', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency, child_latency)
+    child_jitter = yang.gdata.from_xml_opt_cnt(node, 'jitter')
+    yang.gdata.maybe_add(children, 'jitter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter, child_jitter)
+    child_bandwidth = yang.gdata.from_xml_cnt(node, 'bandwidth')
+    yang.gdata.maybe_add(children, 'bandwidth', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth, child_bandwidth)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_class_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_element(e))
+    return yang.gdata.List(keys=['class-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -5416,12 +5883,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class.from_xml(yang.gdata.get_xml_children(n, 'class')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_class_ = yang.gdata.from_xml_opt_list(node, 'class')
+    yang.gdata.maybe_add(children, 'class', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class, child_class_)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5471,12 +5938,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_gdata(n.get_opt_container('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(profile=yang.gdata.from_xml_opt_str(n, 'profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_xml(yang.gdata.get_xml_opt_child(n, 'classes')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_profile = yang.gdata.from_xml_opt_str(node, 'profile')
+    yang.gdata.maybe_add(children, 'profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__profile, child_profile)
+    child_classes = yang.gdata.from_xml_opt_cnt(node, 'classes')
+    yang.gdata.maybe_add(children, 'classes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes, child_classes)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5530,12 +5999,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_gdata(n.get_opt_container('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_gdata(n.get_opt_container('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_xml(yang.gdata.get_xml_opt_child(n, 'qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_xml(yang.gdata.get_xml_opt_child(n, 'qos-profile')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_qos_classification_policy = yang.gdata.from_xml_opt_cnt(node, 'qos-classification-policy')
+    yang.gdata.maybe_add(children, 'qos-classification-policy', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy, child_qos_classification_policy)
+    child_qos_profile = yang.gdata.from_xml_opt_cnt(node, 'qos-profile')
+    yang.gdata.maybe_add(children, 'qos-profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile, child_qos_profile)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5568,6 +6039,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(jd: dict[
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier__signalling_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier__signalling_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adata.MNode):
     signalling_type: str
 
@@ -5588,12 +6062,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(signalling_type=yang.gdata.from_xml_opt_str(n, 'signalling-type'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_signalling_type = yang.gdata.from_xml_opt_str(node, 'signalling-type')
+    yang.gdata.maybe_add(children, 'signalling-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier__signalling_type, child_signalling_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5620,10 +6094,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarri
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_site_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_site_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv4(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv6(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv6(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(yang.adata.MNode):
@@ -5651,12 +6134,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(ipv4=yang.gdata.from_xml_opt_bool(n, 'ipv4'), ipv6=yang.gdata.from_xml_opt_bool(n, 'ipv6'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_bool(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_bool(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv6, child_ipv6)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5685,6 +6170,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__mu
     return yang.gdata.Container(children)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__protocol_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__protocol_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNode):
@@ -5717,12 +6205,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_gdata(n.get_opt_container('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(multicast_site_type=yang.gdata.from_xml_opt_str(n, 'multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast-address-family')), protocol_type=yang.gdata.from_xml_opt_str(n, 'protocol-type'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_multicast_site_type = yang.gdata.from_xml_opt_str(node, 'multicast-site-type')
+    yang.gdata.maybe_add(children, 'multicast-site-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_site_type, child_multicast_site_type)
+    child_multicast_address_family = yang.gdata.from_xml_opt_cnt(node, 'multicast-address-family')
+    yang.gdata.maybe_add(children, 'multicast-address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family, child_multicast_address_family)
+    child_protocol_type = yang.gdata.from_xml_opt_str(node, 'protocol-type')
+    yang.gdata.maybe_add(children, 'protocol-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__protocol_type, child_protocol_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5785,12 +6277,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service(qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_gdata(n.get_opt_container('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_gdata(n.get_opt_container('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_gdata(n.get_opt_container('multicast')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service(qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_xml(yang.gdata.get_xml_opt_child(n, 'qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_xml(yang.gdata.get_xml_opt_child(n, 'carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_qos = yang.gdata.from_xml_opt_cnt(node, 'qos')
+    yang.gdata.maybe_add(children, 'qos', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos, child_qos)
+    child_carrierscarrier = yang.gdata.from_xml_opt_cnt(node, 'carrierscarrier')
+    yang.gdata.maybe_add(children, 'carrierscarrier', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier, child_carrierscarrier)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast, child_multicast)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5828,6 +6324,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service(jd: dict[str, 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNode):
     enabled: bool
 
@@ -5848,12 +6347,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(enabled=n.get_opt_bool('enabled'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection__enabled, child_enabled)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5880,19 +6379,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(jd:
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__area_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__area_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__metric(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(yang.adata.MNode):
@@ -5917,10 +6434,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=n.get_str('target-site'), metric=n.get_opt_int('metric'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=yang.gdata.from_xml_str(n, 'target-site'), metric=yang.gdata.from_xml_opt_int(n, 'metric'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
@@ -5958,13 +6471,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_target_site = yang.gdata.from_xml_str(node, 'target-site')
+    yang.gdata.maybe_add(children, 'target-site', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site, child_target_site)
+    child_metric = yang.gdata.from_xml_opt_int(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric, child_metric)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_target_site)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(e))
+    return yang.gdata.List(keys=['target-site'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -6048,12 +6568,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_xml(yang.gdata.get_xml_children(n, 'sham-link')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sham_link = yang.gdata.from_xml_opt_list(node, 'sham-link')
+    yang.gdata.maybe_add(children, 'sham-link', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link, child_sham_link)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6111,12 +6631,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(address_family=n.get_opt_strs('address-family'), area_address=n.get_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_container('sham-links')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'), area_address=yang.gdata.from_xml_str(n, 'area-address'), metric=yang.gdata.from_xml_opt_int(n, 'metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_xml(yang.gdata.get_xml_opt_child(n, 'sham-links')))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__address_family, child_address_family)
+    child_area_address = yang.gdata.from_xml_str(node, 'area-address')
+    yang.gdata.maybe_add(children, 'area-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__area_address, child_area_address)
+    child_metric = yang.gdata.from_xml_opt_int(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__metric, child_metric)
+    child_sham_links = yang.gdata.from_xml_opt_cnt(node, 'sham-links')
+    yang.gdata.maybe_add(children, 'sham-links', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links, child_sham_links)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6151,12 +6677,18 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     yang.gdata.maybe_add(children, 'metric', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__metric, child_metric)
     child_sham_links = yang.gdata.take_json_opt_cnt(jd, 'sham-links')
     yang.gdata.maybe_add(children, 'sham-links', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links, child_sham_links)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__autonomous_system(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__autonomous_system(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(yang.adata.MNode):
@@ -6182,12 +6714,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_int('autonomous-system'), address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(autonomous_system=yang.gdata.from_xml_int(n, 'autonomous-system'), address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_autonomous_system = yang.gdata.from_xml_int(node, 'autonomous-system')
+    yang.gdata.maybe_add(children, 'autonomous-system', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__autonomous_system, child_autonomous_system)
+    child_address_family = yang.gdata.from_xml_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6213,15 +6747,24 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     yang.gdata.maybe_add(children, 'autonomous-system', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__autonomous_system, child_autonomous_system)
     child_address_family = yang.gdata.take_json_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(yang.adata.MNode):
@@ -6251,10 +6794,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=yang.gdata.from_xml_str(n, 'lan'), next_hop=yang.gdata.from_xml_str(n, 'next-hop'), lan_tag=yang.gdata.from_xml_opt_str(n, 'lan-tag'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
@@ -6295,13 +6834,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_lan = yang.gdata.from_xml_str(node, 'lan')
+    yang.gdata.maybe_add(children, 'lan', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan, child_lan)
+    child_next_hop = yang.gdata.from_xml_str(node, 'next-hop')
+    yang.gdata.maybe_add(children, 'next-hop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop, child_next_hop)
+    child_lan_tag = yang.gdata.from_xml_opt_str(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag, child_lan_tag)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(e))
+    return yang.gdata.List(keys=['lan', 'next-hop'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -6371,10 +6919,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(yang.adata.MNode):
@@ -6404,10 +6961,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=yang.gdata.from_xml_str(n, 'lan'), next_hop=yang.gdata.from_xml_str(n, 'next-hop'), lan_tag=yang.gdata.from_xml_opt_str(n, 'lan-tag'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
@@ -6448,13 +7001,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_lan = yang.gdata.from_xml_str(node, 'lan')
+    yang.gdata.maybe_add(children, 'lan', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan, child_lan)
+    child_next_hop = yang.gdata.from_xml_str(node, 'next-hop')
+    yang.gdata.maybe_add(children, 'next-hop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop, child_next_hop)
+    child_lan_tag = yang.gdata.from_xml_opt_str(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag, child_lan_tag)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(e))
+    return yang.gdata.List(keys=['lan', 'next-hop'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -6546,12 +7108,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_xml(yang.gdata.get_xml_children(n, 'ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_xml(yang.gdata.get_xml_children(n, 'ipv6-lan-prefixes')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4_lan_prefixes = yang.gdata.from_xml_opt_list(node, 'ipv4-lan-prefixes')
+    yang.gdata.maybe_add(children, 'ipv4-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes, child_ipv4_lan_prefixes)
+    child_ipv6_lan_prefixes = yang.gdata.from_xml_opt_list(node, 'ipv6-lan-prefixes')
+    yang.gdata.maybe_add(children, 'ipv6-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes, child_ipv6_lan_prefixes)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6601,12 +7165,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_container('cascaded-lan-prefixes')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_xml(yang.gdata.get_xml_opt_child(n, 'cascaded-lan-prefixes')))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cascaded_lan_prefixes = yang.gdata.from_xml_opt_cnt(node, 'cascaded-lan-prefixes')
+    yang.gdata.maybe_add(children, 'cascaded-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes, child_cascaded_lan_prefixes)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6629,9 +7193,12 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     children = {}
     child_cascaded_lan_prefixes = yang.gdata.take_json_opt_cnt(jd, 'cascaded-lan-prefixes')
     yang.gdata.maybe_add(children, 'cascaded-lan-prefixes', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes, child_cascaded_lan_prefixes)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(yang.adata.MNode):
@@ -6652,12 +7219,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6679,9 +7246,12 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     children = {}
     child_address_family = yang.gdata.take_json_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(yang.adata.MNode):
@@ -6702,12 +7272,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6729,7 +7299,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     children = {}
     child_address_family = yang.gdata.take_json_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(yang.adata.MNode):
     type: str
@@ -6799,10 +7369,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(type=n.get_str('type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf.from_gdata(n.get_opt_container('ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp.from_gdata(n.get_opt_container('bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static.from_gdata(n.get_opt_container('static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip.from_gdata(n.get_opt_container('rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp.from_gdata(n.get_opt_container('vrrp')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(type=yang.gdata.from_xml_str(n, 'type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf.from_xml(yang.gdata.get_xml_opt_child(n, 'ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static.from_xml(yang.gdata.get_xml_opt_child(n, 'static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip.from_xml(yang.gdata.get_xml_opt_child(n, 'rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp.from_xml(yang.gdata.get_xml_opt_child(n, 'vrrp')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]
     mut def __init__(self, elements=[]):
@@ -6839,13 +7405,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_type = yang.gdata.from_xml_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__type, child_type)
+    child_ospf = yang.gdata.from_xml_opt_cnt(node, 'ospf')
+    yang.gdata.maybe_add(children, 'ospf', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf, child_ospf)
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp, child_bgp)
+    child_static = yang.gdata.from_xml_opt_cnt(node, 'static')
+    yang.gdata.maybe_add(children, 'static', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static, child_static)
+    child_rip = yang.gdata.from_xml_opt_cnt(node, 'rip')
+    yang.gdata.maybe_add(children, 'rip', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip, child_rip)
+    child_vrrp = yang.gdata.from_xml_opt_cnt(node, 'vrrp')
+    yang.gdata.maybe_add(children, 'vrrp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp, child_vrrp)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_element(e))
+    return yang.gdata.List(keys=['type'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -6945,12 +7526,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol.from_xml(yang.gdata.get_xml_children(n, 'routing-protocol')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_routing_protocol = yang.gdata.from_xml_opt_list(node, 'routing-protocol')
+    yang.gdata.maybe_add(children, 'routing-protocol', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol, child_routing_protocol)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6978,16 +7559,31 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(jd: 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__location_reference(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__location_reference(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__device_reference(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__device_reference(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(yang.adata.MNode):
@@ -7007,10 +7603,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(group_id=n.get_str('group-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]
@@ -7048,13 +7640,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group__group_id, child_group_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -7134,12 +7731,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group, child_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7167,7 +7764,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__constraint_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__constraint_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(yang.adata.MNode):
@@ -7187,10 +7790,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(group_id=n.get_str('group-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]
@@ -7228,13 +7827,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group__group_id, child_group_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -7297,7 +7901,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_accesses(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_accesses(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_groups(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_groups(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(yang.adata.MNode):
@@ -7330,12 +7940,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group.from_gdata(n.get_opt_list('group')), all_other_accesses=n.get_opt_bool('all-other-accesses'), all_other_groups=n.get_opt_bool('all-other-groups'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group.from_xml(yang.gdata.get_xml_children(n, 'group')), all_other_accesses=yang.gdata.from_xml_opt_bool(n, 'all-other-accesses'), all_other_groups=yang.gdata.from_xml_opt_bool(n, 'all-other-groups'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group, child_group)
+    child_all_other_accesses = yang.gdata.from_xml_opt_bool(node, 'all-other-accesses')
+    yang.gdata.maybe_add(children, 'all-other-accesses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_accesses, child_all_other_accesses)
+    child_all_other_groups = yang.gdata.from_xml_opt_bool(node, 'all-other-groups')
+    yang.gdata.maybe_add(children, 'all-other-groups', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_groups, child_all_other_groups)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7391,10 +8005,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry(constraint_type=n.get_str('constraint-type'), target=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target.from_gdata(n.get_opt_container('target')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry(constraint_type=yang.gdata.from_xml_str(n, 'constraint-type'), target=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target.from_xml(yang.gdata.get_xml_opt_child(n, 'target')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]
     mut def __init__(self, elements=[]):
@@ -7431,13 +8041,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_constraint_type = yang.gdata.from_xml_str(node, 'constraint-type')
+    yang.gdata.maybe_add(children, 'constraint-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__constraint_type, child_constraint_type)
+    child_target = yang.gdata.from_xml_opt_cnt(node, 'target')
+    yang.gdata.maybe_add(children, 'target', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target, child_target)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_constraint_type)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_element(e))
+    return yang.gdata.List(keys=['constraint-type'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -7521,12 +8138,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(constraint=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint.from_gdata(n.get_opt_list('constraint')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(constraint=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint.from_xml(yang.gdata.get_xml_children(n, 'constraint')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_constraint = yang.gdata.from_xml_opt_list(node, 'constraint')
+    yang.gdata.maybe_add(children, 'constraint', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint, child_constraint)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7576,12 +8193,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_gdata(n.get_opt_container('groups')), constraints=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_gdata(n.get_opt_container('constraints')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_xml(yang.gdata.get_xml_opt_child(n, 'groups')), constraints=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_xml(yang.gdata.get_xml_opt_child(n, 'constraints')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_groups = yang.gdata.from_xml_opt_cnt(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups, child_groups)
+    child_constraints = yang.gdata.from_xml_opt_cnt(node, 'constraints')
+    yang.gdata.maybe_add(children, 'constraints', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints, child_constraints)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7614,7 +8233,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__requested_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__requested_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__strict(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__strict(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(yang.adata.MNode):
@@ -7642,12 +8267,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(requested_type=n.get_opt_str('requested-type'), strict=n.get_opt_bool('strict'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(requested_type=yang.gdata.from_xml_opt_str(n, 'requested-type'), strict=yang.gdata.from_xml_opt_bool(n, 'strict'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_requested_type = yang.gdata.from_xml_opt_str(node, 'requested-type')
+    yang.gdata.maybe_add(children, 'requested-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__requested_type, child_requested_type)
+    child_strict = yang.gdata.from_xml_opt_bool(node, 'strict')
+    yang.gdata.maybe_add(children, 'strict', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__strict, child_strict)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7678,7 +8305,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__always_on(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__always_on(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__bearer_reference(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__bearer_reference(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(yang.adata.MNode):
@@ -7711,12 +8344,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(requested_type=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_gdata(n.get_opt_container('requested-type')), always_on=n.get_opt_bool('always-on'), bearer_reference=n.get_opt_str('bearer-reference'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(requested_type=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_xml(yang.gdata.get_xml_opt_child(n, 'requested-type')), always_on=yang.gdata.from_xml_opt_bool(n, 'always-on'), bearer_reference=yang.gdata.from_xml_opt_str(n, 'bearer-reference'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_requested_type = yang.gdata.from_xml_opt_cnt(node, 'requested-type')
+    yang.gdata.maybe_add(children, 'requested-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type, child_requested_type)
+    child_always_on = yang.gdata.from_xml_opt_bool(node, 'always-on')
+    yang.gdata.maybe_add(children, 'always-on', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__always_on, child_always_on)
+    child_bearer_reference = yang.gdata.from_xml_opt_str(node, 'bearer-reference')
+    yang.gdata.maybe_add(children, 'bearer-reference', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__bearer_reference, child_bearer_reference)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7752,22 +8389,43 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__address_allocation_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__address_allocation_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__number_of_dynamic_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__number_of_dynamic_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__start_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__start_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__end_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__end_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(yang.adata.MNode):
@@ -7797,10 +8455,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(group_id=n.get_str('group-id'), start_address=n.get_opt_str('start-address'), end_address=n.get_opt_str('end-address'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'), start_address=yang.gdata.from_xml_opt_str(n, 'start-address'), end_address=yang.gdata.from_xml_opt_str(n, 'end-address'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]
@@ -7838,13 +8492,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__group_id, child_group_id)
+    child_start_address = yang.gdata.from_xml_opt_str(node, 'start-address')
+    yang.gdata.maybe_add(children, 'start-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__start_address, child_start_address)
+    child_end_address = yang.gdata.from_xml_opt_str(node, 'end-address')
+    yang.gdata.maybe_add(children, 'end-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__end_address, child_end_address)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -7932,12 +8595,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group.from_xml(yang.gdata.get_xml_children(n, 'address-group')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_group = yang.gdata.from_xml_opt_list(node, 'address-group')
+    yang.gdata.maybe_add(children, 'address-group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group, child_address_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7997,12 +8660,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_gdata(n.get_opt_container('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'), number_of_dynamic_address=yang.gdata.from_xml_opt_int(n, 'number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-addresses')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__provider_address, child_provider_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__prefix_length, child_prefix_length)
+    child_number_of_dynamic_address = yang.gdata.from_xml_opt_int(node, 'number-of-dynamic-address')
+    yang.gdata.maybe_add(children, 'number-of-dynamic-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__number_of_dynamic_address, child_number_of_dynamic_address)
+    child_customer_addresses = yang.gdata.from_xml_opt_cnt(node, 'customer-addresses')
+    yang.gdata.maybe_add(children, 'customer-addresses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses, child_customer_addresses)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8042,10 +8711,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers__server_ip_address(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers__server_ip_address(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(yang.adata.MNode):
@@ -8066,12 +8744,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(server_ip_address=yang.gdata.from_xml_opt_strs(n, 'server-ip-address'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_server_ip_address = yang.gdata.from_xml_opt_strs(node, 'server-ip-address')
+    yang.gdata.maybe_add(children, 'server-ip-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers__server_ip_address, child_server_ip_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8125,12 +8803,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_container('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-dhcp-servers')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__provider_address, child_provider_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__prefix_length, child_prefix_length)
+    child_customer_dhcp_servers = yang.gdata.from_xml_opt_cnt(node, 'customer-dhcp-servers')
+    yang.gdata.maybe_add(children, 'customer-dhcp-servers', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers, child_customer_dhcp_servers)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8166,10 +8848,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__customer_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__customer_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(yang.adata.MNode):
@@ -8202,12 +8893,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), customer_address=yang.gdata.from_xml_opt_str(n, 'customer-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__provider_address, child_provider_address)
+    child_customer_address = yang.gdata.from_xml_opt_str(node, 'customer-address')
+    yang.gdata.maybe_add(children, 'customer-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__customer_address, child_customer_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__prefix_length, child_prefix_length)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8274,12 +8969,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(address_allocation_type=n.get_opt_str('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_gdata(n.get_opt_container('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_gdata(n.get_opt_container('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_gdata(n.get_opt_container('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(address_allocation_type=yang.gdata.from_xml_opt_str(n, 'address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_xml(yang.gdata.get_xml_opt_child(n, 'provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_xml(yang.gdata.get_xml_opt_child(n, 'dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'addresses')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_allocation_type = yang.gdata.from_xml_opt_str(node, 'address-allocation-type')
+    yang.gdata.maybe_add(children, 'address-allocation-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__address_allocation_type, child_address_allocation_type)
+    child_provider_dhcp = yang.gdata.from_xml_opt_cnt(node, 'provider-dhcp')
+    yang.gdata.maybe_add(children, 'provider-dhcp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp, child_provider_dhcp)
+    child_dhcp_relay = yang.gdata.from_xml_opt_cnt(node, 'dhcp-relay')
+    yang.gdata.maybe_add(children, 'dhcp-relay', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay, child_dhcp_relay)
+    child_addresses = yang.gdata.from_xml_opt_cnt(node, 'addresses')
+    yang.gdata.maybe_add(children, 'addresses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses, child_addresses)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8321,22 +9022,43 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__address_allocation_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__address_allocation_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__number_of_dynamic_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__number_of_dynamic_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__start_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__start_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__end_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__end_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(yang.adata.MNode):
@@ -8366,10 +9088,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(group_id=n.get_str('group-id'), start_address=n.get_opt_str('start-address'), end_address=n.get_opt_str('end-address'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'), start_address=yang.gdata.from_xml_opt_str(n, 'start-address'), end_address=yang.gdata.from_xml_opt_str(n, 'end-address'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]
@@ -8407,13 +9125,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__group_id, child_group_id)
+    child_start_address = yang.gdata.from_xml_opt_str(node, 'start-address')
+    yang.gdata.maybe_add(children, 'start-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__start_address, child_start_address)
+    child_end_address = yang.gdata.from_xml_opt_str(node, 'end-address')
+    yang.gdata.maybe_add(children, 'end-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__end_address, child_end_address)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -8501,12 +9228,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group.from_xml(yang.gdata.get_xml_children(n, 'address-group')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_group = yang.gdata.from_xml_opt_list(node, 'address-group')
+    yang.gdata.maybe_add(children, 'address-group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group, child_address_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8566,12 +9293,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_gdata(n.get_opt_container('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'), number_of_dynamic_address=yang.gdata.from_xml_opt_int(n, 'number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-addresses')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__provider_address, child_provider_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__prefix_length, child_prefix_length)
+    child_number_of_dynamic_address = yang.gdata.from_xml_opt_int(node, 'number-of-dynamic-address')
+    yang.gdata.maybe_add(children, 'number-of-dynamic-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__number_of_dynamic_address, child_number_of_dynamic_address)
+    child_customer_addresses = yang.gdata.from_xml_opt_cnt(node, 'customer-addresses')
+    yang.gdata.maybe_add(children, 'customer-addresses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses, child_customer_addresses)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8611,10 +9344,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers__server_ip_address(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers__server_ip_address(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(yang.adata.MNode):
@@ -8635,12 +9377,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(server_ip_address=yang.gdata.from_xml_opt_strs(n, 'server-ip-address'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_server_ip_address = yang.gdata.from_xml_opt_strs(node, 'server-ip-address')
+    yang.gdata.maybe_add(children, 'server-ip-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers__server_ip_address, child_server_ip_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8694,12 +9436,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_container('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-dhcp-servers')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__provider_address, child_provider_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__prefix_length, child_prefix_length)
+    child_customer_dhcp_servers = yang.gdata.from_xml_opt_cnt(node, 'customer-dhcp-servers')
+    yang.gdata.maybe_add(children, 'customer-dhcp-servers', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers, child_customer_dhcp_servers)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8735,10 +9481,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__customer_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__customer_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(yang.adata.MNode):
@@ -8771,12 +9526,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), customer_address=yang.gdata.from_xml_opt_str(n, 'customer-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__provider_address, child_provider_address)
+    child_customer_address = yang.gdata.from_xml_opt_str(node, 'customer-address')
+    yang.gdata.maybe_add(children, 'customer-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__customer_address, child_customer_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__prefix_length, child_prefix_length)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8843,12 +9602,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(address_allocation_type=n.get_opt_str('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_gdata(n.get_opt_container('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_gdata(n.get_opt_container('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_gdata(n.get_opt_container('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(address_allocation_type=yang.gdata.from_xml_opt_str(n, 'address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_xml(yang.gdata.get_xml_opt_child(n, 'provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_xml(yang.gdata.get_xml_opt_child(n, 'dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'addresses')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_allocation_type = yang.gdata.from_xml_opt_str(node, 'address-allocation-type')
+    yang.gdata.maybe_add(children, 'address-allocation-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__address_allocation_type, child_address_allocation_type)
+    child_provider_dhcp = yang.gdata.from_xml_opt_cnt(node, 'provider-dhcp')
+    yang.gdata.maybe_add(children, 'provider-dhcp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp, child_provider_dhcp)
+    child_dhcp_relay = yang.gdata.from_xml_opt_cnt(node, 'dhcp-relay')
+    yang.gdata.maybe_add(children, 'dhcp-relay', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay, child_dhcp_relay)
+    child_addresses = yang.gdata.from_xml_opt_cnt(node, 'addresses')
+    yang.gdata.maybe_add(children, 'addresses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses, child_addresses)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8890,10 +9655,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__fixed_value(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__fixed_value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__profile_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__profile_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(yang.adata.MNode):
@@ -8926,12 +9700,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(enabled=n.get_opt_bool('enabled'), fixed_value=n.get_opt_int('fixed-value'), profile_name=n.get_opt_str('profile-name'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), fixed_value=yang.gdata.from_xml_opt_int(n, 'fixed-value'), profile_name=yang.gdata.from_xml_opt_str(n, 'profile-name'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__enabled, child_enabled)
+    child_fixed_value = yang.gdata.from_xml_opt_int(node, 'fixed-value')
+    yang.gdata.maybe_add(children, 'fixed-value', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__fixed_value, child_fixed_value)
+    child_profile_name = yang.gdata.from_xml_opt_str(node, 'profile-name')
+    yang.gdata.maybe_add(children, 'profile-name', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__profile_name, child_profile_name)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8983,12 +9761,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(bfd=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_gdata(n.get_opt_container('bfd')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(bfd=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_xml(yang.gdata.get_xml_opt_child(n, 'bfd')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bfd = yang.gdata.from_xml_opt_cnt(node, 'bfd')
+    yang.gdata.maybe_add(children, 'bfd', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd, child_bfd)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9043,12 +9821,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(ipv4=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_gdata(n.get_opt_container('ipv6')), oam=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_gdata(n.get_opt_container('oam')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(ipv4=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv4')), ipv6=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv6')), oam=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_xml(yang.gdata.get_xml_opt_child(n, 'oam')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_cnt(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_cnt(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6, child_ipv6)
+    child_oam = yang.gdata.from_xml_opt_cnt(node, 'oam')
+    yang.gdata.maybe_add(children, 'oam', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam, child_oam)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9099,12 +9881,10 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9127,16 +9907,31 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__layer(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__layer(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__profile_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__profile_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__algorithm(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__preshared_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__preshared_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(yang.adata.MNode):
@@ -9169,12 +9964,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(profile_name=yang.gdata.from_xml_opt_str(n, 'profile-name'), algorithm=yang.gdata.from_xml_opt_str(n, 'algorithm'), preshared_key=yang.gdata.from_xml_opt_str(n, 'preshared-key'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_profile_name = yang.gdata.from_xml_opt_str(node, 'profile-name')
+    yang.gdata.maybe_add(children, 'profile-name', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__profile_name, child_profile_name)
+    child_algorithm = yang.gdata.from_xml_opt_str(node, 'algorithm')
+    yang.gdata.maybe_add(children, 'algorithm', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__algorithm, child_algorithm)
+    child_preshared_key = yang.gdata.from_xml_opt_str(node, 'preshared-key')
+    yang.gdata.maybe_add(children, 'preshared-key', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__preshared_key, child_preshared_key)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9236,12 +10035,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_gdata(n.get_opt_container('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), layer=yang.gdata.from_xml_opt_str(n, 'layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_xml(yang.gdata.get_xml_opt_child(n, 'encryption-profile')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__enabled, child_enabled)
+    child_layer = yang.gdata.from_xml_opt_str(node, 'layer')
+    yang.gdata.maybe_add(children, 'layer', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__layer, child_layer)
+    child_encryption_profile = yang.gdata.from_xml_opt_cnt(node, 'encryption-profile')
+    yang.gdata.maybe_add(children, 'encryption-profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile, child_encryption_profile)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9299,12 +10102,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_gdata(n.get_opt_container('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_gdata(n.get_opt_container('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_xml(yang.gdata.get_xml_opt_child(n, 'authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_xml(yang.gdata.get_xml_opt_child(n, 'encryption')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_authentication = yang.gdata.from_xml_opt_cnt(node, 'authentication')
+    yang.gdata.maybe_add(children, 'authentication', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication, child_authentication)
+    child_encryption = yang.gdata.from_xml_opt_cnt(node, 'encryption')
+    yang.gdata.maybe_add(children, 'encryption', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption, child_encryption)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9339,45 +10144,87 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
         return yang.gdata.Leaf('uint64', int(val))
     return yang.gdata.Leaf('uint64', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_input_bandwidth(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint64', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_output_bandwidth(val: value) -> yang.gdata.Leaf:
     if isinstance(val, str):
         return yang.gdata.Leaf('uint64', int(val))
     return yang.gdata.Leaf('uint64', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_output_bandwidth(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint64', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_mtu(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_mtu(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dscp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dscp(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dot1p(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dot1p(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__target_sites(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__target_sites(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(yang.adata.MNode):
@@ -9405,12 +10252,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=yang.gdata.from_xml_opt_int(n, 'lower-port'), upper_port=yang.gdata.from_xml_opt_int(n, 'upper-port'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_lower_port = yang.gdata.from_xml_opt_int(node, 'lower-port')
+    yang.gdata.maybe_add(children, 'lower-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port, child_lower_port)
+    child_upper_port = yang.gdata.from_xml_opt_int(node, 'upper-port')
+    yang.gdata.maybe_add(children, 'upper-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port, child_upper_port)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9441,10 +10290,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(yang.adata.MNode):
@@ -9472,12 +10330,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=yang.gdata.from_xml_opt_int(n, 'lower-port'), upper_port=yang.gdata.from_xml_opt_int(n, 'upper-port'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_lower_port = yang.gdata.from_xml_opt_int(node, 'lower-port')
+    yang.gdata.maybe_add(children, 'lower-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port, child_lower_port)
+    child_upper_port = yang.gdata.from_xml_opt_int(node, 'upper-port')
+    yang.gdata.maybe_add(children, 'upper-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port, child_upper_port)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9506,6 +10366,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     return yang.gdata.Container(children)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__protocol_field(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__protocol_field(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(yang.adata.MNode):
@@ -9581,12 +10444,34 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_container('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_container('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(dscp=yang.gdata.from_xml_opt_int(n, 'dscp'), dot1p=yang.gdata.from_xml_opt_int(n, 'dot1p'), ipv4_src_prefix=yang.gdata.from_xml_opt_str(n, 'ipv4-src-prefix'), ipv6_src_prefix=yang.gdata.from_xml_opt_str(n, 'ipv6-src-prefix'), ipv4_dst_prefix=yang.gdata.from_xml_opt_str(n, 'ipv4-dst-prefix'), ipv6_dst_prefix=yang.gdata.from_xml_opt_str(n, 'ipv6-dst-prefix'), l4_src_port=yang.gdata.from_xml_opt_int(n, 'l4-src-port'), target_sites=yang.gdata.from_xml_opt_strs(n, 'target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_xml(yang.gdata.get_xml_opt_child(n, 'l4-src-port-range')), l4_dst_port=yang.gdata.from_xml_opt_int(n, 'l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_xml(yang.gdata.get_xml_opt_child(n, 'l4-dst-port-range')), protocol_field=yang.gdata.from_xml_opt_value(n, 'protocol-field'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_dscp = yang.gdata.from_xml_opt_int(node, 'dscp')
+    yang.gdata.maybe_add(children, 'dscp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dscp, child_dscp)
+    child_dot1p = yang.gdata.from_xml_opt_int(node, 'dot1p')
+    yang.gdata.maybe_add(children, 'dot1p', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dot1p, child_dot1p)
+    child_ipv4_src_prefix = yang.gdata.from_xml_opt_str(node, 'ipv4-src-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-src-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix, child_ipv4_src_prefix)
+    child_ipv6_src_prefix = yang.gdata.from_xml_opt_str(node, 'ipv6-src-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-src-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix, child_ipv6_src_prefix)
+    child_ipv4_dst_prefix = yang.gdata.from_xml_opt_str(node, 'ipv4-dst-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-dst-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix, child_ipv4_dst_prefix)
+    child_ipv6_dst_prefix = yang.gdata.from_xml_opt_str(node, 'ipv6-dst-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-dst-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix, child_ipv6_dst_prefix)
+    child_l4_src_port = yang.gdata.from_xml_opt_int(node, 'l4-src-port')
+    yang.gdata.maybe_add(children, 'l4-src-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port, child_l4_src_port)
+    child_target_sites = yang.gdata.from_xml_opt_strs(node, 'target-sites')
+    yang.gdata.maybe_add(children, 'target-sites', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__target_sites, child_target_sites)
+    child_l4_src_port_range = yang.gdata.from_xml_opt_cnt(node, 'l4-src-port-range')
+    yang.gdata.maybe_add(children, 'l4-src-port-range', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range, child_l4_src_port_range)
+    child_l4_dst_port = yang.gdata.from_xml_opt_int(node, 'l4-dst-port')
+    yang.gdata.maybe_add(children, 'l4-dst-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port, child_l4_dst_port)
+    child_l4_dst_port_range = yang.gdata.from_xml_opt_cnt(node, 'l4-dst-port-range')
+    yang.gdata.maybe_add(children, 'l4-dst-port-range', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range, child_l4_dst_port_range)
+    child_protocol_field = yang.gdata.from_xml_opt_value(node, 'protocol-field')
+    yang.gdata.maybe_add(children, 'protocol-field', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__protocol_field, child_protocol_field)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9659,7 +10544,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_application(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_application(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__target_class_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__target_class_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(yang.adata.MNode):
@@ -9694,10 +10585,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(id=n.get_str('id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow.from_gdata(n.get_opt_container('match-flow')), match_application=n.get_opt_str('match-application'), target_class_id=n.get_opt_str('target-class-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(id=yang.gdata.from_xml_str(n, 'id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow.from_xml(yang.gdata.get_xml_opt_child(n, 'match-flow')), match_application=yang.gdata.from_xml_opt_str(n, 'match-application'), target_class_id=yang.gdata.from_xml_opt_str(n, 'target-class-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]
@@ -9735,13 +10622,24 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__id, child_id)
+    child_match_flow = yang.gdata.from_xml_opt_cnt(node, 'match-flow')
+    yang.gdata.maybe_add(children, 'match-flow', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow, child_match_flow)
+    child_match_application = yang.gdata.from_xml_opt_str(node, 'match-application')
+    yang.gdata.maybe_add(children, 'match-application', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_application, child_match_application)
+    child_target_class_id = yang.gdata.from_xml_opt_str(node, 'target-class-id')
+    yang.gdata.maybe_add(children, 'target-class-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__target_class_id, child_target_class_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements, user_order=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -9833,12 +10731,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule.from_xml(yang.gdata.get_xml_children(n, 'rule')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rule = yang.gdata.from_xml_opt_list(node, 'rule')
+    yang.gdata.maybe_add(children, 'rule', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule, child_rule)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9866,19 +10764,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__profile(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__profile(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__class_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__class_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__direction(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__direction(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__rate_limit(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('decimal64', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__rate_limit(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('decimal64', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__use_lowest_latency(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__use_lowest_latency(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__latency_boundary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__latency_boundary(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(yang.adata.MNode):
@@ -9906,12 +10822,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_bool('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(use_lowest_latency=yang.gdata.from_xml_opt_bool(n, 'use-lowest-latency'), latency_boundary=yang.gdata.from_xml_opt_int(n, 'latency-boundary'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_use_lowest_latency = yang.gdata.from_xml_opt_bool(node, 'use-lowest-latency')
+    yang.gdata.maybe_add(children, 'use-lowest-latency', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__use_lowest_latency, child_use_lowest_latency)
+    child_latency_boundary = yang.gdata.from_xml_opt_int(node, 'latency-boundary')
+    yang.gdata.maybe_add(children, 'latency-boundary', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__latency_boundary, child_latency_boundary)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9942,7 +10860,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__latency_boundary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__latency_boundary(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(yang.adata.MNode):
@@ -9970,12 +10894,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_bool('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=yang.gdata.from_xml_opt_bool(n, 'use-lowest-jitter'), latency_boundary=yang.gdata.from_xml_opt_int(n, 'latency-boundary'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_use_lowest_jitter = yang.gdata.from_xml_opt_bool(node, 'use-lowest-jitter')
+    yang.gdata.maybe_add(children, 'use-lowest-jitter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter, child_use_lowest_jitter)
+    child_latency_boundary = yang.gdata.from_xml_opt_int(node, 'latency-boundary')
+    yang.gdata.maybe_add(children, 'latency-boundary', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__latency_boundary, child_latency_boundary)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10006,7 +10932,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('decimal64', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('decimal64', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__end_to_end(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__end_to_end(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(yang.adata.MNode):
@@ -10034,12 +10966,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_float('guaranteed-bw-percent'), end_to_end=n.get_opt_bool('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=yang.gdata.from_xml_float(n, 'guaranteed-bw-percent'), end_to_end=yang.gdata.from_xml_opt_bool(n, 'end-to-end'))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_guaranteed_bw_percent = yang.gdata.from_xml_float(node, 'guaranteed-bw-percent')
+    yang.gdata.maybe_add(children, 'guaranteed-bw-percent', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent, child_guaranteed_bw_percent)
+    child_end_to_end = yang.gdata.from_xml_opt_bool(node, 'end-to-end')
+    yang.gdata.maybe_add(children, 'end-to-end', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__end_to_end, child_end_to_end)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10110,10 +11044,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry(class_id=n.get_str('class-id'), direction=n.get_opt_str('direction'), rate_limit=n.get_opt_float('rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency.from_gdata(n.get_opt_container('latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter.from_gdata(n.get_opt_container('jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth.from_gdata(n.get_container('bandwidth')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry(class_id=yang.gdata.from_xml_str(n, 'class-id'), direction=yang.gdata.from_xml_opt_str(n, 'direction'), rate_limit=yang.gdata.from_xml_opt_float(n, 'rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency.from_xml(yang.gdata.get_xml_opt_child(n, 'latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter.from_xml(yang.gdata.get_xml_opt_child(n, 'jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth.from_xml(yang.gdata.get_xml_child(n, 'bandwidth')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]
     mut def __init__(self, elements=[]):
@@ -10150,13 +11080,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_class_id = yang.gdata.from_xml_str(node, 'class-id')
+    yang.gdata.maybe_add(children, 'class-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__class_id, child_class_id)
+    child_direction = yang.gdata.from_xml_opt_str(node, 'direction')
+    yang.gdata.maybe_add(children, 'direction', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__direction, child_direction)
+    child_rate_limit = yang.gdata.from_xml_opt_float(node, 'rate-limit')
+    yang.gdata.maybe_add(children, 'rate-limit', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__rate_limit, child_rate_limit)
+    child_latency = yang.gdata.from_xml_opt_cnt(node, 'latency')
+    yang.gdata.maybe_add(children, 'latency', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency, child_latency)
+    child_jitter = yang.gdata.from_xml_opt_cnt(node, 'jitter')
+    yang.gdata.maybe_add(children, 'jitter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter, child_jitter)
+    child_bandwidth = yang.gdata.from_xml_cnt(node, 'bandwidth')
+    yang.gdata.maybe_add(children, 'bandwidth', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth, child_bandwidth)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_class_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_element(e))
+    return yang.gdata.List(keys=['class-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -10256,12 +11201,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class.from_xml(yang.gdata.get_xml_children(n, 'class')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_class_ = yang.gdata.from_xml_opt_list(node, 'class')
+    yang.gdata.maybe_add(children, 'class', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class, child_class_)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10311,12 +11256,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_gdata(n.get_opt_container('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(profile=yang.gdata.from_xml_opt_str(n, 'profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_xml(yang.gdata.get_xml_opt_child(n, 'classes')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_profile = yang.gdata.from_xml_opt_str(node, 'profile')
+    yang.gdata.maybe_add(children, 'profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__profile, child_profile)
+    child_classes = yang.gdata.from_xml_opt_cnt(node, 'classes')
+    yang.gdata.maybe_add(children, 'classes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes, child_classes)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10370,12 +11317,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_gdata(n.get_opt_container('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_gdata(n.get_opt_container('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_xml(yang.gdata.get_xml_opt_child(n, 'qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_xml(yang.gdata.get_xml_opt_child(n, 'qos-profile')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_qos_classification_policy = yang.gdata.from_xml_opt_cnt(node, 'qos-classification-policy')
+    yang.gdata.maybe_add(children, 'qos-classification-policy', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy, child_qos_classification_policy)
+    child_qos_profile = yang.gdata.from_xml_opt_cnt(node, 'qos-profile')
+    yang.gdata.maybe_add(children, 'qos-profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile, child_qos_profile)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10408,6 +11357,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier__signalling_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier__signalling_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(yang.adata.MNode):
     signalling_type: str
 
@@ -10428,12 +11380,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(signalling_type=yang.gdata.from_xml_opt_str(n, 'signalling-type'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_signalling_type = yang.gdata.from_xml_opt_str(node, 'signalling-type')
+    yang.gdata.maybe_add(children, 'signalling-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier__signalling_type, child_signalling_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10460,10 +11412,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_site_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_site_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv4(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv6(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv6(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(yang.adata.MNode):
@@ -10491,12 +11452,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(ipv4=yang.gdata.from_xml_opt_bool(n, 'ipv4'), ipv6=yang.gdata.from_xml_opt_bool(n, 'ipv6'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_bool(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_bool(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv6, child_ipv6)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10525,6 +11488,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     return yang.gdata.Container(children)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__protocol_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__protocol_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(yang.adata.MNode):
@@ -10557,12 +11523,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_gdata(n.get_opt_container('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(multicast_site_type=yang.gdata.from_xml_opt_str(n, 'multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast-address-family')), protocol_type=yang.gdata.from_xml_opt_str(n, 'protocol-type'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_multicast_site_type = yang.gdata.from_xml_opt_str(node, 'multicast-site-type')
+    yang.gdata.maybe_add(children, 'multicast-site-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_site_type, child_multicast_site_type)
+    child_multicast_address_family = yang.gdata.from_xml_opt_cnt(node, 'multicast-address-family')
+    yang.gdata.maybe_add(children, 'multicast-address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family, child_multicast_address_family)
+    child_protocol_type = yang.gdata.from_xml_opt_str(node, 'protocol-type')
+    yang.gdata.maybe_add(children, 'protocol-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__protocol_type, child_protocol_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10640,12 +11610,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(svc_input_bandwidth=n.get_int('svc-input-bandwidth'), svc_output_bandwidth=n.get_int('svc-output-bandwidth'), svc_mtu=n.get_int('svc-mtu'), qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_gdata(n.get_opt_container('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_gdata(n.get_opt_container('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_gdata(n.get_opt_container('multicast')))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(svc_input_bandwidth=yang.gdata.from_xml_int(n, 'svc-input-bandwidth'), svc_output_bandwidth=yang.gdata.from_xml_int(n, 'svc-output-bandwidth'), svc_mtu=yang.gdata.from_xml_int(n, 'svc-mtu'), qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_xml(yang.gdata.get_xml_opt_child(n, 'qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_xml(yang.gdata.get_xml_opt_child(n, 'carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_svc_input_bandwidth = yang.gdata.from_xml_int(node, 'svc-input-bandwidth')
+    yang.gdata.maybe_add(children, 'svc-input-bandwidth', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_input_bandwidth, child_svc_input_bandwidth)
+    child_svc_output_bandwidth = yang.gdata.from_xml_int(node, 'svc-output-bandwidth')
+    yang.gdata.maybe_add(children, 'svc-output-bandwidth', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_output_bandwidth, child_svc_output_bandwidth)
+    child_svc_mtu = yang.gdata.from_xml_int(node, 'svc-mtu')
+    yang.gdata.maybe_add(children, 'svc-mtu', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_mtu, child_svc_mtu)
+    child_qos = yang.gdata.from_xml_opt_cnt(node, 'qos')
+    yang.gdata.maybe_add(children, 'qos', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos, child_qos)
+    child_carrierscarrier = yang.gdata.from_xml_opt_cnt(node, 'carrierscarrier')
+    yang.gdata.maybe_add(children, 'carrierscarrier', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier, child_carrierscarrier)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast, child_multicast)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10695,19 +11675,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__area_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__area_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__metric(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(yang.adata.MNode):
@@ -10732,10 +11730,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=n.get_str('target-site'), metric=n.get_opt_int('metric'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=yang.gdata.from_xml_str(n, 'target-site'), metric=yang.gdata.from_xml_opt_int(n, 'metric'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
@@ -10773,13 +11767,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_target_site = yang.gdata.from_xml_str(node, 'target-site')
+    yang.gdata.maybe_add(children, 'target-site', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site, child_target_site)
+    child_metric = yang.gdata.from_xml_opt_int(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric, child_metric)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_target_site)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(e))
+    return yang.gdata.List(keys=['target-site'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -10863,12 +11864,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_xml(yang.gdata.get_xml_children(n, 'sham-link')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sham_link = yang.gdata.from_xml_opt_list(node, 'sham-link')
+    yang.gdata.maybe_add(children, 'sham-link', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link, child_sham_link)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10926,12 +11927,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(address_family=n.get_opt_strs('address-family'), area_address=n.get_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_container('sham-links')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'), area_address=yang.gdata.from_xml_str(n, 'area-address'), metric=yang.gdata.from_xml_opt_int(n, 'metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_xml(yang.gdata.get_xml_opt_child(n, 'sham-links')))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__address_family, child_address_family)
+    child_area_address = yang.gdata.from_xml_str(node, 'area-address')
+    yang.gdata.maybe_add(children, 'area-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__area_address, child_area_address)
+    child_metric = yang.gdata.from_xml_opt_int(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__metric, child_metric)
+    child_sham_links = yang.gdata.from_xml_opt_cnt(node, 'sham-links')
+    yang.gdata.maybe_add(children, 'sham-links', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links, child_sham_links)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10966,12 +11973,18 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     yang.gdata.maybe_add(children, 'metric', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__metric, child_metric)
     child_sham_links = yang.gdata.take_json_opt_cnt(jd, 'sham-links')
     yang.gdata.maybe_add(children, 'sham-links', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links, child_sham_links)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__autonomous_system(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__autonomous_system(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(yang.adata.MNode):
@@ -10997,12 +12010,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_int('autonomous-system'), address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(autonomous_system=yang.gdata.from_xml_int(n, 'autonomous-system'), address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_autonomous_system = yang.gdata.from_xml_int(node, 'autonomous-system')
+    yang.gdata.maybe_add(children, 'autonomous-system', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__autonomous_system, child_autonomous_system)
+    child_address_family = yang.gdata.from_xml_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11028,15 +12043,24 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     yang.gdata.maybe_add(children, 'autonomous-system', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__autonomous_system, child_autonomous_system)
     child_address_family = yang.gdata.take_json_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(yang.adata.MNode):
@@ -11066,10 +12090,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=yang.gdata.from_xml_str(n, 'lan'), next_hop=yang.gdata.from_xml_str(n, 'next-hop'), lan_tag=yang.gdata.from_xml_opt_str(n, 'lan-tag'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
@@ -11110,13 +12130,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_lan = yang.gdata.from_xml_str(node, 'lan')
+    yang.gdata.maybe_add(children, 'lan', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan, child_lan)
+    child_next_hop = yang.gdata.from_xml_str(node, 'next-hop')
+    yang.gdata.maybe_add(children, 'next-hop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop, child_next_hop)
+    child_lan_tag = yang.gdata.from_xml_opt_str(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag, child_lan_tag)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(e))
+    return yang.gdata.List(keys=['lan', 'next-hop'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -11186,10 +12215,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(yang.adata.MNode):
@@ -11219,10 +12257,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=yang.gdata.from_xml_str(n, 'lan'), next_hop=yang.gdata.from_xml_str(n, 'next-hop'), lan_tag=yang.gdata.from_xml_opt_str(n, 'lan-tag'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
@@ -11263,13 +12297,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_lan = yang.gdata.from_xml_str(node, 'lan')
+    yang.gdata.maybe_add(children, 'lan', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan, child_lan)
+    child_next_hop = yang.gdata.from_xml_str(node, 'next-hop')
+    yang.gdata.maybe_add(children, 'next-hop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop, child_next_hop)
+    child_lan_tag = yang.gdata.from_xml_opt_str(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag, child_lan_tag)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(e))
+    return yang.gdata.List(keys=['lan', 'next-hop'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -11361,12 +12404,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_xml(yang.gdata.get_xml_children(n, 'ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_xml(yang.gdata.get_xml_children(n, 'ipv6-lan-prefixes')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4_lan_prefixes = yang.gdata.from_xml_opt_list(node, 'ipv4-lan-prefixes')
+    yang.gdata.maybe_add(children, 'ipv4-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes, child_ipv4_lan_prefixes)
+    child_ipv6_lan_prefixes = yang.gdata.from_xml_opt_list(node, 'ipv6-lan-prefixes')
+    yang.gdata.maybe_add(children, 'ipv6-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes, child_ipv6_lan_prefixes)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11416,12 +12461,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_container('cascaded-lan-prefixes')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_xml(yang.gdata.get_xml_opt_child(n, 'cascaded-lan-prefixes')))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cascaded_lan_prefixes = yang.gdata.from_xml_opt_cnt(node, 'cascaded-lan-prefixes')
+    yang.gdata.maybe_add(children, 'cascaded-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes, child_cascaded_lan_prefixes)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11444,9 +12489,12 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     children = {}
     child_cascaded_lan_prefixes = yang.gdata.take_json_opt_cnt(jd, 'cascaded-lan-prefixes')
     yang.gdata.maybe_add(children, 'cascaded-lan-prefixes', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes, child_cascaded_lan_prefixes)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(yang.adata.MNode):
@@ -11467,12 +12515,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11494,9 +12542,12 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     children = {}
     child_address_family = yang.gdata.take_json_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(yang.adata.MNode):
@@ -11517,12 +12568,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11544,7 +12595,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     children = {}
     child_address_family = yang.gdata.take_json_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(yang.adata.MNode):
     type: str
@@ -11614,10 +12665,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(type=n.get_str('type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf.from_gdata(n.get_opt_container('ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp.from_gdata(n.get_opt_container('bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static.from_gdata(n.get_opt_container('static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip.from_gdata(n.get_opt_container('rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp.from_gdata(n.get_opt_container('vrrp')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(type=yang.gdata.from_xml_str(n, 'type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf.from_xml(yang.gdata.get_xml_opt_child(n, 'ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static.from_xml(yang.gdata.get_xml_opt_child(n, 'static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip.from_xml(yang.gdata.get_xml_opt_child(n, 'rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp.from_xml(yang.gdata.get_xml_opt_child(n, 'vrrp')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]
     mut def __init__(self, elements=[]):
@@ -11654,13 +12701,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_type = yang.gdata.from_xml_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__type, child_type)
+    child_ospf = yang.gdata.from_xml_opt_cnt(node, 'ospf')
+    yang.gdata.maybe_add(children, 'ospf', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf, child_ospf)
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp, child_bgp)
+    child_static = yang.gdata.from_xml_opt_cnt(node, 'static')
+    yang.gdata.maybe_add(children, 'static', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static, child_static)
+    child_rip = yang.gdata.from_xml_opt_cnt(node, 'rip')
+    yang.gdata.maybe_add(children, 'rip', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip, child_rip)
+    child_vrrp = yang.gdata.from_xml_opt_cnt(node, 'vrrp')
+    yang.gdata.maybe_add(children, 'vrrp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp, child_vrrp)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_element(e))
+    return yang.gdata.List(keys=['type'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -11760,12 +12822,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol.from_xml(yang.gdata.get_xml_children(n, 'routing-protocol')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_routing_protocol = yang.gdata.from_xml_opt_list(node, 'routing-protocol')
+    yang.gdata.maybe_add(children, 'routing-protocol', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol, child_routing_protocol)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11793,6 +12855,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability__access_priority(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability__access_priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(yang.adata.MNode):
     access_priority: int
 
@@ -11813,12 +12878,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(access_priority=n.get_opt_int('access-priority'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(access_priority=yang.gdata.from_xml_opt_int(n, 'access-priority'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_access_priority = yang.gdata.from_xml_opt_int(node, 'access-priority')
+    yang.gdata.maybe_add(children, 'access-priority', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability__access_priority, child_access_priority)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11845,10 +12910,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_policy_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_policy_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__site_role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__site_role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(yang.adata.MNode):
@@ -11881,12 +12955,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(vpn_policy_id=n.get_opt_str('vpn-policy-id'), vpn_id=n.get_opt_str('vpn-id'), site_role=n.get_opt_str('site-role'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(vpn_policy_id=yang.gdata.from_xml_opt_str(n, 'vpn-policy-id'), vpn_id=yang.gdata.from_xml_opt_str(n, 'vpn-id'), site_role=yang.gdata.from_xml_opt_str(n, 'site-role'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vpn_policy_id = yang.gdata.from_xml_opt_str(node, 'vpn-policy-id')
+    yang.gdata.maybe_add(children, 'vpn-policy-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_policy_id, child_vpn_policy_id)
+    child_vpn_id = yang.gdata.from_xml_opt_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_id, child_vpn_id)
+    child_site_role = yang.gdata.from_xml_opt_str(node, 'site-role')
+    yang.gdata.maybe_add(children, 'site-role', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__site_role, child_site_role)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11991,10 +13069,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry(site_network_access_id=n.get_str('site-network-access-id'), site_network_access_type=n.get_opt_str('site-network-access-type'), location_reference=n.get_opt_str('location-reference'), device_reference=n.get_opt_str('device-reference'), access_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity.from_gdata(n.get_opt_container('access-diversity')), bearer=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer.from_gdata(n.get_opt_container('bearer')), ip_connection=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection.from_gdata(n.get_opt_container('ip-connection')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security.from_gdata(n.get_opt_container('security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service.from_gdata(n.get_container('service')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols.from_gdata(n.get_opt_container('routing-protocols')), availability=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability.from_gdata(n.get_opt_container('availability')), vpn_attachment=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment.from_gdata(n.get_opt_container('vpn-attachment')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry(site_network_access_id=yang.gdata.from_xml_str(n, 'site-network-access-id'), site_network_access_type=yang.gdata.from_xml_opt_str(n, 'site-network-access-type'), location_reference=yang.gdata.from_xml_opt_str(n, 'location-reference'), device_reference=yang.gdata.from_xml_opt_str(n, 'device-reference'), access_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity.from_xml(yang.gdata.get_xml_opt_child(n, 'access-diversity')), bearer=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer.from_xml(yang.gdata.get_xml_opt_child(n, 'bearer')), ip_connection=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection.from_xml(yang.gdata.get_xml_opt_child(n, 'ip-connection')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security.from_xml(yang.gdata.get_xml_opt_child(n, 'security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service.from_xml(yang.gdata.get_xml_child(n, 'service')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols.from_xml(yang.gdata.get_xml_opt_child(n, 'routing-protocols')), availability=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability.from_xml(yang.gdata.get_xml_opt_child(n, 'availability')), vpn_attachment=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn-attachment')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]
     mut def __init__(self, elements=[]):
@@ -12031,13 +13105,40 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_site_network_access_id = yang.gdata.from_xml_str(node, 'site-network-access-id')
+    yang.gdata.maybe_add(children, 'site-network-access-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_id, child_site_network_access_id)
+    child_site_network_access_type = yang.gdata.from_xml_opt_str(node, 'site-network-access-type')
+    yang.gdata.maybe_add(children, 'site-network-access-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_type, child_site_network_access_type)
+    child_location_reference = yang.gdata.from_xml_opt_str(node, 'location-reference')
+    yang.gdata.maybe_add(children, 'location-reference', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__location_reference, child_location_reference)
+    child_device_reference = yang.gdata.from_xml_opt_str(node, 'device-reference')
+    yang.gdata.maybe_add(children, 'device-reference', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__device_reference, child_device_reference)
+    child_access_diversity = yang.gdata.from_xml_opt_cnt(node, 'access-diversity')
+    yang.gdata.maybe_add(children, 'access-diversity', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity, child_access_diversity)
+    child_bearer = yang.gdata.from_xml_opt_cnt(node, 'bearer')
+    yang.gdata.maybe_add(children, 'bearer', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer, child_bearer)
+    child_ip_connection = yang.gdata.from_xml_opt_cnt(node, 'ip-connection')
+    yang.gdata.maybe_add(children, 'ip-connection', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection, child_ip_connection)
+    child_security = yang.gdata.from_xml_opt_cnt(node, 'security')
+    yang.gdata.maybe_add(children, 'security', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security, child_security)
+    child_service = yang.gdata.from_xml_cnt(node, 'service')
+    yang.gdata.maybe_add(children, 'service', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service, child_service)
+    child_routing_protocols = yang.gdata.from_xml_opt_cnt(node, 'routing-protocols')
+    yang.gdata.maybe_add(children, 'routing-protocols', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols, child_routing_protocols)
+    child_availability = yang.gdata.from_xml_opt_cnt(node, 'availability')
+    yang.gdata.maybe_add(children, 'availability', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability, child_availability)
+    child_vpn_attachment = yang.gdata.from_xml_opt_cnt(node, 'vpn-attachment')
+    yang.gdata.maybe_add(children, 'vpn-attachment', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment, child_vpn_attachment)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_site_network_access_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_element(e))
+    return yang.gdata.List(keys=['site-network-access-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -12161,12 +13262,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(site_network_access=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access.from_gdata(n.get_opt_list('site-network-access')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(site_network_access=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access.from_xml(yang.gdata.get_xml_children(n, 'site-network-access')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_site_network_access = yang.gdata.from_xml_opt_list(node, 'site-network-access')
+    yang.gdata.maybe_add(children, 'site-network-access', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access, child_site_network_access)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -12279,10 +13380,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(site_id=n.get_str('site-id'), requested_site_start=n.get_opt_str('requested-site-start'), requested_site_stop=n.get_opt_str('requested-site-stop'), locations=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations.from_gdata(n.get_opt_container('locations')), devices=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices.from_gdata(n.get_opt_container('devices')), site_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity.from_gdata(n.get_opt_container('site-diversity')), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__management.from_gdata(n.get_container('management')), vpn_policies=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies.from_gdata(n.get_opt_container('vpn-policies')), site_vpn_flavor=n.get_opt_str('site-vpn-flavor'), maximum_routes=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes.from_gdata(n.get_opt_container('maximum-routes')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__security.from_gdata(n.get_opt_container('security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__service.from_gdata(n.get_opt_container('service')), traffic_protection=ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection.from_gdata(n.get_opt_container('traffic-protection')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols.from_gdata(n.get_opt_container('routing-protocols')), site_network_accesses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses.from_gdata(n.get_opt_container('site-network-accesses')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(site_id=yang.gdata.from_xml_str(n, 'site-id'), requested_site_start=yang.gdata.from_xml_opt_str(n, 'requested-site-start'), requested_site_stop=yang.gdata.from_xml_opt_str(n, 'requested-site-stop'), locations=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations.from_xml(yang.gdata.get_xml_opt_child(n, 'locations')), devices=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices.from_xml(yang.gdata.get_xml_opt_child(n, 'devices')), site_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity.from_xml(yang.gdata.get_xml_opt_child(n, 'site-diversity')), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__management.from_xml(yang.gdata.get_xml_child(n, 'management')), vpn_policies=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn-policies')), site_vpn_flavor=yang.gdata.from_xml_opt_str(n, 'site-vpn-flavor'), maximum_routes=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes.from_xml(yang.gdata.get_xml_opt_child(n, 'maximum-routes')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__security.from_xml(yang.gdata.get_xml_opt_child(n, 'security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__service.from_xml(yang.gdata.get_xml_opt_child(n, 'service')), traffic_protection=ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection.from_xml(yang.gdata.get_xml_opt_child(n, 'traffic-protection')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols.from_xml(yang.gdata.get_xml_opt_child(n, 'routing-protocols')), site_network_accesses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses.from_xml(yang.gdata.get_xml_opt_child(n, 'site-network-accesses')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]
     mut def __init__(self, elements=[]):
@@ -12319,13 +13416,46 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site(yang.adata.MNode):
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_site_id = yang.gdata.from_xml_str(node, 'site-id')
+    yang.gdata.maybe_add(children, 'site-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_id, child_site_id)
+    child_requested_site_start = yang.gdata.from_xml_opt_str(node, 'requested-site-start')
+    yang.gdata.maybe_add(children, 'requested-site-start', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_start, child_requested_site_start)
+    child_requested_site_stop = yang.gdata.from_xml_opt_str(node, 'requested-site-stop')
+    yang.gdata.maybe_add(children, 'requested-site-stop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_stop, child_requested_site_stop)
+    child_locations = yang.gdata.from_xml_opt_cnt(node, 'locations')
+    yang.gdata.maybe_add(children, 'locations', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations, child_locations)
+    child_devices = yang.gdata.from_xml_opt_cnt(node, 'devices')
+    yang.gdata.maybe_add(children, 'devices', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices, child_devices)
+    child_site_diversity = yang.gdata.from_xml_opt_cnt(node, 'site-diversity')
+    yang.gdata.maybe_add(children, 'site-diversity', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity, child_site_diversity)
+    child_management = yang.gdata.from_xml_cnt(node, 'management')
+    yang.gdata.maybe_add(children, 'management', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management, child_management)
+    child_vpn_policies = yang.gdata.from_xml_opt_cnt(node, 'vpn-policies')
+    yang.gdata.maybe_add(children, 'vpn-policies', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies, child_vpn_policies)
+    child_site_vpn_flavor = yang.gdata.from_xml_opt_str(node, 'site-vpn-flavor')
+    yang.gdata.maybe_add(children, 'site-vpn-flavor', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_vpn_flavor, child_site_vpn_flavor)
+    child_maximum_routes = yang.gdata.from_xml_opt_cnt(node, 'maximum-routes')
+    yang.gdata.maybe_add(children, 'maximum-routes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes, child_maximum_routes)
+    child_security = yang.gdata.from_xml_opt_cnt(node, 'security')
+    yang.gdata.maybe_add(children, 'security', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security, child_security)
+    child_service = yang.gdata.from_xml_opt_cnt(node, 'service')
+    yang.gdata.maybe_add(children, 'service', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service, child_service)
+    child_traffic_protection = yang.gdata.from_xml_opt_cnt(node, 'traffic-protection')
+    yang.gdata.maybe_add(children, 'traffic-protection', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection, child_traffic_protection)
+    child_routing_protocols = yang.gdata.from_xml_opt_cnt(node, 'routing-protocols')
+    yang.gdata.maybe_add(children, 'routing-protocols', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols, child_routing_protocols)
+    child_site_network_accesses = yang.gdata.from_xml_opt_cnt(node, 'site-network-accesses')
+    yang.gdata.maybe_add(children, 'site-network-accesses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses, child_site_network_accesses)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_site_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(e))
+    return yang.gdata.List(keys=['site-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -12461,12 +13591,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites(site=ietf_l3vpn_svc__l3vpn_svc__sites__site.from_gdata(n.get_opt_list('site')))
         return ietf_l3vpn_svc__l3vpn_svc__sites()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites(site=ietf_l3vpn_svc__l3vpn_svc__sites__site.from_xml(yang.gdata.get_xml_children(n, 'site')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_site = yang.gdata.from_xml_opt_list(node, 'site')
+    yang.gdata.maybe_add(children, 'site', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site, child_site)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -12521,12 +13651,16 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc(vpn_profiles=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_gdata(n.get_opt_container('vpn-profiles')), vpn_services=ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_gdata(n.get_opt_container('vpn-services')), sites=ietf_l3vpn_svc__l3vpn_svc__sites.from_gdata(n.get_opt_container('sites')))
         return ietf_l3vpn_svc__l3vpn_svc()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc(vpn_profiles=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn-profiles')), vpn_services=ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn-services')), sites=ietf_l3vpn_svc__l3vpn_svc__sites.from_xml(yang.gdata.get_xml_opt_child(n, 'sites')))
-        return ietf_l3vpn_svc__l3vpn_svc()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vpn_profiles = yang.gdata.from_xml_opt_cnt(node, 'vpn-profiles')
+    yang.gdata.maybe_add(children, 'vpn-profiles', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles, child_vpn_profiles)
+    child_vpn_services = yang.gdata.from_xml_opt_cnt(node, 'vpn-services')
+    yang.gdata.maybe_add(children, 'vpn-services', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services, child_vpn_services)
+    child_sites = yang.gdata.from_xml_opt_cnt(node, 'sites')
+    yang.gdata.maybe_add(children, 'sites', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites, child_sites)
+    return yang.gdata.Container(children, ns='urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc', module='ietf-l3vpn-svc')
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -12586,12 +13720,14 @@ class root(yang.adata.MNode):
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_container('netinfra')), l3vpn_svc=ietf_l3vpn_svc__l3vpn_svc.from_gdata(n.get_opt_container('l3vpn-svc')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(netinfra=netinfra__netinfra.from_xml(yang.gdata.get_xml_opt_child(n, 'netinfra', 'http://example.com/netinfra')), l3vpn_svc=ietf_l3vpn_svc__l3vpn_svc.from_xml(yang.gdata.get_xml_opt_child(n, 'l3vpn-svc', 'urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_netinfra = yang.gdata.from_xml_opt_cnt(node, 'netinfra', 'http://example.com/netinfra')
+    yang.gdata.maybe_add(children, 'netinfra', from_xml_netinfra__netinfra, child_netinfra)
+    child_l3vpn_svc = yang.gdata.from_xml_opt_cnt(node, 'l3vpn-svc', 'urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc')
+    yang.gdata.maybe_add(children, 'l3vpn-svc', from_xml_ietf_l3vpn_svc__l3vpn_svc, child_l3vpn_svc)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/src/respnet/layers/y_0_loose.act
+++ b/src/respnet/layers/y_0_loose.act
@@ -10,16 +10,31 @@ import yang.gdata
 mut def from_json_netinfra__netinfra__router__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra__netinfra__router__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__router__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_netinfra__netinfra__router__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 mut def from_json_netinfra__netinfra__router__role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra__netinfra__router__role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__router__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_netinfra__netinfra__router__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_netinfra__netinfra__router__mock(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_netinfra__netinfra__router__mock(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 class netinfra__netinfra__router_entry(yang.adata.MNode):
@@ -60,10 +75,6 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
         return netinfra__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), role=n.get_opt_str('role'), asn=n.get_opt_int('asn'), mock=n.get_opt_str('mock'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra__netinfra__router_entry:
-        return netinfra__netinfra__router_entry(name=yang.gdata.from_xml_str(n, 'name'), id=yang.gdata.from_xml_opt_int(n, 'id'), role=yang.gdata.from_xml_opt_str(n, 'role'), asn=yang.gdata.from_xml_opt_int(n, 'asn'), mock=yang.gdata.from_xml_opt_str(n, 'mock'))
-
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -100,13 +111,26 @@ class netinfra__netinfra__router(yang.adata.MNode):
                 res.append(netinfra__netinfra__router_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra__netinfra__router_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra__netinfra__router_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra__netinfra__router_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_netinfra__netinfra__router__name, child_name)
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_netinfra__netinfra__router__id, child_id)
+    child_role = yang.gdata.from_xml_opt_str(node, 'role')
+    yang.gdata.maybe_add(children, 'role', from_xml_netinfra__netinfra__router__role, child_role)
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_netinfra__netinfra__router__asn, child_asn)
+    child_mock = yang.gdata.from_xml_opt_str(node, 'mock')
+    yang.gdata.maybe_add(children, 'mock', from_xml_netinfra__netinfra__router__mock, child_mock)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_netinfra__netinfra__router(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra__netinfra__router_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_netinfra__netinfra__router_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -185,13 +209,25 @@ mut def from_json_netinfra__netinfra__router(jd: list[dict[str, ?value]]) -> yan
 mut def from_json_netinfra__netinfra__backbone_link__left_router(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra__netinfra__backbone_link__left_router(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__backbone_link__left_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra__netinfra__backbone_link__left_interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_netinfra__netinfra__backbone_link__right_router(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra__netinfra__backbone_link__right_router(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra__netinfra__backbone_link__right_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra__netinfra__backbone_link__right_interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
@@ -226,10 +262,6 @@ class netinfra__netinfra__backbone_link_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__backbone_link_entry:
         return netinfra__netinfra__backbone_link_entry(left_router=n.get_str('left-router'), left_interface=n.get_str('left-interface'), right_router=n.get_str('right-router'), right_interface=n.get_str('right-interface'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra__netinfra__backbone_link_entry:
-        return netinfra__netinfra__backbone_link_entry(left_router=yang.gdata.from_xml_str(n, 'left-router'), left_interface=yang.gdata.from_xml_str(n, 'left-interface'), right_router=yang.gdata.from_xml_str(n, 'right-router'), right_interface=yang.gdata.from_xml_str(n, 'right-interface'))
 
 class netinfra__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra__netinfra__backbone_link_entry]
@@ -276,13 +308,24 @@ class netinfra__netinfra__backbone_link(yang.adata.MNode):
                 res.append(netinfra__netinfra__backbone_link_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra__netinfra__backbone_link_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra__netinfra__backbone_link_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra__netinfra__backbone_link_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_left_router = yang.gdata.from_xml_str(node, 'left-router')
+    yang.gdata.maybe_add(children, 'left-router', from_xml_netinfra__netinfra__backbone_link__left_router, child_left_router)
+    child_left_interface = yang.gdata.from_xml_str(node, 'left-interface')
+    yang.gdata.maybe_add(children, 'left-interface', from_xml_netinfra__netinfra__backbone_link__left_interface, child_left_interface)
+    child_right_router = yang.gdata.from_xml_str(node, 'right-router')
+    yang.gdata.maybe_add(children, 'right-router', from_xml_netinfra__netinfra__backbone_link__right_router, child_right_router)
+    child_right_interface = yang.gdata.from_xml_str(node, 'right-interface')
+    yang.gdata.maybe_add(children, 'right-interface', from_xml_netinfra__netinfra__backbone_link__right_interface, child_right_interface)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_left_router), yang.gdata.yang_str(child_left_interface), yang.gdata.yang_str(child_right_router), yang.gdata.yang_str(child_right_interface)])
+
+mut def from_xml_netinfra__netinfra__backbone_link(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra__netinfra__backbone_link_element(e))
+    return yang.gdata.List(keys=['left-router', 'left-interface', 'right-router', 'right-interface'], elements=elements)
 
 mut def from_json_path_netinfra__netinfra__backbone_link_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -376,12 +419,14 @@ class netinfra__netinfra(yang.adata.MNode):
             return netinfra__netinfra(router=netinfra__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')))
         return netinfra__netinfra()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> netinfra__netinfra:
-        if n != None:
-            return netinfra__netinfra(router=netinfra__netinfra__router.from_xml(yang.gdata.get_xml_children(n, 'router')), backbone_link=netinfra__netinfra__backbone_link.from_xml(yang.gdata.get_xml_children(n, 'backbone-link')))
-        return netinfra__netinfra()
 
+mut def from_xml_netinfra__netinfra(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_router = yang.gdata.from_xml_opt_list(node, 'router')
+    yang.gdata.maybe_add(children, 'router', from_xml_netinfra__netinfra__router, child_router)
+    child_backbone_link = yang.gdata.from_xml_opt_list(node, 'backbone-link')
+    yang.gdata.maybe_add(children, 'backbone-link', from_xml_netinfra__netinfra__backbone_link, child_backbone_link)
+    return yang.gdata.Container(children, ns='http://example.com/netinfra', module='netinfra')
 
 mut def from_json_path_netinfra__netinfra(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -414,6 +459,9 @@ mut def from_json_netinfra__netinfra(jd: dict[str, ?value]) -> yang.gdata.Contai
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -431,10 +479,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(id=n.get_str('id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry(id=yang.gdata.from_xml_str(n, 'id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]
@@ -472,13 +516,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -541,6 +590,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -558,10 +610,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(id=n.get_str('id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry(id=yang.gdata.from_xml_str(n, 'id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]
@@ -599,13 +647,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encry
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -668,6 +721,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -685,10 +741,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(id=n.get_str('id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry(id=yang.gdata.from_xml_str(n, 'id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]
@@ -726,13 +778,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_p
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -795,6 +852,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identi
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(yang.adata.MNode):
     id: str
 
@@ -812,10 +872,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(id=n.get_str('id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry(id=yang.gdata.from_xml_str(n, 'id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]
@@ -853,13 +909,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_p
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -954,12 +1015,18 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(cloud_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier.from_gdata(n.get_opt_list('cloud-identifier')), encryption_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier.from_gdata(n.get_opt_list('encryption-profile-identifier')), qos_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier.from_gdata(n.get_opt_list('qos-profile-identifier')), bfd_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier.from_gdata(n.get_opt_list('bfd-profile-identifier')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(cloud_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier.from_xml(yang.gdata.get_xml_children(n, 'cloud-identifier')), encryption_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier.from_xml(yang.gdata.get_xml_children(n, 'encryption-profile-identifier')), qos_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier.from_xml(yang.gdata.get_xml_children(n, 'qos-profile-identifier')), bfd_profile_identifier=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier.from_xml(yang.gdata.get_xml_children(n, 'bfd-profile-identifier')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cloud_identifier = yang.gdata.from_xml_opt_list(node, 'cloud-identifier')
+    yang.gdata.maybe_add(children, 'cloud-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__cloud_identifier, child_cloud_identifier)
+    child_encryption_profile_identifier = yang.gdata.from_xml_opt_list(node, 'encryption-profile-identifier')
+    yang.gdata.maybe_add(children, 'encryption-profile-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__encryption_profile_identifier, child_encryption_profile_identifier)
+    child_qos_profile_identifier = yang.gdata.from_xml_opt_list(node, 'qos-profile-identifier')
+    yang.gdata.maybe_add(children, 'qos-profile-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__qos_profile_identifier, child_qos_profile_identifier)
+    child_bfd_profile_identifier = yang.gdata.from_xml_opt_list(node, 'bfd-profile-identifier')
+    yang.gdata.maybe_add(children, 'bfd-profile-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers__bfd_profile_identifier, child_bfd_profile_identifier)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1019,12 +1086,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(valid_provider_identifiers=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_gdata(n.get_opt_container('valid-provider-identifiers')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_profiles:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(valid_provider_identifiers=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers.from_xml(yang.gdata.get_xml_opt_child(n, 'valid-provider-identifiers')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_profiles()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_valid_provider_identifiers = yang.gdata.from_xml_opt_cnt(node, 'valid-provider-identifiers')
+    yang.gdata.maybe_add(children, 'valid-provider-identifiers', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles__valid_provider_identifiers, child_valid_provider_identifiers)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1052,28 +1119,55 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles(jd: dict[str, ?value])
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__customer_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__customer_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_service_topology(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_service_topology(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__cloud_identifier(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__cloud_identifier(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_any(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_any(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_site(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('leafref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_site(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('leafref', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__deny_site(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__deny_site(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__nat44_customer_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__nat44_customer_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(yang.adata.MNode):
@@ -1101,12 +1195,14 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(enabled=n.get_opt_bool('enabled'), nat44_customer_address=n.get_opt_str('nat44-customer-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), nat44_customer_address=yang.gdata.from_xml_opt_str(n, 'nat44-customer-address'))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__enabled, child_enabled)
+    child_nat44_customer_address = yang.gdata.from_xml_opt_str(node, 'nat44-customer-address')
+    yang.gdata.maybe_add(children, 'nat44-customer-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44__nat44_customer_address, child_nat44_customer_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1154,12 +1250,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(nat44=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_gdata(n.get_opt_container('nat44')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(nat44=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44.from_xml(yang.gdata.get_xml_opt_child(n, 'nat44')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_nat44 = yang.gdata.from_xml_opt_cnt(node, 'nat44')
+    yang.gdata.maybe_add(children, 'nat44', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation__nat44, child_nat44)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1218,10 +1314,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry(cloud_identifier=n.get_str('cloud-identifier'), permit_any=n.get_opt_bool('permit-any'), permit_site=n.get_opt_strs('permit-site'), deny_site=n.get_opt_strs('deny-site'), address_translation=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation.from_gdata(n.get_opt_container('address-translation')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry(cloud_identifier=yang.gdata.from_xml_str(n, 'cloud-identifier'), permit_any=yang.gdata.from_xml_opt_bool(n, 'permit-any'), permit_site=yang.gdata.from_xml_opt_strs(n, 'permit-site'), deny_site=yang.gdata.from_xml_opt_strs(n, 'deny-site'), address_translation=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation.from_xml(yang.gdata.get_xml_opt_child(n, 'address-translation')))
-
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]
     mut def __init__(self, elements=[]):
@@ -1258,13 +1350,26 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__clou
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_cloud_identifier = yang.gdata.from_xml_str(node, 'cloud-identifier')
+    yang.gdata.maybe_add(children, 'cloud-identifier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__cloud_identifier, child_cloud_identifier)
+    child_permit_any = yang.gdata.from_xml_opt_bool(node, 'permit-any')
+    yang.gdata.maybe_add(children, 'permit-any', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_any, child_permit_any)
+    child_permit_site = yang.gdata.from_xml_opt_strs(node, 'permit-site')
+    yang.gdata.maybe_add(children, 'permit-site', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__permit_site, child_permit_site)
+    child_deny_site = yang.gdata.from_xml_opt_strs(node, 'deny-site')
+    yang.gdata.maybe_add(children, 'deny-site', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__deny_site, child_deny_site)
+    child_address_translation = yang.gdata.from_xml_opt_cnt(node, 'address-translation')
+    yang.gdata.maybe_add(children, 'address-translation', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access__address_translation, child_address_translation)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_cloud_identifier)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_element(e))
+    return yang.gdata.List(keys=['cloud-identifier'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1360,12 +1465,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(yang.
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(cloud_access=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access.from_gdata(n.get_opt_list('cloud-access')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(cloud_access=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access.from_xml(yang.gdata.get_xml_children(n, 'cloud-access')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cloud_access = yang.gdata.from_xml_opt_list(node, 'cloud-access')
+    yang.gdata.maybe_add(children, 'cloud-access', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses__cloud_access, child_cloud_access)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1393,7 +1498,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_ac
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors__tree_flavor(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors__tree_flavor(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('identityref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(yang.adata.MNode):
@@ -1414,12 +1525,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(tree_flavor=n.get_opt_strs('tree-flavor'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(tree_flavor=yang.gdata.from_xml_opt_strs(n, 'tree-flavor'))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_tree_flavor = yang.gdata.from_xml_opt_strs(node, 'tree-flavor')
+    yang.gdata.maybe_add(children, 'tree-flavor', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors__tree_flavor, child_tree_flavor)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1446,13 +1557,25 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__rp_redundancy(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__rp_redundancy(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__optimal_traffic_delivery(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__optimal_traffic_delivery(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(yang.adata.MNode):
@@ -1485,12 +1608,16 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(enabled=n.get_opt_bool('enabled'), rp_redundancy=n.get_opt_bool('rp-redundancy'), optimal_traffic_delivery=n.get_opt_bool('optimal-traffic-delivery'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), rp_redundancy=yang.gdata.from_xml_opt_bool(n, 'rp-redundancy'), optimal_traffic_delivery=yang.gdata.from_xml_opt_bool(n, 'optimal-traffic-delivery'))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__enabled, child_enabled)
+    child_rp_redundancy = yang.gdata.from_xml_opt_bool(node, 'rp-redundancy')
+    yang.gdata.maybe_add(children, 'rp-redundancy', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__rp_redundancy, child_rp_redundancy)
+    child_optimal_traffic_delivery = yang.gdata.from_xml_opt_bool(node, 'optimal-traffic-delivery')
+    yang.gdata.maybe_add(children, 'optimal-traffic-delivery', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed__optimal_traffic_delivery, child_optimal_traffic_delivery)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1525,16 +1652,31 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__rp_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__rp_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_start(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_start(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_end(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_end(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(yang.adata.MNode):
@@ -1569,10 +1711,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(id=n.get_int('id'), group_address=n.get_opt_str('group-address'), group_start=n.get_opt_str('group-start'), group_end=n.get_opt_str('group-end'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry(id=yang.gdata.from_xml_int(n, 'id'), group_address=yang.gdata.from_xml_opt_str(n, 'group-address'), group_start=yang.gdata.from_xml_opt_str(n, 'group-start'), group_end=yang.gdata.from_xml_opt_str(n, 'group-end'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]
@@ -1610,13 +1748,24 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__id, child_id)
+    child_group_address = yang.gdata.from_xml_opt_str(node, 'group-address')
+    yang.gdata.maybe_add(children, 'group-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_address, child_group_address)
+    child_group_start = yang.gdata.from_xml_opt_str(node, 'group-start')
+    yang.gdata.maybe_add(children, 'group-start', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_start, child_group_start)
+    child_group_end = yang.gdata.from_xml_opt_str(node, 'group-end')
+    yang.gdata.maybe_add(children, 'group-end', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group__group_end, child_group_end)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1708,12 +1857,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(group=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(group=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups__group, child_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1771,10 +1920,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry(id=n.get_int('id'), provider_managed=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed.from_gdata(n.get_opt_container('provider-managed')), rp_address=n.get_opt_str('rp-address'), groups=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups.from_gdata(n.get_opt_container('groups')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry(id=yang.gdata.from_xml_int(n, 'id'), provider_managed=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed.from_xml(yang.gdata.get_xml_opt_child(n, 'provider-managed')), rp_address=yang.gdata.from_xml_opt_str(n, 'rp-address'), groups=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups.from_xml(yang.gdata.get_xml_opt_child(n, 'groups')))
-
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]
     mut def __init__(self, elements=[]):
@@ -1811,13 +1956,24 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__id, child_id)
+    child_provider_managed = yang.gdata.from_xml_opt_cnt(node, 'provider-managed')
+    yang.gdata.maybe_add(children, 'provider-managed', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__provider_managed, child_provider_managed)
+    child_rp_address = yang.gdata.from_xml_str(node, 'rp-address')
+    yang.gdata.maybe_add(children, 'rp-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__rp_address, child_rp_address)
+    child_groups = yang.gdata.from_xml_opt_cnt(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping__groups, child_groups)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1909,12 +2065,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_gr
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(rp_group_mapping=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping.from_gdata(n.get_opt_list('rp-group-mapping')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(rp_group_mapping=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping.from_xml(yang.gdata.get_xml_children(n, 'rp-group-mapping')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rp_group_mapping = yang.gdata.from_xml_opt_list(node, 'rp-group-mapping')
+    yang.gdata.maybe_add(children, 'rp-group-mapping', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings__rp_group_mapping, child_rp_group_mapping)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1942,7 +2098,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__rp_discovery_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__rp_discovery_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates__bsr_candidate_address(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates__bsr_candidate_address(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(yang.adata.MNode):
@@ -1963,12 +2125,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(bsr_candidate_address=n.get_opt_strs('bsr-candidate-address'))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(bsr_candidate_address=yang.gdata.from_xml_opt_strs(n, 'bsr-candidate-address'))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bsr_candidate_address = yang.gdata.from_xml_opt_strs(node, 'bsr-candidate-address')
+    yang.gdata.maybe_add(children, 'bsr-candidate-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates__bsr_candidate_address, child_bsr_candidate_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2017,12 +2179,14 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_di
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(rp_discovery_type=n.get_opt_str('rp-discovery-type'), bsr_candidates=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_gdata(n.get_opt_container('bsr-candidates')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(rp_discovery_type=yang.gdata.from_xml_opt_str(n, 'rp-discovery-type'), bsr_candidates=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates.from_xml(yang.gdata.get_xml_opt_child(n, 'bsr-candidates')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rp_discovery_type = yang.gdata.from_xml_opt_str(node, 'rp-discovery-type')
+    yang.gdata.maybe_add(children, 'rp-discovery-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__rp_discovery_type, child_rp_discovery_type)
+    child_bsr_candidates = yang.gdata.from_xml_opt_cnt(node, 'bsr-candidates')
+    yang.gdata.maybe_add(children, 'bsr-candidates', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery__bsr_candidates, child_bsr_candidates)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2076,12 +2240,14 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(rp_group_mappings=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_gdata(n.get_opt_container('rp-group-mappings')), rp_discovery=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_gdata(n.get_opt_container('rp-discovery')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(rp_group_mappings=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings.from_xml(yang.gdata.get_xml_opt_child(n, 'rp-group-mappings')), rp_discovery=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery.from_xml(yang.gdata.get_xml_opt_child(n, 'rp-discovery')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rp_group_mappings = yang.gdata.from_xml_opt_cnt(node, 'rp-group-mappings')
+    yang.gdata.maybe_add(children, 'rp-group-mappings', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_group_mappings, child_rp_group_mappings)
+    child_rp_discovery = yang.gdata.from_xml_opt_cnt(node, 'rp-discovery')
+    yang.gdata.maybe_add(children, 'rp-discovery', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp__rp_discovery, child_rp_discovery)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2141,12 +2307,16 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(yang.adata
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(enabled=n.get_opt_bool('enabled'), customer_tree_flavors=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_gdata(n.get_opt_container('customer-tree-flavors')), rp=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_gdata(n.get_opt_container('rp')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), customer_tree_flavors=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-tree-flavors')), rp=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp.from_xml(yang.gdata.get_xml_opt_child(n, 'rp')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__enabled, child_enabled)
+    child_customer_tree_flavors = yang.gdata.from_xml_opt_cnt(node, 'customer-tree-flavors')
+    yang.gdata.maybe_add(children, 'customer-tree-flavors', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__customer_tree_flavors, child_customer_tree_flavors)
+    child_rp = yang.gdata.from_xml_opt_cnt(node, 'rp')
+    yang.gdata.maybe_add(children, 'rp', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast__rp, child_rp)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2183,10 +2353,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__carrierscarrier(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__carrierscarrier(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__local_sites_role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__local_sites_role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(yang.adata.MNode):
@@ -2211,10 +2390,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(vpn_id=n.get_str('vpn-id'), local_sites_role=n.get_opt_str('local-sites-role'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry(vpn_id=yang.gdata.from_xml_str(n, 'vpn-id'), local_sites_role=yang.gdata.from_xml_opt_str(n, 'local-sites-role'))
 
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]
@@ -2252,13 +2427,20 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extra
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_id = yang.gdata.from_xml_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__vpn_id, child_vpn_id)
+    child_local_sites_role = yang.gdata.from_xml_opt_str(node, 'local-sites-role')
+    yang.gdata.maybe_add(children, 'local-sites-role', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn__local_sites_role, child_local_sites_role)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_element(e))
+    return yang.gdata.List(keys=['vpn-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2342,12 +2524,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(extranet_vpn=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn.from_gdata(n.get_opt_list('extranet-vpn')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(extranet_vpn=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn.from_xml(yang.gdata.get_xml_children(n, 'extranet-vpn')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_extranet_vpn = yang.gdata.from_xml_opt_list(node, 'extranet-vpn')
+    yang.gdata.maybe_add(children, 'extranet-vpn', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns__extranet_vpn, child_extranet_vpn)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2420,10 +2602,6 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(yang.adata.MNod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry:
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(vpn_id=n.get_str('vpn-id'), customer_name=n.get_opt_str('customer-name'), vpn_service_topology=n.get_opt_str('vpn-service-topology'), cloud_accesses=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses.from_gdata(n.get_opt_container('cloud-accesses')), multicast=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast.from_gdata(n.get_opt_container('multicast')), carrierscarrier=n.get_opt_bool('carrierscarrier'), extranet_vpns=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns.from_gdata(n.get_opt_container('extranet-vpns')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry(vpn_id=yang.gdata.from_xml_str(n, 'vpn-id'), customer_name=yang.gdata.from_xml_opt_str(n, 'customer-name'), vpn_service_topology=yang.gdata.from_xml_opt_str(n, 'vpn-service-topology'), cloud_accesses=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses.from_xml(yang.gdata.get_xml_opt_child(n, 'cloud-accesses')), multicast=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')), carrierscarrier=yang.gdata.from_xml_opt_bool(n, 'carrierscarrier'), extranet_vpns=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns.from_xml(yang.gdata.get_xml_opt_child(n, 'extranet-vpns')))
-
 class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]
     mut def __init__(self, elements=[]):
@@ -2460,13 +2638,30 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(yang.adata.MNode):
                 res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_id = yang.gdata.from_xml_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_id, child_vpn_id)
+    child_customer_name = yang.gdata.from_xml_opt_str(node, 'customer-name')
+    yang.gdata.maybe_add(children, 'customer-name', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__customer_name, child_customer_name)
+    child_vpn_service_topology = yang.gdata.from_xml_opt_str(node, 'vpn-service-topology')
+    yang.gdata.maybe_add(children, 'vpn-service-topology', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__vpn_service_topology, child_vpn_service_topology)
+    child_cloud_accesses = yang.gdata.from_xml_opt_cnt(node, 'cloud-accesses')
+    yang.gdata.maybe_add(children, 'cloud-accesses', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__cloud_accesses, child_cloud_accesses)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__multicast, child_multicast)
+    child_carrierscarrier = yang.gdata.from_xml_opt_bool(node, 'carrierscarrier')
+    yang.gdata.maybe_add(children, 'carrierscarrier', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__carrierscarrier, child_carrierscarrier)
+    child_extranet_vpns = yang.gdata.from_xml_opt_cnt(node, 'extranet-vpns')
+    yang.gdata.maybe_add(children, 'extranet-vpns', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service__extranet_vpns, child_extranet_vpns)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(e))
+    return yang.gdata.List(keys=['vpn-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2570,12 +2765,12 @@ class ietf_l3vpn_svc__l3vpn_svc__vpn_services(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__vpn_services(vpn_service=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service.from_gdata(n.get_opt_list('vpn-service')))
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__vpn_services:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__vpn_services(vpn_service=ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service.from_xml(yang.gdata.get_xml_children(n, 'vpn-service')))
-        return ietf_l3vpn_svc__l3vpn_svc__vpn_services()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vpn_service = yang.gdata.from_xml_opt_list(node, 'vpn-service')
+    yang.gdata.maybe_add(children, 'vpn-service', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service, child_vpn_service)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__vpn_services(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2603,28 +2798,55 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__vpn_services(jd: dict[str, ?value])
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_start(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_start(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_stop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_stop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__location_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__location_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__postal_code(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__postal_code(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__state(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__state(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__city(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__city(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__country_code(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__country_code(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.adata.MNode):
@@ -2670,10 +2892,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(yang.ada
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(location_id=n.get_str('location-id'), address=n.get_opt_str('address'), postal_code=n.get_opt_str('postal-code'), state=n.get_opt_str('state'), city=n.get_opt_str('city'), country_code=n.get_opt_str('country-code'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry(location_id=yang.gdata.from_xml_str(n, 'location-id'), address=yang.gdata.from_xml_opt_str(n, 'address'), postal_code=yang.gdata.from_xml_opt_str(n, 'postal-code'), state=yang.gdata.from_xml_opt_str(n, 'state'), city=yang.gdata.from_xml_opt_str(n, 'city'), country_code=yang.gdata.from_xml_opt_str(n, 'country-code'))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]
     mut def __init__(self, elements=[]):
@@ -2710,13 +2928,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(yang.adata.MNo
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_location_id = yang.gdata.from_xml_str(node, 'location-id')
+    yang.gdata.maybe_add(children, 'location-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__location_id, child_location_id)
+    child_address = yang.gdata.from_xml_opt_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__address, child_address)
+    child_postal_code = yang.gdata.from_xml_opt_str(node, 'postal-code')
+    yang.gdata.maybe_add(children, 'postal-code', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__postal_code, child_postal_code)
+    child_state = yang.gdata.from_xml_opt_str(node, 'state')
+    yang.gdata.maybe_add(children, 'state', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__state, child_state)
+    child_city = yang.gdata.from_xml_opt_str(node, 'city')
+    yang.gdata.maybe_add(children, 'city', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__city, child_city)
+    child_country_code = yang.gdata.from_xml_opt_str(node, 'country-code')
+    yang.gdata.maybe_add(children, 'country-code', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location__country_code, child_country_code)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_location_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_element(e))
+    return yang.gdata.List(keys=['location-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2816,12 +3049,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(location=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location.from_gdata(n.get_opt_list('location')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__locations:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(location=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location.from_xml(yang.gdata.get_xml_children(n, 'location')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__locations()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_location = yang.gdata.from_xml_opt_list(node, 'location')
+    yang.gdata.maybe_add(children, 'location', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations__location, child_location)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2849,13 +3082,25 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations(jd: dict[str
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__device_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__device_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__location(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__location(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address_family(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address_family(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.adata.MNode):
@@ -2883,12 +3128,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(yang.a
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(address_family=n.get_opt_str('address-family'), address=n.get_opt_str('address'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(address_family=yang.gdata.from_xml_opt_str(n, 'address-family'), address=yang.gdata.from_xml_opt_str(n, 'address'))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_str(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address_family, child_address_family)
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management__address, child_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2944,10 +3191,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(yang.adata.M
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(device_id=n.get_str('device-id'), location=n.get_opt_str('location'), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management.from_gdata(n.get_opt_container('management')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry(device_id=yang.gdata.from_xml_str(n, 'device-id'), location=yang.gdata.from_xml_opt_str(n, 'location'), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management.from_xml(yang.gdata.get_xml_opt_child(n, 'management')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -2984,13 +3227,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(yang.adata.MNode):
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_device_id = yang.gdata.from_xml_str(node, 'device-id')
+    yang.gdata.maybe_add(children, 'device-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__device_id, child_device_id)
+    child_location = yang.gdata.from_xml_str(node, 'location')
+    yang.gdata.maybe_add(children, 'location', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__location, child_location)
+    child_management = yang.gdata.from_xml_opt_cnt(node, 'management')
+    yang.gdata.maybe_add(children, 'management', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device__management, child_management)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_device_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_element(e))
+    return yang.gdata.List(keys=['device-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3078,12 +3330,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(device=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device.from_gdata(n.get_opt_list('device')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__devices:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(device=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device.from_xml(yang.gdata.get_xml_children(n, 'device')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__devices()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_device = yang.gdata.from_xml_opt_list(node, 'device')
+    yang.gdata.maybe_add(children, 'device', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices__device, child_device)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3111,6 +3363,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices(jd: dict[str, 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(yang.adata.MNode):
     group_id: str
 
@@ -3128,10 +3383,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entr
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(group_id=n.get_str('group-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]
@@ -3169,13 +3420,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(yang
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group__group_id, child_group_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3255,12 +3511,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(yang.adata.
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups__group, child_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3305,12 +3561,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_gdata(n.get_opt_container('groups')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups.from_xml(yang.gdata.get_xml_opt_child(n, 'groups')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_groups = yang.gdata.from_xml_opt_cnt(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity__groups, child_groups)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3338,6 +3594,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity(jd: dic
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__management__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
     type: ?str
 
@@ -3358,12 +3617,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__management(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__management(type=n.get_opt_str('type'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__management:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__management(type=yang.gdata.from_xml_opt_str(n, 'type'))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__management')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_type = yang.gdata.from_xml_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management__type, child_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__management(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3390,19 +3649,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__management(jd: dict[st
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__vpn_policy_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__vpn_policy_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__lan_tag(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__lan_tag(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv4_lan_prefix(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv4_lan_prefix(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv6_lan_prefix(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv6_lan_prefix(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(yang.adata.MNode):
@@ -3431,10 +3708,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(type=n.get_str('type'), lan_tag=n.get_opt_strs('lan-tag'), ipv4_lan_prefix=n.get_opt_strs('ipv4-lan-prefix'), ipv6_lan_prefix=n.get_opt_strs('ipv6-lan-prefix'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry(type=yang.gdata.from_xml_str(n, 'type'), lan_tag=yang.gdata.from_xml_opt_strs(n, 'lan-tag'), ipv4_lan_prefix=yang.gdata.from_xml_opt_strs(n, 'ipv4-lan-prefix'), ipv6_lan_prefix=yang.gdata.from_xml_opt_strs(n, 'ipv6-lan-prefix'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]
@@ -3472,13 +3745,24 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_type = yang.gdata.from_xml_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__type, child_type)
+    child_lan_tag = yang.gdata.from_xml_opt_strs(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__lan_tag, child_lan_tag)
+    child_ipv4_lan_prefix = yang.gdata.from_xml_opt_strs(node, 'ipv4-lan-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-lan-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv4_lan_prefix, child_ipv4_lan_prefix)
+    child_ipv6_lan_prefix = yang.gdata.from_xml_opt_strs(node, 'ipv6-lan-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-lan-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter__ipv6_lan_prefix, child_ipv6_lan_prefix)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_element(e))
+    return yang.gdata.List(keys=['type'], elements=elements, user_order=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3570,12 +3854,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(filter=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter.from_gdata(n.get_opt_list('filter')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(filter=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter.from_xml(yang.gdata.get_xml_children(n, 'filter')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_filter = yang.gdata.from_xml_opt_list(node, 'filter')
+    yang.gdata.maybe_add(children, 'filter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters__filter, child_filter)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -3603,7 +3887,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_poli
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__site_role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__site_role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(yang.adata.MNode):
@@ -3628,10 +3918,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(vpn_id=n.get_str('vpn-id'), site_role=n.get_opt_str('site-role'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry(vpn_id=yang.gdata.from_xml_str(n, 'vpn-id'), site_role=yang.gdata.from_xml_opt_str(n, 'site-role'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]
@@ -3669,13 +3955,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_id = yang.gdata.from_xml_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__vpn_id, child_vpn_id)
+    child_site_role = yang.gdata.from_xml_opt_str(node, 'site-role')
+    yang.gdata.maybe_add(children, 'site-role', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn__site_role, child_site_role)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_element(e))
+    return yang.gdata.List(keys=['vpn-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3767,10 +4060,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry(id=n.get_str('id'), filters=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters.from_gdata(n.get_opt_container('filters')), vpn=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn.from_gdata(n.get_opt_list('vpn')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry(id=yang.gdata.from_xml_str(n, 'id'), filters=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters.from_xml(yang.gdata.get_xml_opt_child(n, 'filters')), vpn=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn.from_xml(yang.gdata.get_xml_children(n, 'vpn')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]
     mut def __init__(self, elements=[]):
@@ -3807,13 +4096,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__id, child_id)
+    child_filters = yang.gdata.from_xml_opt_cnt(node, 'filters')
+    yang.gdata.maybe_add(children, 'filters', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__filters, child_filters)
+    child_vpn = yang.gdata.from_xml_opt_list(node, 'vpn')
+    yang.gdata.maybe_add(children, 'vpn', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries__vpn, child_vpn)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -3904,10 +4202,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(yan
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(vpn_policy_id=n.get_str('vpn-policy-id'), entries=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries.from_gdata(n.get_opt_list('entries')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry(vpn_policy_id=yang.gdata.from_xml_str(n, 'vpn-policy-id'), entries=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries.from_xml(yang.gdata.get_xml_children(n, 'entries')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]
     mut def __init__(self, elements=[]):
@@ -3944,13 +4238,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(yang.adat
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_policy_id = yang.gdata.from_xml_str(node, 'vpn-policy-id')
+    yang.gdata.maybe_add(children, 'vpn-policy-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__vpn_policy_id, child_vpn_policy_id)
+    child_entries = yang.gdata.from_xml_opt_list(node, 'entries')
+    yang.gdata.maybe_add(children, 'entries', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy__entries, child_entries)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_policy_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_element(e))
+    return yang.gdata.List(keys=['vpn-policy-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -4034,12 +4335,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(vpn_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy.from_gdata(n.get_opt_list('vpn-policy')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(vpn_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy.from_xml(yang.gdata.get_xml_children(n, 'vpn-policy')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vpn_policy = yang.gdata.from_xml_opt_list(node, 'vpn-policy')
+    yang.gdata.maybe_add(children, 'vpn-policy', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies__vpn_policy, child_vpn_policy)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4067,10 +4368,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies(jd: dict[
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_vpn_flavor(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_vpn_flavor(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__af(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__af(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__maximum_routes(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__maximum_routes(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(yang.adata.MNode):
@@ -4095,10 +4405,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_ent
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(af=n.get_str('af'), maximum_routes=n.get_opt_int('maximum-routes'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry(af=yang.gdata.from_xml_str(n, 'af'), maximum_routes=yang.gdata.from_xml_opt_int(n, 'maximum-routes'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]
@@ -4136,13 +4442,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(yan
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_af = yang.gdata.from_xml_str(node, 'af')
+    yang.gdata.maybe_add(children, 'af', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__af, child_af)
+    child_maximum_routes = yang.gdata.from_xml_opt_int(node, 'maximum-routes')
+    yang.gdata.maybe_add(children, 'maximum-routes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family__maximum_routes, child_maximum_routes)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_af)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_element(e))
+    return yang.gdata.List(keys=['af'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -4226,12 +4539,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family.from_gdata(n.get_opt_list('address-family')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family.from_xml(yang.gdata.get_xml_children(n, 'address-family')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_list(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes__address_family, child_address_family)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4272,12 +4585,10 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(yang.adat
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4300,16 +4611,31 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authenticati
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__layer(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__layer(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__profile_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__profile_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__algorithm(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__preshared_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__preshared_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(yang.adata.MNode):
@@ -4342,12 +4668,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(profile_name=yang.gdata.from_xml_opt_str(n, 'profile-name'), algorithm=yang.gdata.from_xml_opt_str(n, 'algorithm'), preshared_key=yang.gdata.from_xml_opt_str(n, 'preshared-key'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_profile_name = yang.gdata.from_xml_opt_str(node, 'profile-name')
+    yang.gdata.maybe_add(children, 'profile-name', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__profile_name, child_profile_name)
+    child_algorithm = yang.gdata.from_xml_opt_str(node, 'algorithm')
+    yang.gdata.maybe_add(children, 'algorithm', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__algorithm, child_algorithm)
+    child_preshared_key = yang.gdata.from_xml_opt_str(node, 'preshared-key')
+    yang.gdata.maybe_add(children, 'preshared-key', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile__preshared_key, child_preshared_key)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4409,12 +4739,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(yang.adata.MN
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_gdata(n.get_opt_container('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), layer=yang.gdata.from_xml_opt_str(n, 'layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile.from_xml(yang.gdata.get_xml_opt_child(n, 'encryption-profile')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__enabled, child_enabled)
+    child_layer = yang.gdata.from_xml_opt_str(node, 'layer')
+    yang.gdata.maybe_add(children, 'layer', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__layer, child_layer)
+    child_encryption_profile = yang.gdata.from_xml_opt_cnt(node, 'encryption-profile')
+    yang.gdata.maybe_add(children, 'encryption-profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption__encryption_profile, child_encryption_profile)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4472,12 +4806,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__security(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_gdata(n.get_opt_container('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_gdata(n.get_opt_container('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__security()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__security:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication.from_xml(yang.gdata.get_xml_opt_child(n, 'authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption.from_xml(yang.gdata.get_xml_opt_child(n, 'encryption')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__security()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_authentication = yang.gdata.from_xml_opt_cnt(node, 'authentication')
+    yang.gdata.maybe_add(children, 'authentication', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__authentication, child_authentication)
+    child_encryption = yang.gdata.from_xml_opt_cnt(node, 'encryption')
+    yang.gdata.maybe_add(children, 'encryption', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security__encryption, child_encryption)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__security(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4510,34 +4846,67 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__security(jd: dict[str,
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dscp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dscp(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dot1p(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dot1p(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__target_sites(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__target_sites(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(yang.adata.MNode):
@@ -4565,12 +4934,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=yang.gdata.from_xml_opt_int(n, 'lower-port'), upper_port=yang.gdata.from_xml_opt_int(n, 'upper-port'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_lower_port = yang.gdata.from_xml_opt_int(node, 'lower-port')
+    yang.gdata.maybe_add(children, 'lower-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port, child_lower_port)
+    child_upper_port = yang.gdata.from_xml_opt_int(node, 'upper-port')
+    yang.gdata.maybe_add(children, 'upper-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port, child_upper_port)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4601,10 +4972,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(yang.adata.MNode):
@@ -4632,12 +5012,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=yang.gdata.from_xml_opt_int(n, 'lower-port'), upper_port=yang.gdata.from_xml_opt_int(n, 'upper-port'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_lower_port = yang.gdata.from_xml_opt_int(node, 'lower-port')
+    yang.gdata.maybe_add(children, 'lower-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port, child_lower_port)
+    child_upper_port = yang.gdata.from_xml_opt_int(node, 'upper-port')
+    yang.gdata.maybe_add(children, 'upper-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port, child_upper_port)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4666,6 +5048,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
     return yang.gdata.Container(children)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__protocol_field(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__protocol_field(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(yang.adata.MNode):
@@ -4741,12 +5126,34 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_container('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_container('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(dscp=yang.gdata.from_xml_opt_int(n, 'dscp'), dot1p=yang.gdata.from_xml_opt_int(n, 'dot1p'), ipv4_src_prefix=yang.gdata.from_xml_opt_str(n, 'ipv4-src-prefix'), ipv6_src_prefix=yang.gdata.from_xml_opt_str(n, 'ipv6-src-prefix'), ipv4_dst_prefix=yang.gdata.from_xml_opt_str(n, 'ipv4-dst-prefix'), ipv6_dst_prefix=yang.gdata.from_xml_opt_str(n, 'ipv6-dst-prefix'), l4_src_port=yang.gdata.from_xml_opt_int(n, 'l4-src-port'), target_sites=yang.gdata.from_xml_opt_strs(n, 'target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_xml(yang.gdata.get_xml_opt_child(n, 'l4-src-port-range')), l4_dst_port=yang.gdata.from_xml_opt_int(n, 'l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_xml(yang.gdata.get_xml_opt_child(n, 'l4-dst-port-range')), protocol_field=yang.gdata.from_xml_opt_value(n, 'protocol-field'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_dscp = yang.gdata.from_xml_opt_int(node, 'dscp')
+    yang.gdata.maybe_add(children, 'dscp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dscp, child_dscp)
+    child_dot1p = yang.gdata.from_xml_opt_int(node, 'dot1p')
+    yang.gdata.maybe_add(children, 'dot1p', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__dot1p, child_dot1p)
+    child_ipv4_src_prefix = yang.gdata.from_xml_opt_str(node, 'ipv4-src-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-src-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix, child_ipv4_src_prefix)
+    child_ipv6_src_prefix = yang.gdata.from_xml_opt_str(node, 'ipv6-src-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-src-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix, child_ipv6_src_prefix)
+    child_ipv4_dst_prefix = yang.gdata.from_xml_opt_str(node, 'ipv4-dst-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-dst-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix, child_ipv4_dst_prefix)
+    child_ipv6_dst_prefix = yang.gdata.from_xml_opt_str(node, 'ipv6-dst-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-dst-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix, child_ipv6_dst_prefix)
+    child_l4_src_port = yang.gdata.from_xml_opt_int(node, 'l4-src-port')
+    yang.gdata.maybe_add(children, 'l4-src-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port, child_l4_src_port)
+    child_target_sites = yang.gdata.from_xml_opt_strs(node, 'target-sites')
+    yang.gdata.maybe_add(children, 'target-sites', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__target_sites, child_target_sites)
+    child_l4_src_port_range = yang.gdata.from_xml_opt_cnt(node, 'l4-src-port-range')
+    yang.gdata.maybe_add(children, 'l4-src-port-range', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range, child_l4_src_port_range)
+    child_l4_dst_port = yang.gdata.from_xml_opt_int(node, 'l4-dst-port')
+    yang.gdata.maybe_add(children, 'l4-dst-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port, child_l4_dst_port)
+    child_l4_dst_port_range = yang.gdata.from_xml_opt_cnt(node, 'l4-dst-port-range')
+    yang.gdata.maybe_add(children, 'l4-dst-port-range', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range, child_l4_dst_port_range)
+    child_protocol_field = yang.gdata.from_xml_opt_value(node, 'protocol-field')
+    yang.gdata.maybe_add(children, 'protocol-field', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow__protocol_field, child_protocol_field)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -4819,7 +5226,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_application(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_application(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__target_class_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__target_class_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(yang.adata.MNode):
@@ -4854,10 +5267,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(id=n.get_str('id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow.from_gdata(n.get_opt_container('match-flow')), match_application=n.get_opt_str('match-application'), target_class_id=n.get_opt_str('target-class-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry(id=yang.gdata.from_xml_str(n, 'id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow.from_xml(yang.gdata.get_xml_opt_child(n, 'match-flow')), match_application=yang.gdata.from_xml_opt_str(n, 'match-application'), target_class_id=yang.gdata.from_xml_opt_str(n, 'target-class-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]
@@ -4895,13 +5304,24 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__id, child_id)
+    child_match_flow = yang.gdata.from_xml_opt_cnt(node, 'match-flow')
+    yang.gdata.maybe_add(children, 'match-flow', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_flow, child_match_flow)
+    child_match_application = yang.gdata.from_xml_opt_str(node, 'match-application')
+    yang.gdata.maybe_add(children, 'match-application', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__match_application, child_match_application)
+    child_target_class_id = yang.gdata.from_xml_opt_str(node, 'target-class-id')
+    yang.gdata.maybe_add(children, 'target-class-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule__target_class_id, child_target_class_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements, user_order=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -4993,12 +5413,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_p
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule.from_xml(yang.gdata.get_xml_children(n, 'rule')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rule = yang.gdata.from_xml_opt_list(node, 'rule')
+    yang.gdata.maybe_add(children, 'rule', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy__rule, child_rule)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5026,19 +5446,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_clas
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__profile(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__profile(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__class_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__class_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__direction(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__direction(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__rate_limit(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('decimal64', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__rate_limit(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('decimal64', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__use_lowest_latency(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__use_lowest_latency(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__latency_boundary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__latency_boundary(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(yang.adata.MNode):
@@ -5066,12 +5504,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_bool('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(use_lowest_latency=yang.gdata.from_xml_opt_bool(n, 'use-lowest-latency'), latency_boundary=yang.gdata.from_xml_opt_int(n, 'latency-boundary'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_use_lowest_latency = yang.gdata.from_xml_opt_bool(node, 'use-lowest-latency')
+    yang.gdata.maybe_add(children, 'use-lowest-latency', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__use_lowest_latency, child_use_lowest_latency)
+    child_latency_boundary = yang.gdata.from_xml_opt_int(node, 'latency-boundary')
+    yang.gdata.maybe_add(children, 'latency-boundary', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency__latency_boundary, child_latency_boundary)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5102,7 +5542,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_prof
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__latency_boundary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__latency_boundary(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(yang.adata.MNode):
@@ -5130,12 +5576,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_bool('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=yang.gdata.from_xml_opt_bool(n, 'use-lowest-jitter'), latency_boundary=yang.gdata.from_xml_opt_int(n, 'latency-boundary'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_use_lowest_jitter = yang.gdata.from_xml_opt_bool(node, 'use-lowest-jitter')
+    yang.gdata.maybe_add(children, 'use-lowest-jitter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter, child_use_lowest_jitter)
+    child_latency_boundary = yang.gdata.from_xml_opt_int(node, 'latency-boundary')
+    yang.gdata.maybe_add(children, 'latency-boundary', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter__latency_boundary, child_latency_boundary)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5166,7 +5614,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_prof
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('decimal64', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('decimal64', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__end_to_end(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__end_to_end(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(yang.adata.MNode):
@@ -5194,12 +5648,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_opt_float('guaranteed-bw-percent'), end_to_end=n.get_opt_bool('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=yang.gdata.from_xml_opt_float(n, 'guaranteed-bw-percent'), end_to_end=yang.gdata.from_xml_opt_bool(n, 'end-to-end'))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_guaranteed_bw_percent = yang.gdata.from_xml_float(node, 'guaranteed-bw-percent')
+    yang.gdata.maybe_add(children, 'guaranteed-bw-percent', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent, child_guaranteed_bw_percent)
+    child_end_to_end = yang.gdata.from_xml_opt_bool(node, 'end-to-end')
+    yang.gdata.maybe_add(children, 'end-to-end', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth__end_to_end, child_end_to_end)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5270,10 +5726,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry(class_id=n.get_str('class-id'), direction=n.get_opt_str('direction'), rate_limit=n.get_opt_float('rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency.from_gdata(n.get_opt_container('latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter.from_gdata(n.get_opt_container('jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth.from_gdata(n.get_opt_container('bandwidth')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry(class_id=yang.gdata.from_xml_str(n, 'class-id'), direction=yang.gdata.from_xml_opt_str(n, 'direction'), rate_limit=yang.gdata.from_xml_opt_float(n, 'rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency.from_xml(yang.gdata.get_xml_opt_child(n, 'latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter.from_xml(yang.gdata.get_xml_opt_child(n, 'jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth.from_xml(yang.gdata.get_xml_opt_child(n, 'bandwidth')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]
     mut def __init__(self, elements=[]):
@@ -5310,13 +5762,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_class_id = yang.gdata.from_xml_str(node, 'class-id')
+    yang.gdata.maybe_add(children, 'class-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__class_id, child_class_id)
+    child_direction = yang.gdata.from_xml_opt_str(node, 'direction')
+    yang.gdata.maybe_add(children, 'direction', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__direction, child_direction)
+    child_rate_limit = yang.gdata.from_xml_opt_float(node, 'rate-limit')
+    yang.gdata.maybe_add(children, 'rate-limit', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__rate_limit, child_rate_limit)
+    child_latency = yang.gdata.from_xml_opt_cnt(node, 'latency')
+    yang.gdata.maybe_add(children, 'latency', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__latency, child_latency)
+    child_jitter = yang.gdata.from_xml_opt_cnt(node, 'jitter')
+    yang.gdata.maybe_add(children, 'jitter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__jitter, child_jitter)
+    child_bandwidth = yang.gdata.from_xml_opt_cnt(node, 'bandwidth')
+    yang.gdata.maybe_add(children, 'bandwidth', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class__bandwidth, child_bandwidth)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_class_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_element(e))
+    return yang.gdata.List(keys=['class-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -5416,12 +5883,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class.from_xml(yang.gdata.get_xml_children(n, 'class')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_class_ = yang.gdata.from_xml_opt_list(node, 'class')
+    yang.gdata.maybe_add(children, 'class', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes__class, child_class_)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5471,12 +5938,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(yang.ada
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_gdata(n.get_opt_container('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(profile=yang.gdata.from_xml_opt_str(n, 'profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes.from_xml(yang.gdata.get_xml_opt_child(n, 'classes')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_profile = yang.gdata.from_xml_opt_str(node, 'profile')
+    yang.gdata.maybe_add(children, 'profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__profile, child_profile)
+    child_classes = yang.gdata.from_xml_opt_cnt(node, 'classes')
+    yang.gdata.maybe_add(children, 'classes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile__classes, child_classes)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5530,12 +5999,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_gdata(n.get_opt_container('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_gdata(n.get_opt_container('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy.from_xml(yang.gdata.get_xml_opt_child(n, 'qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile.from_xml(yang.gdata.get_xml_opt_child(n, 'qos-profile')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_qos_classification_policy = yang.gdata.from_xml_opt_cnt(node, 'qos-classification-policy')
+    yang.gdata.maybe_add(children, 'qos-classification-policy', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_classification_policy, child_qos_classification_policy)
+    child_qos_profile = yang.gdata.from_xml_opt_cnt(node, 'qos-profile')
+    yang.gdata.maybe_add(children, 'qos-profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos__qos_profile, child_qos_profile)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5568,6 +6039,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos(jd: dict[
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier__signalling_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier__signalling_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adata.MNode):
     signalling_type: ?str
 
@@ -5588,12 +6062,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(yang.adat
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(signalling_type=yang.gdata.from_xml_opt_str(n, 'signalling-type'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_signalling_type = yang.gdata.from_xml_opt_str(node, 'signalling-type')
+    yang.gdata.maybe_add(children, 'signalling-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier__signalling_type, child_signalling_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5620,10 +6094,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarri
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_site_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_site_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv4(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv6(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv6(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(yang.adata.MNode):
@@ -5651,12 +6134,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_addr
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(ipv4=yang.gdata.from_xml_opt_bool(n, 'ipv4'), ipv6=yang.gdata.from_xml_opt_bool(n, 'ipv6'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_bool(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_bool(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family__ipv6, child_ipv6)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5685,6 +6170,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__mu
     return yang.gdata.Container(children)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__protocol_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__protocol_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNode):
@@ -5717,12 +6205,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(yang.adata.MNod
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_gdata(n.get_opt_container('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(multicast_site_type=yang.gdata.from_xml_opt_str(n, 'multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast-address-family')), protocol_type=yang.gdata.from_xml_opt_str(n, 'protocol-type'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_multicast_site_type = yang.gdata.from_xml_opt_str(node, 'multicast-site-type')
+    yang.gdata.maybe_add(children, 'multicast-site-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_site_type, child_multicast_site_type)
+    child_multicast_address_family = yang.gdata.from_xml_opt_cnt(node, 'multicast-address-family')
+    yang.gdata.maybe_add(children, 'multicast-address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__multicast_address_family, child_multicast_address_family)
+    child_protocol_type = yang.gdata.from_xml_opt_str(node, 'protocol-type')
+    yang.gdata.maybe_add(children, 'protocol-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast__protocol_type, child_protocol_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5785,12 +6277,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__service(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__service(qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_gdata(n.get_opt_container('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_gdata(n.get_opt_container('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_gdata(n.get_opt_container('multicast')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__service()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__service:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__service(qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos.from_xml(yang.gdata.get_xml_opt_child(n, 'qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier.from_xml(yang.gdata.get_xml_opt_child(n, 'carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__service()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_qos = yang.gdata.from_xml_opt_cnt(node, 'qos')
+    yang.gdata.maybe_add(children, 'qos', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__qos, child_qos)
+    child_carrierscarrier = yang.gdata.from_xml_opt_cnt(node, 'carrierscarrier')
+    yang.gdata.maybe_add(children, 'carrierscarrier', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__carrierscarrier, child_carrierscarrier)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service__multicast, child_multicast)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__service(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5828,6 +6324,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__service(jd: dict[str, 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNode):
     enabled: ?bool
 
@@ -5848,12 +6347,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(yang.adata.MNod
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(enabled=n.get_opt_bool('enabled'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection__enabled, child_enabled)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -5880,19 +6379,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection(jd:
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__area_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__area_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__metric(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(yang.adata.MNode):
@@ -5917,10 +6434,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=n.get_str('target-site'), metric=n.get_opt_int('metric'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=yang.gdata.from_xml_str(n, 'target-site'), metric=yang.gdata.from_xml_opt_int(n, 'metric'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
@@ -5958,13 +6471,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_target_site = yang.gdata.from_xml_str(node, 'target-site')
+    yang.gdata.maybe_add(children, 'target-site', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site, child_target_site)
+    child_metric = yang.gdata.from_xml_opt_int(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric, child_metric)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_target_site)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(e))
+    return yang.gdata.List(keys=['target-site'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -6048,12 +6568,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_xml(yang.gdata.get_xml_children(n, 'sham-link')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sham_link = yang.gdata.from_xml_opt_list(node, 'sham-link')
+    yang.gdata.maybe_add(children, 'sham-link', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links__sham_link, child_sham_link)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6111,12 +6631,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(address_family=n.get_opt_strs('address-family'), area_address=n.get_opt_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_container('sham-links')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'), area_address=yang.gdata.from_xml_opt_str(n, 'area-address'), metric=yang.gdata.from_xml_opt_int(n, 'metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links.from_xml(yang.gdata.get_xml_opt_child(n, 'sham-links')))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__address_family, child_address_family)
+    child_area_address = yang.gdata.from_xml_str(node, 'area-address')
+    yang.gdata.maybe_add(children, 'area-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__area_address, child_area_address)
+    child_metric = yang.gdata.from_xml_opt_int(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__metric, child_metric)
+    child_sham_links = yang.gdata.from_xml_opt_cnt(node, 'sham-links')
+    yang.gdata.maybe_add(children, 'sham-links', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links, child_sham_links)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6151,12 +6677,18 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     yang.gdata.maybe_add(children, 'metric', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__metric, child_metric)
     child_sham_links = yang.gdata.take_json_opt_cnt(jd, 'sham-links')
     yang.gdata.maybe_add(children, 'sham-links', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf__sham_links, child_sham_links)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__autonomous_system(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__autonomous_system(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(yang.adata.MNode):
@@ -6182,12 +6714,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_opt_int('autonomous-system'), address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(autonomous_system=yang.gdata.from_xml_opt_int(n, 'autonomous-system'), address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_autonomous_system = yang.gdata.from_xml_int(node, 'autonomous-system')
+    yang.gdata.maybe_add(children, 'autonomous-system', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__autonomous_system, child_autonomous_system)
+    child_address_family = yang.gdata.from_xml_opt_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6213,15 +6747,24 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     yang.gdata.maybe_add(children, 'autonomous-system', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__autonomous_system, child_autonomous_system)
     child_address_family = yang.gdata.take_json_opt_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(yang.adata.MNode):
@@ -6251,10 +6794,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=yang.gdata.from_xml_str(n, 'lan'), next_hop=yang.gdata.from_xml_str(n, 'next-hop'), lan_tag=yang.gdata.from_xml_opt_str(n, 'lan-tag'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
@@ -6295,13 +6834,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_lan = yang.gdata.from_xml_str(node, 'lan')
+    yang.gdata.maybe_add(children, 'lan', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan, child_lan)
+    child_next_hop = yang.gdata.from_xml_str(node, 'next-hop')
+    yang.gdata.maybe_add(children, 'next-hop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop, child_next_hop)
+    child_lan_tag = yang.gdata.from_xml_opt_str(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag, child_lan_tag)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(e))
+    return yang.gdata.List(keys=['lan', 'next-hop'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -6371,10 +6919,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(yang.adata.MNode):
@@ -6404,10 +6961,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=yang.gdata.from_xml_str(n, 'lan'), next_hop=yang.gdata.from_xml_str(n, 'next-hop'), lan_tag=yang.gdata.from_xml_opt_str(n, 'lan-tag'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
@@ -6448,13 +7001,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_lan = yang.gdata.from_xml_str(node, 'lan')
+    yang.gdata.maybe_add(children, 'lan', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan, child_lan)
+    child_next_hop = yang.gdata.from_xml_str(node, 'next-hop')
+    yang.gdata.maybe_add(children, 'next-hop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop, child_next_hop)
+    child_lan_tag = yang.gdata.from_xml_opt_str(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag, child_lan_tag)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(e))
+    return yang.gdata.List(keys=['lan', 'next-hop'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -6546,12 +7108,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_xml(yang.gdata.get_xml_children(n, 'ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_xml(yang.gdata.get_xml_children(n, 'ipv6-lan-prefixes')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4_lan_prefixes = yang.gdata.from_xml_opt_list(node, 'ipv4-lan-prefixes')
+    yang.gdata.maybe_add(children, 'ipv4-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes, child_ipv4_lan_prefixes)
+    child_ipv6_lan_prefixes = yang.gdata.from_xml_opt_list(node, 'ipv6-lan-prefixes')
+    yang.gdata.maybe_add(children, 'ipv6-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes, child_ipv6_lan_prefixes)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6601,12 +7165,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_container('cascaded-lan-prefixes')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_xml(yang.gdata.get_xml_opt_child(n, 'cascaded-lan-prefixes')))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cascaded_lan_prefixes = yang.gdata.from_xml_opt_cnt(node, 'cascaded-lan-prefixes')
+    yang.gdata.maybe_add(children, 'cascaded-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes, child_cascaded_lan_prefixes)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6629,9 +7193,12 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     children = {}
     child_cascaded_lan_prefixes = yang.gdata.take_json_opt_cnt(jd, 'cascaded-lan-prefixes')
     yang.gdata.maybe_add(children, 'cascaded-lan-prefixes', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static__cascaded_lan_prefixes, child_cascaded_lan_prefixes)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(yang.adata.MNode):
@@ -6652,12 +7219,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6679,9 +7246,12 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     children = {}
     child_address_family = yang.gdata.take_json_opt_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(yang.adata.MNode):
@@ -6702,12 +7272,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6729,7 +7299,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__rou
     children = {}
     child_address_family = yang.gdata.take_json_opt_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(yang.adata.MNode):
     type: str
@@ -6799,10 +7369,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(type=n.get_str('type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf.from_gdata(n.get_opt_container('ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp.from_gdata(n.get_opt_container('bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static.from_gdata(n.get_opt_container('static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip.from_gdata(n.get_opt_container('rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp.from_gdata(n.get_opt_container('vrrp')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry(type=yang.gdata.from_xml_str(n, 'type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf.from_xml(yang.gdata.get_xml_opt_child(n, 'ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static.from_xml(yang.gdata.get_xml_opt_child(n, 'static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip.from_xml(yang.gdata.get_xml_opt_child(n, 'rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp.from_xml(yang.gdata.get_xml_opt_child(n, 'vrrp')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]
     mut def __init__(self, elements=[]):
@@ -6839,13 +7405,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protoco
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_type = yang.gdata.from_xml_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__type, child_type)
+    child_ospf = yang.gdata.from_xml_opt_cnt(node, 'ospf')
+    yang.gdata.maybe_add(children, 'ospf', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__ospf, child_ospf)
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__bgp, child_bgp)
+    child_static = yang.gdata.from_xml_opt_cnt(node, 'static')
+    yang.gdata.maybe_add(children, 'static', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__static, child_static)
+    child_rip = yang.gdata.from_xml_opt_cnt(node, 'rip')
+    yang.gdata.maybe_add(children, 'rip', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__rip, child_rip)
+    child_vrrp = yang.gdata.from_xml_opt_cnt(node, 'vrrp')
+    yang.gdata.maybe_add(children, 'vrrp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol__vrrp, child_vrrp)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_element(e))
+    return yang.gdata.List(keys=['type'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -6945,12 +7526,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(yang.adata.MNode
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol.from_xml(yang.gdata.get_xml_children(n, 'routing-protocol')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_routing_protocol = yang.gdata.from_xml_opt_list(node, 'routing-protocol')
+    yang.gdata.maybe_add(children, 'routing-protocol', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols__routing_protocol, child_routing_protocol)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -6978,16 +7559,31 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols(jd: 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__location_reference(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__location_reference(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__device_reference(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__device_reference(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(yang.adata.MNode):
@@ -7007,10 +7603,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(group_id=n.get_str('group-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]
@@ -7048,13 +7640,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group__group_id, child_group_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -7134,12 +7731,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group.from_gdata(n.get_opt_list('group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group.from_xml(yang.gdata.get_xml_children(n, 'group')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups__group, child_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7167,7 +7764,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__constraint_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__constraint_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(yang.adata.MNode):
@@ -7187,10 +7790,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(group_id=n.get_str('group-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]
@@ -7228,13 +7827,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group__group_id, child_group_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -7297,7 +7901,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_accesses(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_accesses(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_groups(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_groups(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(yang.adata.MNode):
@@ -7330,12 +7940,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group.from_gdata(n.get_opt_list('group')), all_other_accesses=n.get_opt_bool('all-other-accesses'), all_other_groups=n.get_opt_bool('all-other-groups'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group.from_xml(yang.gdata.get_xml_children(n, 'group')), all_other_accesses=yang.gdata.from_xml_opt_bool(n, 'all-other-accesses'), all_other_groups=yang.gdata.from_xml_opt_bool(n, 'all-other-groups'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group = yang.gdata.from_xml_opt_list(node, 'group')
+    yang.gdata.maybe_add(children, 'group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__group, child_group)
+    child_all_other_accesses = yang.gdata.from_xml_opt_bool(node, 'all-other-accesses')
+    yang.gdata.maybe_add(children, 'all-other-accesses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_accesses, child_all_other_accesses)
+    child_all_other_groups = yang.gdata.from_xml_opt_bool(node, 'all-other-groups')
+    yang.gdata.maybe_add(children, 'all-other-groups', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target__all_other_groups, child_all_other_groups)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7391,10 +8005,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry(constraint_type=n.get_str('constraint-type'), target=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target.from_gdata(n.get_opt_container('target')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry(constraint_type=yang.gdata.from_xml_str(n, 'constraint-type'), target=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target.from_xml(yang.gdata.get_xml_opt_child(n, 'target')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]
     mut def __init__(self, elements=[]):
@@ -7431,13 +8041,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_constraint_type = yang.gdata.from_xml_str(node, 'constraint-type')
+    yang.gdata.maybe_add(children, 'constraint-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__constraint_type, child_constraint_type)
+    child_target = yang.gdata.from_xml_opt_cnt(node, 'target')
+    yang.gdata.maybe_add(children, 'target', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint__target, child_target)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_constraint_type)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_element(e))
+    return yang.gdata.List(keys=['constraint-type'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -7521,12 +8138,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(constraint=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint.from_gdata(n.get_opt_list('constraint')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(constraint=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint.from_xml(yang.gdata.get_xml_children(n, 'constraint')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_constraint = yang.gdata.from_xml_opt_list(node, 'constraint')
+    yang.gdata.maybe_add(children, 'constraint', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints__constraint, child_constraint)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7576,12 +8193,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_gdata(n.get_opt_container('groups')), constraints=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_gdata(n.get_opt_container('constraints')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(groups=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups.from_xml(yang.gdata.get_xml_opt_child(n, 'groups')), constraints=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints.from_xml(yang.gdata.get_xml_opt_child(n, 'constraints')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_groups = yang.gdata.from_xml_opt_cnt(node, 'groups')
+    yang.gdata.maybe_add(children, 'groups', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__groups, child_groups)
+    child_constraints = yang.gdata.from_xml_opt_cnt(node, 'constraints')
+    yang.gdata.maybe_add(children, 'constraints', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity__constraints, child_constraints)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7614,7 +8233,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__requested_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__requested_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__strict(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__strict(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(yang.adata.MNode):
@@ -7642,12 +8267,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(requested_type=n.get_opt_str('requested-type'), strict=n.get_opt_bool('strict'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(requested_type=yang.gdata.from_xml_opt_str(n, 'requested-type'), strict=yang.gdata.from_xml_opt_bool(n, 'strict'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_requested_type = yang.gdata.from_xml_opt_str(node, 'requested-type')
+    yang.gdata.maybe_add(children, 'requested-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__requested_type, child_requested_type)
+    child_strict = yang.gdata.from_xml_opt_bool(node, 'strict')
+    yang.gdata.maybe_add(children, 'strict', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type__strict, child_strict)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7678,7 +8305,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__always_on(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__always_on(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__bearer_reference(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__bearer_reference(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(yang.adata.MNode):
@@ -7711,12 +8344,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(requested_type=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_gdata(n.get_opt_container('requested-type')), always_on=n.get_opt_bool('always-on'), bearer_reference=n.get_opt_str('bearer-reference'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(requested_type=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type.from_xml(yang.gdata.get_xml_opt_child(n, 'requested-type')), always_on=yang.gdata.from_xml_opt_bool(n, 'always-on'), bearer_reference=yang.gdata.from_xml_opt_str(n, 'bearer-reference'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_requested_type = yang.gdata.from_xml_opt_cnt(node, 'requested-type')
+    yang.gdata.maybe_add(children, 'requested-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__requested_type, child_requested_type)
+    child_always_on = yang.gdata.from_xml_opt_bool(node, 'always-on')
+    yang.gdata.maybe_add(children, 'always-on', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__always_on, child_always_on)
+    child_bearer_reference = yang.gdata.from_xml_opt_str(node, 'bearer-reference')
+    yang.gdata.maybe_add(children, 'bearer-reference', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer__bearer_reference, child_bearer_reference)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7752,22 +8389,43 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__address_allocation_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__address_allocation_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__number_of_dynamic_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__number_of_dynamic_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__start_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__start_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__end_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__end_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(yang.adata.MNode):
@@ -7797,10 +8455,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(group_id=n.get_str('group-id'), start_address=n.get_opt_str('start-address'), end_address=n.get_opt_str('end-address'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'), start_address=yang.gdata.from_xml_opt_str(n, 'start-address'), end_address=yang.gdata.from_xml_opt_str(n, 'end-address'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]
@@ -7838,13 +8492,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__group_id, child_group_id)
+    child_start_address = yang.gdata.from_xml_opt_str(node, 'start-address')
+    yang.gdata.maybe_add(children, 'start-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__start_address, child_start_address)
+    child_end_address = yang.gdata.from_xml_opt_str(node, 'end-address')
+    yang.gdata.maybe_add(children, 'end-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group__end_address, child_end_address)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -7932,12 +8595,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group.from_xml(yang.gdata.get_xml_children(n, 'address-group')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_group = yang.gdata.from_xml_opt_list(node, 'address-group')
+    yang.gdata.maybe_add(children, 'address-group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses__address_group, child_address_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -7997,12 +8660,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_gdata(n.get_opt_container('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'), number_of_dynamic_address=yang.gdata.from_xml_opt_int(n, 'number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-addresses')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__provider_address, child_provider_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__prefix_length, child_prefix_length)
+    child_number_of_dynamic_address = yang.gdata.from_xml_opt_int(node, 'number-of-dynamic-address')
+    yang.gdata.maybe_add(children, 'number-of-dynamic-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__number_of_dynamic_address, child_number_of_dynamic_address)
+    child_customer_addresses = yang.gdata.from_xml_opt_cnt(node, 'customer-addresses')
+    yang.gdata.maybe_add(children, 'customer-addresses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp__customer_addresses, child_customer_addresses)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8042,10 +8711,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers__server_ip_address(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers__server_ip_address(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(yang.adata.MNode):
@@ -8066,12 +8744,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(server_ip_address=yang.gdata.from_xml_opt_strs(n, 'server-ip-address'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_server_ip_address = yang.gdata.from_xml_opt_strs(node, 'server-ip-address')
+    yang.gdata.maybe_add(children, 'server-ip-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers__server_ip_address, child_server_ip_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8125,12 +8803,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_container('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-dhcp-servers')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__provider_address, child_provider_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__prefix_length, child_prefix_length)
+    child_customer_dhcp_servers = yang.gdata.from_xml_opt_cnt(node, 'customer-dhcp-servers')
+    yang.gdata.maybe_add(children, 'customer-dhcp-servers', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay__customer_dhcp_servers, child_customer_dhcp_servers)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8166,10 +8848,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__customer_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__customer_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(yang.adata.MNode):
@@ -8202,12 +8893,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), customer_address=yang.gdata.from_xml_opt_str(n, 'customer-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__provider_address, child_provider_address)
+    child_customer_address = yang.gdata.from_xml_opt_str(node, 'customer-address')
+    yang.gdata.maybe_add(children, 'customer-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__customer_address, child_customer_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses__prefix_length, child_prefix_length)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8274,12 +8969,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(address_allocation_type=n.get_opt_str('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_gdata(n.get_opt_container('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_gdata(n.get_opt_container('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_gdata(n.get_opt_container('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(address_allocation_type=yang.gdata.from_xml_opt_str(n, 'address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp.from_xml(yang.gdata.get_xml_opt_child(n, 'provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay.from_xml(yang.gdata.get_xml_opt_child(n, 'dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'addresses')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_allocation_type = yang.gdata.from_xml_opt_str(node, 'address-allocation-type')
+    yang.gdata.maybe_add(children, 'address-allocation-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__address_allocation_type, child_address_allocation_type)
+    child_provider_dhcp = yang.gdata.from_xml_opt_cnt(node, 'provider-dhcp')
+    yang.gdata.maybe_add(children, 'provider-dhcp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__provider_dhcp, child_provider_dhcp)
+    child_dhcp_relay = yang.gdata.from_xml_opt_cnt(node, 'dhcp-relay')
+    yang.gdata.maybe_add(children, 'dhcp-relay', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__dhcp_relay, child_dhcp_relay)
+    child_addresses = yang.gdata.from_xml_opt_cnt(node, 'addresses')
+    yang.gdata.maybe_add(children, 'addresses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4__addresses, child_addresses)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8321,22 +9022,43 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__address_allocation_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__address_allocation_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__number_of_dynamic_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__number_of_dynamic_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__group_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__group_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__start_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__start_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__end_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__end_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(yang.adata.MNode):
@@ -8366,10 +9088,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(group_id=n.get_str('group-id'), start_address=n.get_opt_str('start-address'), end_address=n.get_opt_str('end-address'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry(group_id=yang.gdata.from_xml_str(n, 'group-id'), start_address=yang.gdata.from_xml_opt_str(n, 'start-address'), end_address=yang.gdata.from_xml_opt_str(n, 'end-address'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]
@@ -8407,13 +9125,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_group_id = yang.gdata.from_xml_str(node, 'group-id')
+    yang.gdata.maybe_add(children, 'group-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__group_id, child_group_id)
+    child_start_address = yang.gdata.from_xml_opt_str(node, 'start-address')
+    yang.gdata.maybe_add(children, 'start-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__start_address, child_start_address)
+    child_end_address = yang.gdata.from_xml_opt_str(node, 'end-address')
+    yang.gdata.maybe_add(children, 'end-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group__end_address, child_end_address)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_group_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_element(e))
+    return yang.gdata.List(keys=['group-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -8501,12 +9228,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group.from_gdata(n.get_opt_list('address-group')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(address_group=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group.from_xml(yang.gdata.get_xml_children(n, 'address-group')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_group = yang.gdata.from_xml_opt_list(node, 'address-group')
+    yang.gdata.maybe_add(children, 'address-group', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses__address_group, child_address_group)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8566,12 +9293,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), number_of_dynamic_address=n.get_opt_int('number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_gdata(n.get_opt_container('customer-addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'), number_of_dynamic_address=yang.gdata.from_xml_opt_int(n, 'number-of-dynamic-address'), customer_addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-addresses')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__provider_address, child_provider_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__prefix_length, child_prefix_length)
+    child_number_of_dynamic_address = yang.gdata.from_xml_opt_int(node, 'number-of-dynamic-address')
+    yang.gdata.maybe_add(children, 'number-of-dynamic-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__number_of_dynamic_address, child_number_of_dynamic_address)
+    child_customer_addresses = yang.gdata.from_xml_opt_cnt(node, 'customer-addresses')
+    yang.gdata.maybe_add(children, 'customer-addresses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp__customer_addresses, child_customer_addresses)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8611,10 +9344,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers__server_ip_address(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers__server_ip_address(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(yang.adata.MNode):
@@ -8635,12 +9377,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(server_ip_address=n.get_opt_strs('server-ip-address'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(server_ip_address=yang.gdata.from_xml_opt_strs(n, 'server-ip-address'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_server_ip_address = yang.gdata.from_xml_opt_strs(node, 'server-ip-address')
+    yang.gdata.maybe_add(children, 'server-ip-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers__server_ip_address, child_server_ip_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8694,12 +9436,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(provider_address=n.get_opt_str('provider-address'), prefix_length=n.get_opt_int('prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_gdata(n.get_opt_container('customer-dhcp-servers')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'), customer_dhcp_servers=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers.from_xml(yang.gdata.get_xml_opt_child(n, 'customer-dhcp-servers')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__provider_address, child_provider_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__prefix_length, child_prefix_length)
+    child_customer_dhcp_servers = yang.gdata.from_xml_opt_cnt(node, 'customer-dhcp-servers')
+    yang.gdata.maybe_add(children, 'customer-dhcp-servers', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay__customer_dhcp_servers, child_customer_dhcp_servers)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8735,10 +9481,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__provider_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__provider_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__customer_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__customer_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(yang.adata.MNode):
@@ -8771,12 +9526,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(provider_address=n.get_opt_str('provider-address'), customer_address=n.get_opt_str('customer-address'), prefix_length=n.get_opt_int('prefix-length'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(provider_address=yang.gdata.from_xml_opt_str(n, 'provider-address'), customer_address=yang.gdata.from_xml_opt_str(n, 'customer-address'), prefix_length=yang.gdata.from_xml_opt_int(n, 'prefix-length'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_provider_address = yang.gdata.from_xml_opt_str(node, 'provider-address')
+    yang.gdata.maybe_add(children, 'provider-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__provider_address, child_provider_address)
+    child_customer_address = yang.gdata.from_xml_opt_str(node, 'customer-address')
+    yang.gdata.maybe_add(children, 'customer-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__customer_address, child_customer_address)
+    child_prefix_length = yang.gdata.from_xml_opt_int(node, 'prefix-length')
+    yang.gdata.maybe_add(children, 'prefix-length', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses__prefix_length, child_prefix_length)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8843,12 +9602,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(address_allocation_type=n.get_opt_str('address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_gdata(n.get_opt_container('provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_gdata(n.get_opt_container('dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_gdata(n.get_opt_container('addresses')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(address_allocation_type=yang.gdata.from_xml_opt_str(n, 'address-allocation-type'), provider_dhcp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp.from_xml(yang.gdata.get_xml_opt_child(n, 'provider-dhcp')), dhcp_relay=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay.from_xml(yang.gdata.get_xml_opt_child(n, 'dhcp-relay')), addresses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses.from_xml(yang.gdata.get_xml_opt_child(n, 'addresses')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_allocation_type = yang.gdata.from_xml_opt_str(node, 'address-allocation-type')
+    yang.gdata.maybe_add(children, 'address-allocation-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__address_allocation_type, child_address_allocation_type)
+    child_provider_dhcp = yang.gdata.from_xml_opt_cnt(node, 'provider-dhcp')
+    yang.gdata.maybe_add(children, 'provider-dhcp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__provider_dhcp, child_provider_dhcp)
+    child_dhcp_relay = yang.gdata.from_xml_opt_cnt(node, 'dhcp-relay')
+    yang.gdata.maybe_add(children, 'dhcp-relay', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__dhcp_relay, child_dhcp_relay)
+    child_addresses = yang.gdata.from_xml_opt_cnt(node, 'addresses')
+    yang.gdata.maybe_add(children, 'addresses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6__addresses, child_addresses)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8890,10 +9655,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__fixed_value(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__fixed_value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__profile_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__profile_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(yang.adata.MNode):
@@ -8926,12 +9700,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(enabled=n.get_opt_bool('enabled'), fixed_value=n.get_opt_int('fixed-value'), profile_name=n.get_opt_str('profile-name'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), fixed_value=yang.gdata.from_xml_opt_int(n, 'fixed-value'), profile_name=yang.gdata.from_xml_opt_str(n, 'profile-name'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__enabled, child_enabled)
+    child_fixed_value = yang.gdata.from_xml_opt_int(node, 'fixed-value')
+    yang.gdata.maybe_add(children, 'fixed-value', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__fixed_value, child_fixed_value)
+    child_profile_name = yang.gdata.from_xml_opt_str(node, 'profile-name')
+    yang.gdata.maybe_add(children, 'profile-name', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd__profile_name, child_profile_name)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -8983,12 +9761,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(bfd=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_gdata(n.get_opt_container('bfd')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(bfd=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd.from_xml(yang.gdata.get_xml_opt_child(n, 'bfd')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bfd = yang.gdata.from_xml_opt_cnt(node, 'bfd')
+    yang.gdata.maybe_add(children, 'bfd', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam__bfd, child_bfd)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9043,12 +9821,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(ipv4=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_gdata(n.get_opt_container('ipv4')), ipv6=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_gdata(n.get_opt_container('ipv6')), oam=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_gdata(n.get_opt_container('oam')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(ipv4=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv4')), ipv6=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6.from_xml(yang.gdata.get_xml_opt_child(n, 'ipv6')), oam=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam.from_xml(yang.gdata.get_xml_opt_child(n, 'oam')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_cnt(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_cnt(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__ipv6, child_ipv6)
+    child_oam = yang.gdata.from_xml_opt_cnt(node, 'oam')
+    yang.gdata.maybe_add(children, 'oam', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection__oam, child_oam)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9099,12 +9881,10 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9127,16 +9907,31 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__layer(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__layer(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__profile_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__profile_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__algorithm(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__algorithm(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__preshared_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__preshared_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(yang.adata.MNode):
@@ -9169,12 +9964,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(profile_name=n.get_opt_str('profile-name'), algorithm=n.get_opt_str('algorithm'), preshared_key=n.get_opt_str('preshared-key'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(profile_name=yang.gdata.from_xml_opt_str(n, 'profile-name'), algorithm=yang.gdata.from_xml_opt_str(n, 'algorithm'), preshared_key=yang.gdata.from_xml_opt_str(n, 'preshared-key'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_profile_name = yang.gdata.from_xml_opt_str(node, 'profile-name')
+    yang.gdata.maybe_add(children, 'profile-name', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__profile_name, child_profile_name)
+    child_algorithm = yang.gdata.from_xml_opt_str(node, 'algorithm')
+    yang.gdata.maybe_add(children, 'algorithm', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__algorithm, child_algorithm)
+    child_preshared_key = yang.gdata.from_xml_opt_str(node, 'preshared-key')
+    yang.gdata.maybe_add(children, 'preshared-key', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile__preshared_key, child_preshared_key)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9236,12 +10035,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(enabled=n.get_opt_bool('enabled'), layer=n.get_opt_str('layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_gdata(n.get_opt_container('encryption-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(enabled=yang.gdata.from_xml_opt_bool(n, 'enabled'), layer=yang.gdata.from_xml_opt_str(n, 'layer'), encryption_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile.from_xml(yang.gdata.get_xml_opt_child(n, 'encryption-profile')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__enabled, child_enabled)
+    child_layer = yang.gdata.from_xml_opt_str(node, 'layer')
+    yang.gdata.maybe_add(children, 'layer', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__layer, child_layer)
+    child_encryption_profile = yang.gdata.from_xml_opt_cnt(node, 'encryption-profile')
+    yang.gdata.maybe_add(children, 'encryption-profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption__encryption_profile, child_encryption_profile)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9299,12 +10102,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_gdata(n.get_opt_container('authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_gdata(n.get_opt_container('encryption')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(authentication=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication.from_xml(yang.gdata.get_xml_opt_child(n, 'authentication')), encryption=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption.from_xml(yang.gdata.get_xml_opt_child(n, 'encryption')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_authentication = yang.gdata.from_xml_opt_cnt(node, 'authentication')
+    yang.gdata.maybe_add(children, 'authentication', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__authentication, child_authentication)
+    child_encryption = yang.gdata.from_xml_opt_cnt(node, 'encryption')
+    yang.gdata.maybe_add(children, 'encryption', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security__encryption, child_encryption)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9339,45 +10144,87 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
         return yang.gdata.Leaf('uint64', int(val))
     return yang.gdata.Leaf('uint64', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_input_bandwidth(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint64', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_output_bandwidth(val: value) -> yang.gdata.Leaf:
     if isinstance(val, str):
         return yang.gdata.Leaf('uint64', int(val))
     return yang.gdata.Leaf('uint64', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_output_bandwidth(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint64', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_mtu(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_mtu(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dscp(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dscp(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dot1p(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dot1p(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__target_sites(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__target_sites(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(yang.adata.MNode):
@@ -9405,12 +10252,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(lower_port=yang.gdata.from_xml_opt_int(n, 'lower-port'), upper_port=yang.gdata.from_xml_opt_int(n, 'upper-port'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_lower_port = yang.gdata.from_xml_opt_int(node, 'lower-port')
+    yang.gdata.maybe_add(children, 'lower-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__lower_port, child_lower_port)
+    child_upper_port = yang.gdata.from_xml_opt_int(node, 'upper-port')
+    yang.gdata.maybe_add(children, 'upper-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range__upper_port, child_upper_port)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9441,10 +10290,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(yang.adata.MNode):
@@ -9472,12 +10330,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=n.get_opt_int('lower-port'), upper_port=n.get_opt_int('upper-port'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(lower_port=yang.gdata.from_xml_opt_int(n, 'lower-port'), upper_port=yang.gdata.from_xml_opt_int(n, 'upper-port'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_lower_port = yang.gdata.from_xml_opt_int(node, 'lower-port')
+    yang.gdata.maybe_add(children, 'lower-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__lower_port, child_lower_port)
+    child_upper_port = yang.gdata.from_xml_opt_int(node, 'upper-port')
+    yang.gdata.maybe_add(children, 'upper-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range__upper_port, child_upper_port)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9506,6 +10366,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     return yang.gdata.Container(children)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__protocol_field(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__protocol_field(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(yang.adata.MNode):
@@ -9581,12 +10444,34 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(dscp=n.get_opt_int('dscp'), dot1p=n.get_opt_int('dot1p'), ipv4_src_prefix=n.get_opt_str('ipv4-src-prefix'), ipv6_src_prefix=n.get_opt_str('ipv6-src-prefix'), ipv4_dst_prefix=n.get_opt_str('ipv4-dst-prefix'), ipv6_dst_prefix=n.get_opt_str('ipv6-dst-prefix'), l4_src_port=n.get_opt_int('l4-src-port'), target_sites=n.get_opt_strs('target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_gdata(n.get_opt_container('l4-src-port-range')), l4_dst_port=n.get_opt_int('l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_gdata(n.get_opt_container('l4-dst-port-range')), protocol_field=n.get_opt_value('protocol-field'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(dscp=yang.gdata.from_xml_opt_int(n, 'dscp'), dot1p=yang.gdata.from_xml_opt_int(n, 'dot1p'), ipv4_src_prefix=yang.gdata.from_xml_opt_str(n, 'ipv4-src-prefix'), ipv6_src_prefix=yang.gdata.from_xml_opt_str(n, 'ipv6-src-prefix'), ipv4_dst_prefix=yang.gdata.from_xml_opt_str(n, 'ipv4-dst-prefix'), ipv6_dst_prefix=yang.gdata.from_xml_opt_str(n, 'ipv6-dst-prefix'), l4_src_port=yang.gdata.from_xml_opt_int(n, 'l4-src-port'), target_sites=yang.gdata.from_xml_opt_strs(n, 'target-sites'), l4_src_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range.from_xml(yang.gdata.get_xml_opt_child(n, 'l4-src-port-range')), l4_dst_port=yang.gdata.from_xml_opt_int(n, 'l4-dst-port'), l4_dst_port_range=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range.from_xml(yang.gdata.get_xml_opt_child(n, 'l4-dst-port-range')), protocol_field=yang.gdata.from_xml_opt_value(n, 'protocol-field'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_dscp = yang.gdata.from_xml_opt_int(node, 'dscp')
+    yang.gdata.maybe_add(children, 'dscp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dscp, child_dscp)
+    child_dot1p = yang.gdata.from_xml_opt_int(node, 'dot1p')
+    yang.gdata.maybe_add(children, 'dot1p', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__dot1p, child_dot1p)
+    child_ipv4_src_prefix = yang.gdata.from_xml_opt_str(node, 'ipv4-src-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-src-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_src_prefix, child_ipv4_src_prefix)
+    child_ipv6_src_prefix = yang.gdata.from_xml_opt_str(node, 'ipv6-src-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-src-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_src_prefix, child_ipv6_src_prefix)
+    child_ipv4_dst_prefix = yang.gdata.from_xml_opt_str(node, 'ipv4-dst-prefix')
+    yang.gdata.maybe_add(children, 'ipv4-dst-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv4_dst_prefix, child_ipv4_dst_prefix)
+    child_ipv6_dst_prefix = yang.gdata.from_xml_opt_str(node, 'ipv6-dst-prefix')
+    yang.gdata.maybe_add(children, 'ipv6-dst-prefix', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__ipv6_dst_prefix, child_ipv6_dst_prefix)
+    child_l4_src_port = yang.gdata.from_xml_opt_int(node, 'l4-src-port')
+    yang.gdata.maybe_add(children, 'l4-src-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port, child_l4_src_port)
+    child_target_sites = yang.gdata.from_xml_opt_strs(node, 'target-sites')
+    yang.gdata.maybe_add(children, 'target-sites', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__target_sites, child_target_sites)
+    child_l4_src_port_range = yang.gdata.from_xml_opt_cnt(node, 'l4-src-port-range')
+    yang.gdata.maybe_add(children, 'l4-src-port-range', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_src_port_range, child_l4_src_port_range)
+    child_l4_dst_port = yang.gdata.from_xml_opt_int(node, 'l4-dst-port')
+    yang.gdata.maybe_add(children, 'l4-dst-port', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port, child_l4_dst_port)
+    child_l4_dst_port_range = yang.gdata.from_xml_opt_cnt(node, 'l4-dst-port-range')
+    yang.gdata.maybe_add(children, 'l4-dst-port-range', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__l4_dst_port_range, child_l4_dst_port_range)
+    child_protocol_field = yang.gdata.from_xml_opt_value(node, 'protocol-field')
+    yang.gdata.maybe_add(children, 'protocol-field', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow__protocol_field, child_protocol_field)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9659,7 +10544,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_application(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_application(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__target_class_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__target_class_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(yang.adata.MNode):
@@ -9694,10 +10585,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(id=n.get_str('id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow.from_gdata(n.get_opt_container('match-flow')), match_application=n.get_opt_str('match-application'), target_class_id=n.get_opt_str('target-class-id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry(id=yang.gdata.from_xml_str(n, 'id'), match_flow=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow.from_xml(yang.gdata.get_xml_opt_child(n, 'match-flow')), match_application=yang.gdata.from_xml_opt_str(n, 'match-application'), target_class_id=yang.gdata.from_xml_opt_str(n, 'target-class-id'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]
@@ -9735,13 +10622,24 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__id, child_id)
+    child_match_flow = yang.gdata.from_xml_opt_cnt(node, 'match-flow')
+    yang.gdata.maybe_add(children, 'match-flow', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_flow, child_match_flow)
+    child_match_application = yang.gdata.from_xml_opt_str(node, 'match-application')
+    yang.gdata.maybe_add(children, 'match-application', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__match_application, child_match_application)
+    child_target_class_id = yang.gdata.from_xml_opt_str(node, 'target-class-id')
+    yang.gdata.maybe_add(children, 'target-class-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule__target_class_id, child_target_class_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_element(e))
+    return yang.gdata.List(keys=['id'], elements=elements, user_order=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -9833,12 +10731,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule.from_gdata(n.get_opt_list('rule')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(rule=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule.from_xml(yang.gdata.get_xml_children(n, 'rule')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_rule = yang.gdata.from_xml_opt_list(node, 'rule')
+    yang.gdata.maybe_add(children, 'rule', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy__rule, child_rule)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9866,19 +10764,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__profile(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__profile(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__class_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__class_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__direction(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__direction(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__rate_limit(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('decimal64', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__rate_limit(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('decimal64', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__use_lowest_latency(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__use_lowest_latency(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__latency_boundary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__latency_boundary(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(yang.adata.MNode):
@@ -9906,12 +10822,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(use_lowest_latency=n.get_opt_bool('use-lowest-latency'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(use_lowest_latency=yang.gdata.from_xml_opt_bool(n, 'use-lowest-latency'), latency_boundary=yang.gdata.from_xml_opt_int(n, 'latency-boundary'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_use_lowest_latency = yang.gdata.from_xml_opt_bool(node, 'use-lowest-latency')
+    yang.gdata.maybe_add(children, 'use-lowest-latency', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__use_lowest_latency, child_use_lowest_latency)
+    child_latency_boundary = yang.gdata.from_xml_opt_int(node, 'latency-boundary')
+    yang.gdata.maybe_add(children, 'latency-boundary', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency__latency_boundary, child_latency_boundary)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -9942,7 +10860,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__latency_boundary(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__latency_boundary(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(yang.adata.MNode):
@@ -9970,12 +10894,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=n.get_opt_bool('use-lowest-jitter'), latency_boundary=n.get_opt_int('latency-boundary'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(use_lowest_jitter=yang.gdata.from_xml_opt_bool(n, 'use-lowest-jitter'), latency_boundary=yang.gdata.from_xml_opt_int(n, 'latency-boundary'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_use_lowest_jitter = yang.gdata.from_xml_opt_bool(node, 'use-lowest-jitter')
+    yang.gdata.maybe_add(children, 'use-lowest-jitter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__use_lowest_jitter, child_use_lowest_jitter)
+    child_latency_boundary = yang.gdata.from_xml_opt_int(node, 'latency-boundary')
+    yang.gdata.maybe_add(children, 'latency-boundary', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter__latency_boundary, child_latency_boundary)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10006,7 +10932,13 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('decimal64', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('decimal64', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__end_to_end(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__end_to_end(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(yang.adata.MNode):
@@ -10034,12 +10966,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=n.get_opt_float('guaranteed-bw-percent'), end_to_end=n.get_opt_bool('end-to-end'))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(guaranteed_bw_percent=yang.gdata.from_xml_opt_float(n, 'guaranteed-bw-percent'), end_to_end=yang.gdata.from_xml_opt_bool(n, 'end-to-end'))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_guaranteed_bw_percent = yang.gdata.from_xml_float(node, 'guaranteed-bw-percent')
+    yang.gdata.maybe_add(children, 'guaranteed-bw-percent', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__guaranteed_bw_percent, child_guaranteed_bw_percent)
+    child_end_to_end = yang.gdata.from_xml_opt_bool(node, 'end-to-end')
+    yang.gdata.maybe_add(children, 'end-to-end', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth__end_to_end, child_end_to_end)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10110,10 +11044,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry(class_id=n.get_str('class-id'), direction=n.get_opt_str('direction'), rate_limit=n.get_opt_float('rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency.from_gdata(n.get_opt_container('latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter.from_gdata(n.get_opt_container('jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth.from_gdata(n.get_opt_container('bandwidth')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry(class_id=yang.gdata.from_xml_str(n, 'class-id'), direction=yang.gdata.from_xml_opt_str(n, 'direction'), rate_limit=yang.gdata.from_xml_opt_float(n, 'rate-limit'), latency=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency.from_xml(yang.gdata.get_xml_opt_child(n, 'latency')), jitter=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter.from_xml(yang.gdata.get_xml_opt_child(n, 'jitter')), bandwidth=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth.from_xml(yang.gdata.get_xml_opt_child(n, 'bandwidth')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]
     mut def __init__(self, elements=[]):
@@ -10150,13 +11080,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_class_id = yang.gdata.from_xml_str(node, 'class-id')
+    yang.gdata.maybe_add(children, 'class-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__class_id, child_class_id)
+    child_direction = yang.gdata.from_xml_opt_str(node, 'direction')
+    yang.gdata.maybe_add(children, 'direction', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__direction, child_direction)
+    child_rate_limit = yang.gdata.from_xml_opt_float(node, 'rate-limit')
+    yang.gdata.maybe_add(children, 'rate-limit', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__rate_limit, child_rate_limit)
+    child_latency = yang.gdata.from_xml_opt_cnt(node, 'latency')
+    yang.gdata.maybe_add(children, 'latency', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__latency, child_latency)
+    child_jitter = yang.gdata.from_xml_opt_cnt(node, 'jitter')
+    yang.gdata.maybe_add(children, 'jitter', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__jitter, child_jitter)
+    child_bandwidth = yang.gdata.from_xml_opt_cnt(node, 'bandwidth')
+    yang.gdata.maybe_add(children, 'bandwidth', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class__bandwidth, child_bandwidth)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_class_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_element(e))
+    return yang.gdata.List(keys=['class-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -10256,12 +11201,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class.from_gdata(n.get_opt_list('class')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(class_=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class.from_xml(yang.gdata.get_xml_children(n, 'class')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_class_ = yang.gdata.from_xml_opt_list(node, 'class')
+    yang.gdata.maybe_add(children, 'class', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes__class, child_class_)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10311,12 +11256,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(profile=n.get_opt_str('profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_gdata(n.get_opt_container('classes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(profile=yang.gdata.from_xml_opt_str(n, 'profile'), classes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes.from_xml(yang.gdata.get_xml_opt_child(n, 'classes')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_profile = yang.gdata.from_xml_opt_str(node, 'profile')
+    yang.gdata.maybe_add(children, 'profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__profile, child_profile)
+    child_classes = yang.gdata.from_xml_opt_cnt(node, 'classes')
+    yang.gdata.maybe_add(children, 'classes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile__classes, child_classes)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10370,12 +11317,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_gdata(n.get_opt_container('qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_gdata(n.get_opt_container('qos-profile')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(qos_classification_policy=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy.from_xml(yang.gdata.get_xml_opt_child(n, 'qos-classification-policy')), qos_profile=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile.from_xml(yang.gdata.get_xml_opt_child(n, 'qos-profile')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_qos_classification_policy = yang.gdata.from_xml_opt_cnt(node, 'qos-classification-policy')
+    yang.gdata.maybe_add(children, 'qos-classification-policy', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_classification_policy, child_qos_classification_policy)
+    child_qos_profile = yang.gdata.from_xml_opt_cnt(node, 'qos-profile')
+    yang.gdata.maybe_add(children, 'qos-profile', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos__qos_profile, child_qos_profile)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10408,6 +11357,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier__signalling_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier__signalling_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(yang.adata.MNode):
     signalling_type: ?str
 
@@ -10428,12 +11380,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(signalling_type=n.get_opt_str('signalling-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(signalling_type=yang.gdata.from_xml_opt_str(n, 'signalling-type'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_signalling_type = yang.gdata.from_xml_opt_str(node, 'signalling-type')
+    yang.gdata.maybe_add(children, 'signalling-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier__signalling_type, child_signalling_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10460,10 +11412,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_site_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_site_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv4(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv6(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv6(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(yang.adata.MNode):
@@ -10491,12 +11452,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(ipv4=n.get_opt_bool('ipv4'), ipv6=n.get_opt_bool('ipv6'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(ipv4=yang.gdata.from_xml_opt_bool(n, 'ipv4'), ipv6=yang.gdata.from_xml_opt_bool(n, 'ipv6'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4 = yang.gdata.from_xml_opt_bool(node, 'ipv4')
+    yang.gdata.maybe_add(children, 'ipv4', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv4, child_ipv4)
+    child_ipv6 = yang.gdata.from_xml_opt_bool(node, 'ipv6')
+    yang.gdata.maybe_add(children, 'ipv6', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family__ipv6, child_ipv6)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10525,6 +11488,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     return yang.gdata.Container(children)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__protocol_type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__protocol_type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(yang.adata.MNode):
@@ -10557,12 +11523,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(multicast_site_type=n.get_opt_str('multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_gdata(n.get_opt_container('multicast-address-family')), protocol_type=n.get_opt_str('protocol-type'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(multicast_site_type=yang.gdata.from_xml_opt_str(n, 'multicast-site-type'), multicast_address_family=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast-address-family')), protocol_type=yang.gdata.from_xml_opt_str(n, 'protocol-type'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_multicast_site_type = yang.gdata.from_xml_opt_str(node, 'multicast-site-type')
+    yang.gdata.maybe_add(children, 'multicast-site-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_site_type, child_multicast_site_type)
+    child_multicast_address_family = yang.gdata.from_xml_opt_cnt(node, 'multicast-address-family')
+    yang.gdata.maybe_add(children, 'multicast-address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__multicast_address_family, child_multicast_address_family)
+    child_protocol_type = yang.gdata.from_xml_opt_str(node, 'protocol-type')
+    yang.gdata.maybe_add(children, 'protocol-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast__protocol_type, child_protocol_type)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10640,12 +11610,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(svc_input_bandwidth=n.get_opt_int('svc-input-bandwidth'), svc_output_bandwidth=n.get_opt_int('svc-output-bandwidth'), svc_mtu=n.get_opt_int('svc-mtu'), qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_gdata(n.get_opt_container('qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_gdata(n.get_opt_container('carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_gdata(n.get_opt_container('multicast')))
         raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(svc_input_bandwidth=yang.gdata.from_xml_opt_int(n, 'svc-input-bandwidth'), svc_output_bandwidth=yang.gdata.from_xml_opt_int(n, 'svc-output-bandwidth'), svc_mtu=yang.gdata.from_xml_opt_int(n, 'svc-mtu'), qos=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos.from_xml(yang.gdata.get_xml_opt_child(n, 'qos')), carrierscarrier=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier.from_xml(yang.gdata.get_xml_opt_child(n, 'carrierscarrier')), multicast=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast.from_xml(yang.gdata.get_xml_opt_child(n, 'multicast')))
-        raise ValueError('Missing required subtree ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service')
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_svc_input_bandwidth = yang.gdata.from_xml_int(node, 'svc-input-bandwidth')
+    yang.gdata.maybe_add(children, 'svc-input-bandwidth', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_input_bandwidth, child_svc_input_bandwidth)
+    child_svc_output_bandwidth = yang.gdata.from_xml_int(node, 'svc-output-bandwidth')
+    yang.gdata.maybe_add(children, 'svc-output-bandwidth', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_output_bandwidth, child_svc_output_bandwidth)
+    child_svc_mtu = yang.gdata.from_xml_int(node, 'svc-mtu')
+    yang.gdata.maybe_add(children, 'svc-mtu', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__svc_mtu, child_svc_mtu)
+    child_qos = yang.gdata.from_xml_opt_cnt(node, 'qos')
+    yang.gdata.maybe_add(children, 'qos', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__qos, child_qos)
+    child_carrierscarrier = yang.gdata.from_xml_opt_cnt(node, 'carrierscarrier')
+    yang.gdata.maybe_add(children, 'carrierscarrier', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__carrierscarrier, child_carrierscarrier)
+    child_multicast = yang.gdata.from_xml_opt_cnt(node, 'multicast')
+    yang.gdata.maybe_add(children, 'multicast', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service__multicast, child_multicast)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10695,19 +11675,37 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__area_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__area_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__metric(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint16', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(yang.adata.MNode):
@@ -10732,10 +11730,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=n.get_str('target-site'), metric=n.get_opt_int('metric'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry(target_site=yang.gdata.from_xml_str(n, 'target-site'), metric=yang.gdata.from_xml_opt_int(n, 'metric'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]
@@ -10773,13 +11767,20 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_target_site = yang.gdata.from_xml_str(node, 'target-site')
+    yang.gdata.maybe_add(children, 'target-site', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__target_site, child_target_site)
+    child_metric = yang.gdata.from_xml_opt_int(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link__metric, child_metric)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_target_site)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(e))
+    return yang.gdata.List(keys=['target-site'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -10863,12 +11864,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_gdata(n.get_opt_list('sham-link')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(sham_link=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link.from_xml(yang.gdata.get_xml_children(n, 'sham-link')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sham_link = yang.gdata.from_xml_opt_list(node, 'sham-link')
+    yang.gdata.maybe_add(children, 'sham-link', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links__sham_link, child_sham_link)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10926,12 +11927,18 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(address_family=n.get_opt_strs('address-family'), area_address=n.get_opt_str('area-address'), metric=n.get_opt_int('metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_gdata(n.get_opt_container('sham-links')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'), area_address=yang.gdata.from_xml_opt_str(n, 'area-address'), metric=yang.gdata.from_xml_opt_int(n, 'metric'), sham_links=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links.from_xml(yang.gdata.get_xml_opt_child(n, 'sham-links')))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__address_family, child_address_family)
+    child_area_address = yang.gdata.from_xml_str(node, 'area-address')
+    yang.gdata.maybe_add(children, 'area-address', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__area_address, child_area_address)
+    child_metric = yang.gdata.from_xml_opt_int(node, 'metric')
+    yang.gdata.maybe_add(children, 'metric', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__metric, child_metric)
+    child_sham_links = yang.gdata.from_xml_opt_cnt(node, 'sham-links')
+    yang.gdata.maybe_add(children, 'sham-links', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links, child_sham_links)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -10966,12 +11973,18 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     yang.gdata.maybe_add(children, 'metric', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__metric, child_metric)
     child_sham_links = yang.gdata.take_json_opt_cnt(jd, 'sham-links')
     yang.gdata.maybe_add(children, 'sham-links', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf__sham_links, child_sham_links)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__autonomous_system(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__autonomous_system(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(yang.adata.MNode):
@@ -10997,12 +12010,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(autonomous_system=n.get_opt_int('autonomous-system'), address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(autonomous_system=yang.gdata.from_xml_opt_int(n, 'autonomous-system'), address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_autonomous_system = yang.gdata.from_xml_int(node, 'autonomous-system')
+    yang.gdata.maybe_add(children, 'autonomous-system', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__autonomous_system, child_autonomous_system)
+    child_address_family = yang.gdata.from_xml_opt_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11028,15 +12043,24 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     yang.gdata.maybe_add(children, 'autonomous-system', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__autonomous_system, child_autonomous_system)
     child_address_family = yang.gdata.take_json_opt_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(yang.adata.MNode):
@@ -11066,10 +12090,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry(lan=yang.gdata.from_xml_str(n, 'lan'), next_hop=yang.gdata.from_xml_str(n, 'next-hop'), lan_tag=yang.gdata.from_xml_opt_str(n, 'lan-tag'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]
@@ -11110,13 +12130,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_lan = yang.gdata.from_xml_str(node, 'lan')
+    yang.gdata.maybe_add(children, 'lan', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan, child_lan)
+    child_next_hop = yang.gdata.from_xml_str(node, 'next-hop')
+    yang.gdata.maybe_add(children, 'next-hop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__next_hop, child_next_hop)
+    child_lan_tag = yang.gdata.from_xml_opt_str(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes__lan_tag, child_lan_tag)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(e))
+    return yang.gdata.List(keys=['lan', 'next-hop'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -11186,10 +12215,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(yang.adata.MNode):
@@ -11219,10 +12257,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=n.get_str('lan'), next_hop=n.get_str('next-hop'), lan_tag=n.get_opt_str('lan-tag'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry(lan=yang.gdata.from_xml_str(n, 'lan'), next_hop=yang.gdata.from_xml_str(n, 'next-hop'), lan_tag=yang.gdata.from_xml_opt_str(n, 'lan-tag'))
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]
@@ -11263,13 +12297,22 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_lan = yang.gdata.from_xml_str(node, 'lan')
+    yang.gdata.maybe_add(children, 'lan', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan, child_lan)
+    child_next_hop = yang.gdata.from_xml_str(node, 'next-hop')
+    yang.gdata.maybe_add(children, 'next-hop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__next_hop, child_next_hop)
+    child_lan_tag = yang.gdata.from_xml_opt_str(node, 'lan-tag')
+    yang.gdata.maybe_add(children, 'lan-tag', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes__lan_tag, child_lan_tag)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_lan), yang.gdata.yang_str(child_next_hop)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(e))
+    return yang.gdata.List(keys=['lan', 'next-hop'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -11361,12 +12404,14 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_gdata(n.get_opt_list('ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_gdata(n.get_opt_list('ipv6-lan-prefixes')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(ipv4_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes.from_xml(yang.gdata.get_xml_children(n, 'ipv4-lan-prefixes')), ipv6_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes.from_xml(yang.gdata.get_xml_children(n, 'ipv6-lan-prefixes')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ipv4_lan_prefixes = yang.gdata.from_xml_opt_list(node, 'ipv4-lan-prefixes')
+    yang.gdata.maybe_add(children, 'ipv4-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv4_lan_prefixes, child_ipv4_lan_prefixes)
+    child_ipv6_lan_prefixes = yang.gdata.from_xml_opt_list(node, 'ipv6-lan-prefixes')
+    yang.gdata.maybe_add(children, 'ipv6-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes__ipv6_lan_prefixes, child_ipv6_lan_prefixes)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11416,12 +12461,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_gdata(n.get_opt_container('cascaded-lan-prefixes')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(cascaded_lan_prefixes=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes.from_xml(yang.gdata.get_xml_opt_child(n, 'cascaded-lan-prefixes')))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cascaded_lan_prefixes = yang.gdata.from_xml_opt_cnt(node, 'cascaded-lan-prefixes')
+    yang.gdata.maybe_add(children, 'cascaded-lan-prefixes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes, child_cascaded_lan_prefixes)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11444,9 +12489,12 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     children = {}
     child_cascaded_lan_prefixes = yang.gdata.take_json_opt_cnt(jd, 'cascaded-lan-prefixes')
     yang.gdata.maybe_add(children, 'cascaded-lan-prefixes', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static__cascaded_lan_prefixes, child_cascaded_lan_prefixes)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(yang.adata.MNode):
@@ -11467,12 +12515,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11494,9 +12542,12 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     children = {}
     child_address_family = yang.gdata.take_json_opt_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp__address_family(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp__address_family(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(yang.adata.MNode):
@@ -11517,12 +12568,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(address_family=n.get_opt_strs('address-family'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(address_family=yang.gdata.from_xml_opt_strs(n, 'address-family'))
-        return None
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_address_family = yang.gdata.from_xml_opt_strs(node, 'address-family')
+    yang.gdata.maybe_add(children, 'address-family', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp__address_family, child_address_family)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11544,7 +12595,7 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
     children = {}
     child_address_family = yang.gdata.take_json_opt_strs(jd, 'address-family')
     yang.gdata.maybe_add(children, 'address-family', from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp__address_family, child_address_family)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(yang.adata.MNode):
     type: str
@@ -11614,10 +12665,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(type=n.get_str('type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf.from_gdata(n.get_opt_container('ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp.from_gdata(n.get_opt_container('bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static.from_gdata(n.get_opt_container('static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip.from_gdata(n.get_opt_container('rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp.from_gdata(n.get_opt_container('vrrp')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry(type=yang.gdata.from_xml_str(n, 'type'), ospf=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf.from_xml(yang.gdata.get_xml_opt_child(n, 'ospf')), bgp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')), static=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static.from_xml(yang.gdata.get_xml_opt_child(n, 'static')), rip=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip.from_xml(yang.gdata.get_xml_opt_child(n, 'rip')), vrrp=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp.from_xml(yang.gdata.get_xml_opt_child(n, 'vrrp')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]
     mut def __init__(self, elements=[]):
@@ -11654,13 +12701,28 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_type = yang.gdata.from_xml_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__type, child_type)
+    child_ospf = yang.gdata.from_xml_opt_cnt(node, 'ospf')
+    yang.gdata.maybe_add(children, 'ospf', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__ospf, child_ospf)
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__bgp, child_bgp)
+    child_static = yang.gdata.from_xml_opt_cnt(node, 'static')
+    yang.gdata.maybe_add(children, 'static', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__static, child_static)
+    child_rip = yang.gdata.from_xml_opt_cnt(node, 'rip')
+    yang.gdata.maybe_add(children, 'rip', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__rip, child_rip)
+    child_vrrp = yang.gdata.from_xml_opt_cnt(node, 'vrrp')
+    yang.gdata.maybe_add(children, 'vrrp', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol__vrrp, child_vrrp)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_type)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_element(e))
+    return yang.gdata.List(keys=['type'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -11760,12 +12822,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol.from_gdata(n.get_opt_list('routing-protocol')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(routing_protocol=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol.from_xml(yang.gdata.get_xml_children(n, 'routing-protocol')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_routing_protocol = yang.gdata.from_xml_opt_list(node, 'routing-protocol')
+    yang.gdata.maybe_add(children, 'routing-protocol', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols__routing_protocol, child_routing_protocol)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11793,6 +12855,9 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability__access_priority(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability__access_priority(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(yang.adata.MNode):
     access_priority: ?int
 
@@ -11813,12 +12878,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(access_priority=n.get_opt_int('access-priority'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(access_priority=yang.gdata.from_xml_opt_int(n, 'access-priority'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_access_priority = yang.gdata.from_xml_opt_int(node, 'access-priority')
+    yang.gdata.maybe_add(children, 'access-priority', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability__access_priority, child_access_priority)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11845,10 +12910,19 @@ mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses_
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_policy_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_policy_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('leafref', val)
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
 mut def from_json_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__site_role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('identityref', val)
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__site_role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('identityref', val)
 
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(yang.adata.MNode):
@@ -11881,12 +12955,16 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(vpn_policy_id=n.get_opt_str('vpn-policy-id'), vpn_id=n.get_opt_str('vpn-id'), site_role=n.get_opt_str('site-role'))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(vpn_policy_id=yang.gdata.from_xml_opt_str(n, 'vpn-policy-id'), vpn_id=yang.gdata.from_xml_opt_str(n, 'vpn-id'), site_role=yang.gdata.from_xml_opt_str(n, 'site-role'))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vpn_policy_id = yang.gdata.from_xml_opt_str(node, 'vpn-policy-id')
+    yang.gdata.maybe_add(children, 'vpn-policy-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_policy_id, child_vpn_policy_id)
+    child_vpn_id = yang.gdata.from_xml_opt_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__vpn_id, child_vpn_id)
+    child_site_role = yang.gdata.from_xml_opt_str(node, 'site-role')
+    yang.gdata.maybe_add(children, 'site-role', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment__site_role, child_site_role)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -11991,10 +13069,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry(site_network_access_id=n.get_str('site-network-access-id'), site_network_access_type=n.get_opt_str('site-network-access-type'), location_reference=n.get_opt_str('location-reference'), device_reference=n.get_opt_str('device-reference'), access_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity.from_gdata(n.get_opt_container('access-diversity')), bearer=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer.from_gdata(n.get_opt_container('bearer')), ip_connection=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection.from_gdata(n.get_opt_container('ip-connection')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security.from_gdata(n.get_opt_container('security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service.from_gdata(n.get_opt_container('service')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols.from_gdata(n.get_opt_container('routing-protocols')), availability=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability.from_gdata(n.get_opt_container('availability')), vpn_attachment=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment.from_gdata(n.get_opt_container('vpn-attachment')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry(site_network_access_id=yang.gdata.from_xml_str(n, 'site-network-access-id'), site_network_access_type=yang.gdata.from_xml_opt_str(n, 'site-network-access-type'), location_reference=yang.gdata.from_xml_opt_str(n, 'location-reference'), device_reference=yang.gdata.from_xml_opt_str(n, 'device-reference'), access_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity.from_xml(yang.gdata.get_xml_opt_child(n, 'access-diversity')), bearer=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer.from_xml(yang.gdata.get_xml_opt_child(n, 'bearer')), ip_connection=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection.from_xml(yang.gdata.get_xml_opt_child(n, 'ip-connection')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security.from_xml(yang.gdata.get_xml_opt_child(n, 'security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service.from_xml(yang.gdata.get_xml_opt_child(n, 'service')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols.from_xml(yang.gdata.get_xml_opt_child(n, 'routing-protocols')), availability=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability.from_xml(yang.gdata.get_xml_opt_child(n, 'availability')), vpn_attachment=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn-attachment')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]
     mut def __init__(self, elements=[]):
@@ -12031,13 +13105,40 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_networ
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_site_network_access_id = yang.gdata.from_xml_str(node, 'site-network-access-id')
+    yang.gdata.maybe_add(children, 'site-network-access-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_id, child_site_network_access_id)
+    child_site_network_access_type = yang.gdata.from_xml_opt_str(node, 'site-network-access-type')
+    yang.gdata.maybe_add(children, 'site-network-access-type', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__site_network_access_type, child_site_network_access_type)
+    child_location_reference = yang.gdata.from_xml_opt_str(node, 'location-reference')
+    yang.gdata.maybe_add(children, 'location-reference', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__location_reference, child_location_reference)
+    child_device_reference = yang.gdata.from_xml_opt_str(node, 'device-reference')
+    yang.gdata.maybe_add(children, 'device-reference', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__device_reference, child_device_reference)
+    child_access_diversity = yang.gdata.from_xml_opt_cnt(node, 'access-diversity')
+    yang.gdata.maybe_add(children, 'access-diversity', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__access_diversity, child_access_diversity)
+    child_bearer = yang.gdata.from_xml_opt_cnt(node, 'bearer')
+    yang.gdata.maybe_add(children, 'bearer', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__bearer, child_bearer)
+    child_ip_connection = yang.gdata.from_xml_opt_cnt(node, 'ip-connection')
+    yang.gdata.maybe_add(children, 'ip-connection', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__ip_connection, child_ip_connection)
+    child_security = yang.gdata.from_xml_opt_cnt(node, 'security')
+    yang.gdata.maybe_add(children, 'security', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__security, child_security)
+    child_service = yang.gdata.from_xml_opt_cnt(node, 'service')
+    yang.gdata.maybe_add(children, 'service', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__service, child_service)
+    child_routing_protocols = yang.gdata.from_xml_opt_cnt(node, 'routing-protocols')
+    yang.gdata.maybe_add(children, 'routing-protocols', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__routing_protocols, child_routing_protocols)
+    child_availability = yang.gdata.from_xml_opt_cnt(node, 'availability')
+    yang.gdata.maybe_add(children, 'availability', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__availability, child_availability)
+    child_vpn_attachment = yang.gdata.from_xml_opt_cnt(node, 'vpn-attachment')
+    yang.gdata.maybe_add(children, 'vpn-attachment', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access__vpn_attachment, child_vpn_attachment)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_site_network_access_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_element(e))
+    return yang.gdata.List(keys=['site-network-access-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -12161,12 +13262,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(yang.adata.M
             return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(site_network_access=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access.from_gdata(n.get_opt_list('site-network-access')))
         return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(site_network_access=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access.from_xml(yang.gdata.get_xml_children(n, 'site-network-access')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_site_network_access = yang.gdata.from_xml_opt_list(node, 'site-network-access')
+    yang.gdata.maybe_add(children, 'site-network-access', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses__site_network_access, child_site_network_access)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -12279,10 +13380,6 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site_entry:
         return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(site_id=n.get_str('site-id'), requested_site_start=n.get_opt_str('requested-site-start'), requested_site_stop=n.get_opt_str('requested-site-stop'), locations=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations.from_gdata(n.get_opt_container('locations')), devices=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices.from_gdata(n.get_opt_container('devices')), site_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity.from_gdata(n.get_opt_container('site-diversity')), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__management.from_gdata(n.get_opt_container('management')), vpn_policies=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies.from_gdata(n.get_opt_container('vpn-policies')), site_vpn_flavor=n.get_opt_str('site-vpn-flavor'), maximum_routes=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes.from_gdata(n.get_opt_container('maximum-routes')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__security.from_gdata(n.get_opt_container('security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__service.from_gdata(n.get_opt_container('service')), traffic_protection=ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection.from_gdata(n.get_opt_container('traffic-protection')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols.from_gdata(n.get_opt_container('routing-protocols')), site_network_accesses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses.from_gdata(n.get_opt_container('site-network-accesses')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites__site_entry:
-        return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(site_id=yang.gdata.from_xml_str(n, 'site-id'), requested_site_start=yang.gdata.from_xml_opt_str(n, 'requested-site-start'), requested_site_stop=yang.gdata.from_xml_opt_str(n, 'requested-site-stop'), locations=ietf_l3vpn_svc__l3vpn_svc__sites__site__locations.from_xml(yang.gdata.get_xml_opt_child(n, 'locations')), devices=ietf_l3vpn_svc__l3vpn_svc__sites__site__devices.from_xml(yang.gdata.get_xml_opt_child(n, 'devices')), site_diversity=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity.from_xml(yang.gdata.get_xml_opt_child(n, 'site-diversity')), management=ietf_l3vpn_svc__l3vpn_svc__sites__site__management.from_xml(yang.gdata.get_xml_opt_child(n, 'management')), vpn_policies=ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn-policies')), site_vpn_flavor=yang.gdata.from_xml_opt_str(n, 'site-vpn-flavor'), maximum_routes=ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes.from_xml(yang.gdata.get_xml_opt_child(n, 'maximum-routes')), security=ietf_l3vpn_svc__l3vpn_svc__sites__site__security.from_xml(yang.gdata.get_xml_opt_child(n, 'security')), service=ietf_l3vpn_svc__l3vpn_svc__sites__site__service.from_xml(yang.gdata.get_xml_opt_child(n, 'service')), traffic_protection=ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection.from_xml(yang.gdata.get_xml_opt_child(n, 'traffic-protection')), routing_protocols=ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols.from_xml(yang.gdata.get_xml_opt_child(n, 'routing-protocols')), site_network_accesses=ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses.from_xml(yang.gdata.get_xml_opt_child(n, 'site-network-accesses')))
-
 class ietf_l3vpn_svc__l3vpn_svc__sites__site(yang.adata.MNode):
     elements: list[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]
     mut def __init__(self, elements=[]):
@@ -12319,13 +13416,46 @@ class ietf_l3vpn_svc__l3vpn_svc__sites__site(yang.adata.MNode):
                 res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[ietf_l3vpn_svc__l3vpn_svc__sites__site_entry]:
-        res = []
-        for node in nodes:
-            res.append(ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_xml(node))
-        return res
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_site_id = yang.gdata.from_xml_str(node, 'site-id')
+    yang.gdata.maybe_add(children, 'site-id', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_id, child_site_id)
+    child_requested_site_start = yang.gdata.from_xml_opt_str(node, 'requested-site-start')
+    yang.gdata.maybe_add(children, 'requested-site-start', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_start, child_requested_site_start)
+    child_requested_site_stop = yang.gdata.from_xml_opt_str(node, 'requested-site-stop')
+    yang.gdata.maybe_add(children, 'requested-site-stop', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__requested_site_stop, child_requested_site_stop)
+    child_locations = yang.gdata.from_xml_opt_cnt(node, 'locations')
+    yang.gdata.maybe_add(children, 'locations', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__locations, child_locations)
+    child_devices = yang.gdata.from_xml_opt_cnt(node, 'devices')
+    yang.gdata.maybe_add(children, 'devices', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__devices, child_devices)
+    child_site_diversity = yang.gdata.from_xml_opt_cnt(node, 'site-diversity')
+    yang.gdata.maybe_add(children, 'site-diversity', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_diversity, child_site_diversity)
+    child_management = yang.gdata.from_xml_opt_cnt(node, 'management')
+    yang.gdata.maybe_add(children, 'management', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__management, child_management)
+    child_vpn_policies = yang.gdata.from_xml_opt_cnt(node, 'vpn-policies')
+    yang.gdata.maybe_add(children, 'vpn-policies', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__vpn_policies, child_vpn_policies)
+    child_site_vpn_flavor = yang.gdata.from_xml_opt_str(node, 'site-vpn-flavor')
+    yang.gdata.maybe_add(children, 'site-vpn-flavor', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_vpn_flavor, child_site_vpn_flavor)
+    child_maximum_routes = yang.gdata.from_xml_opt_cnt(node, 'maximum-routes')
+    yang.gdata.maybe_add(children, 'maximum-routes', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__maximum_routes, child_maximum_routes)
+    child_security = yang.gdata.from_xml_opt_cnt(node, 'security')
+    yang.gdata.maybe_add(children, 'security', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__security, child_security)
+    child_service = yang.gdata.from_xml_opt_cnt(node, 'service')
+    yang.gdata.maybe_add(children, 'service', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__service, child_service)
+    child_traffic_protection = yang.gdata.from_xml_opt_cnt(node, 'traffic-protection')
+    yang.gdata.maybe_add(children, 'traffic-protection', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__traffic_protection, child_traffic_protection)
+    child_routing_protocols = yang.gdata.from_xml_opt_cnt(node, 'routing-protocols')
+    yang.gdata.maybe_add(children, 'routing-protocols', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__routing_protocols, child_routing_protocols)
+    child_site_network_accesses = yang.gdata.from_xml_opt_cnt(node, 'site-network-accesses')
+    yang.gdata.maybe_add(children, 'site-network-accesses', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site__site_network_accesses, child_site_network_accesses)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_site_id)])
+
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(e))
+    return yang.gdata.List(keys=['site-id'], elements=elements)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites__site_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -12461,12 +13591,12 @@ class ietf_l3vpn_svc__l3vpn_svc__sites(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc__sites(site=ietf_l3vpn_svc__l3vpn_svc__sites__site.from_gdata(n.get_opt_list('site')))
         return ietf_l3vpn_svc__l3vpn_svc__sites()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc__sites:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc__sites(site=ietf_l3vpn_svc__l3vpn_svc__sites__site.from_xml(yang.gdata.get_xml_children(n, 'site')))
-        return ietf_l3vpn_svc__l3vpn_svc__sites()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc__sites(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_site = yang.gdata.from_xml_opt_list(node, 'site')
+    yang.gdata.maybe_add(children, 'site', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites__site, child_site)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc__sites(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -12521,12 +13651,16 @@ class ietf_l3vpn_svc__l3vpn_svc(yang.adata.MNode):
             return ietf_l3vpn_svc__l3vpn_svc(vpn_profiles=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_gdata(n.get_opt_container('vpn-profiles')), vpn_services=ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_gdata(n.get_opt_container('vpn-services')), sites=ietf_l3vpn_svc__l3vpn_svc__sites.from_gdata(n.get_opt_container('sites')))
         return ietf_l3vpn_svc__l3vpn_svc()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ietf_l3vpn_svc__l3vpn_svc:
-        if n != None:
-            return ietf_l3vpn_svc__l3vpn_svc(vpn_profiles=ietf_l3vpn_svc__l3vpn_svc__vpn_profiles.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn-profiles')), vpn_services=ietf_l3vpn_svc__l3vpn_svc__vpn_services.from_xml(yang.gdata.get_xml_opt_child(n, 'vpn-services')), sites=ietf_l3vpn_svc__l3vpn_svc__sites.from_xml(yang.gdata.get_xml_opt_child(n, 'sites')))
-        return ietf_l3vpn_svc__l3vpn_svc()
 
+mut def from_xml_ietf_l3vpn_svc__l3vpn_svc(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_vpn_profiles = yang.gdata.from_xml_opt_cnt(node, 'vpn-profiles')
+    yang.gdata.maybe_add(children, 'vpn-profiles', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_profiles, child_vpn_profiles)
+    child_vpn_services = yang.gdata.from_xml_opt_cnt(node, 'vpn-services')
+    yang.gdata.maybe_add(children, 'vpn-services', from_xml_ietf_l3vpn_svc__l3vpn_svc__vpn_services, child_vpn_services)
+    child_sites = yang.gdata.from_xml_opt_cnt(node, 'sites')
+    yang.gdata.maybe_add(children, 'sites', from_xml_ietf_l3vpn_svc__l3vpn_svc__sites, child_sites)
+    return yang.gdata.Container(children, ns='urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc', module='ietf-l3vpn-svc')
 
 mut def from_json_path_ietf_l3vpn_svc__l3vpn_svc(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -12586,12 +13720,14 @@ class root(yang.adata.MNode):
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_container('netinfra')), l3vpn_svc=ietf_l3vpn_svc__l3vpn_svc.from_gdata(n.get_opt_container('l3vpn-svc')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(netinfra=netinfra__netinfra.from_xml(yang.gdata.get_xml_opt_child(n, 'netinfra', 'http://example.com/netinfra')), l3vpn_svc=ietf_l3vpn_svc__l3vpn_svc.from_xml(yang.gdata.get_xml_opt_child(n, 'l3vpn-svc', 'urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_netinfra = yang.gdata.from_xml_opt_cnt(node, 'netinfra', 'http://example.com/netinfra')
+    yang.gdata.maybe_add(children, 'netinfra', from_xml_netinfra__netinfra, child_netinfra)
+    child_l3vpn_svc = yang.gdata.from_xml_opt_cnt(node, 'l3vpn-svc', 'urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc')
+    yang.gdata.maybe_add(children, 'l3vpn-svc', from_xml_ietf_l3vpn_svc__l3vpn_svc, child_l3vpn_svc)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/src/respnet/layers/y_1.act
+++ b/src/respnet/layers/y_1.act
@@ -10,22 +10,43 @@ import yang.gdata
 mut def from_json_netinfra_inter__netinfra__router__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 mut def from_json_netinfra_inter__netinfra__router__role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__mock(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__mock(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 mut def from_json_netinfra_inter__netinfra__router__base_config__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__base_config__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_netinfra_inter__netinfra__router__base_config__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__base_config__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__base_config__ipv6_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__base_config__ipv6_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
@@ -58,12 +79,16 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
             return netinfra_inter__netinfra__router__base_config(asn=n.get_int('asn'), ipv4_address=n.get_str('ipv4-address'), ipv6_address=n.get_str('ipv6-address'))
         raise ValueError('Missing required subtree netinfra_inter__netinfra__router__base_config')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> netinfra_inter__netinfra__router__base_config:
-        if n != None:
-            return netinfra_inter__netinfra__router__base_config(asn=yang.gdata.from_xml_int(n, 'asn'), ipv4_address=yang.gdata.from_xml_str(n, 'ipv4-address'), ipv6_address=yang.gdata.from_xml_str(n, 'ipv6-address'))
-        raise ValueError('Missing required subtree netinfra_inter__netinfra__router__base_config')
 
+mut def from_xml_netinfra_inter__netinfra__router__base_config(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_netinfra_inter__netinfra__router__base_config__asn, child_asn)
+    child_ipv4_address = yang.gdata.from_xml_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_netinfra_inter__netinfra__router__base_config__ipv4_address, child_ipv4_address)
+    child_ipv6_address = yang.gdata.from_xml_str(node, 'ipv6-address')
+    yang.gdata.maybe_add(children, 'ipv6-address', from_xml_netinfra_inter__netinfra__router__base_config__ipv6_address, child_ipv6_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_netinfra_inter__netinfra__router__base_config(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -98,7 +123,13 @@ mut def from_json_netinfra_inter__netinfra__router__base_config(jd: dict[str, ?v
 mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__l3vpn_vrf__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf__ebgp_customer_address(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('union', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__l3vpn_vrf__ebgp_customer_address(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('union', val)
 
 class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
@@ -121,10 +152,6 @@ class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router__l3vpn_vrf_entry:
         return netinfra_inter__netinfra__router__l3vpn_vrf_entry(vpn_id=n.get_str('vpn-id'), ebgp_customer_address=n.get_opt_strs('ebgp-customer-address'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__router__l3vpn_vrf_entry:
-        return netinfra_inter__netinfra__router__l3vpn_vrf_entry(vpn_id=yang.gdata.from_xml_str(n, 'vpn-id'), ebgp_customer_address=yang.gdata.from_xml_opt_strs(n, 'ebgp-customer-address'))
 
 class netinfra_inter__netinfra__router__l3vpn_vrf(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]
@@ -162,13 +189,20 @@ class netinfra_inter__netinfra__router__l3vpn_vrf(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__router__l3vpn_vrf_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__router__l3vpn_vrf_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__router__l3vpn_vrf_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_id = yang.gdata.from_xml_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_netinfra_inter__netinfra__router__l3vpn_vrf__vpn_id, child_vpn_id)
+    child_ebgp_customer_address = yang.gdata.from_xml_opt_strs(node, 'ebgp-customer-address')
+    yang.gdata.maybe_add(children, 'ebgp-customer-address', from_xml_netinfra_inter__netinfra__router__l3vpn_vrf__ebgp_customer_address, child_ebgp_customer_address)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
+
+mut def from_xml_netinfra_inter__netinfra__router__l3vpn_vrf(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__router__l3vpn_vrf_element(e))
+    return yang.gdata.List(keys=['vpn-id'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__router__l3vpn_vrf_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -275,10 +309,6 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router_entry:
         return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_int('id'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_container('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__router_entry:
-        return netinfra_inter__netinfra__router_entry(name=yang.gdata.from_xml_str(n, 'name'), id=yang.gdata.from_xml_int(n, 'id'), role=yang.gdata.from_xml_opt_str(n, 'role'), mock=yang.gdata.from_xml_opt_str(n, 'mock'), base_config=netinfra_inter__netinfra__router__base_config.from_xml(yang.gdata.get_xml_child(n, 'base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_xml(yang.gdata.get_xml_children(n, 'l3vpn-vrf')))
-
 class netinfra_inter__netinfra__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -315,13 +345,28 @@ class netinfra_inter__netinfra__router(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__router_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__router_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__router_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__router_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_netinfra_inter__netinfra__router__name, child_name)
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_netinfra_inter__netinfra__router__id, child_id)
+    child_role = yang.gdata.from_xml_opt_str(node, 'role')
+    yang.gdata.maybe_add(children, 'role', from_xml_netinfra_inter__netinfra__router__role, child_role)
+    child_mock = yang.gdata.from_xml_opt_str(node, 'mock')
+    yang.gdata.maybe_add(children, 'mock', from_xml_netinfra_inter__netinfra__router__mock, child_mock)
+    child_base_config = yang.gdata.from_xml_cnt(node, 'base-config')
+    yang.gdata.maybe_add(children, 'base-config', from_xml_netinfra_inter__netinfra__router__base_config, child_base_config)
+    child_l3vpn_vrf = yang.gdata.from_xml_opt_list(node, 'l3vpn-vrf')
+    yang.gdata.maybe_add(children, 'l3vpn-vrf', from_xml_netinfra_inter__netinfra__router__l3vpn_vrf, child_l3vpn_vrf)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_netinfra_inter__netinfra__router(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__router_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__router_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -404,13 +449,25 @@ mut def from_json_netinfra_inter__netinfra__router(jd: list[dict[str, ?value]]) 
 mut def from_json_netinfra_inter__netinfra__backbone_link__left_router(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__backbone_link__left_router(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__backbone_link__left_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__backbone_link__left_interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_netinfra_inter__netinfra__backbone_link__right_router(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__backbone_link__right_router(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__backbone_link__right_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__backbone_link__right_interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
@@ -445,10 +502,6 @@ class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__backbone_link_entry:
         return netinfra_inter__netinfra__backbone_link_entry(left_router=n.get_str('left-router'), left_interface=n.get_str('left-interface'), right_router=n.get_str('right-router'), right_interface=n.get_str('right-interface'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__backbone_link_entry:
-        return netinfra_inter__netinfra__backbone_link_entry(left_router=yang.gdata.from_xml_str(n, 'left-router'), left_interface=yang.gdata.from_xml_str(n, 'left-interface'), right_router=yang.gdata.from_xml_str(n, 'right-router'), right_interface=yang.gdata.from_xml_str(n, 'right-interface'))
 
 class netinfra_inter__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__backbone_link_entry]
@@ -495,13 +548,24 @@ class netinfra_inter__netinfra__backbone_link(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__backbone_link_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__backbone_link_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__backbone_link_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__backbone_link_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_left_router = yang.gdata.from_xml_str(node, 'left-router')
+    yang.gdata.maybe_add(children, 'left-router', from_xml_netinfra_inter__netinfra__backbone_link__left_router, child_left_router)
+    child_left_interface = yang.gdata.from_xml_str(node, 'left-interface')
+    yang.gdata.maybe_add(children, 'left-interface', from_xml_netinfra_inter__netinfra__backbone_link__left_interface, child_left_interface)
+    child_right_router = yang.gdata.from_xml_str(node, 'right-router')
+    yang.gdata.maybe_add(children, 'right-router', from_xml_netinfra_inter__netinfra__backbone_link__right_router, child_right_router)
+    child_right_interface = yang.gdata.from_xml_str(node, 'right-interface')
+    yang.gdata.maybe_add(children, 'right-interface', from_xml_netinfra_inter__netinfra__backbone_link__right_interface, child_right_interface)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_left_router), yang.gdata.yang_str(child_left_interface), yang.gdata.yang_str(child_right_router), yang.gdata.yang_str(child_right_interface)])
+
+mut def from_xml_netinfra_inter__netinfra__backbone_link(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__backbone_link_element(e))
+    return yang.gdata.List(keys=['left-router', 'left-interface', 'right-router', 'right-interface'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__backbone_link_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -573,13 +637,25 @@ mut def from_json_netinfra_inter__netinfra__backbone_link(jd: list[dict[str, ?va
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__authentication_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__router__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__router__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
@@ -604,10 +680,6 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__ibgp_fullmesh__router_entry:
         return netinfra_inter__netinfra__ibgp_fullmesh__router_entry(name=n.get_str('name'), ipv4_address=n.get_str('ipv4-address'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__ibgp_fullmesh__router_entry:
-        return netinfra_inter__netinfra__ibgp_fullmesh__router_entry(name=yang.gdata.from_xml_str(n, 'name'), ipv4_address=yang.gdata.from_xml_str(n, 'ipv4-address'))
 
 class netinfra_inter__netinfra__ibgp_fullmesh__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]
@@ -645,13 +717,20 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__ibgp_fullmesh__router_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__ibgp_fullmesh__router_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router__name, child_name)
+    child_ipv4_address = yang.gdata.from_xml_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router__ipv4_address, child_ipv4_address)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__ibgp_fullmesh__router_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -743,10 +822,6 @@ class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__ibgp_fullmesh_entry:
         return netinfra_inter__netinfra__ibgp_fullmesh_entry(asn=n.get_int('asn'), authentication_key=n.get_str('authentication-key'), router=netinfra_inter__netinfra__ibgp_fullmesh__router.from_gdata(n.get_opt_list('router')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__ibgp_fullmesh_entry:
-        return netinfra_inter__netinfra__ibgp_fullmesh_entry(asn=yang.gdata.from_xml_int(n, 'asn'), authentication_key=yang.gdata.from_xml_str(n, 'authentication-key'), router=netinfra_inter__netinfra__ibgp_fullmesh__router.from_xml(yang.gdata.get_xml_children(n, 'router')))
-
 class netinfra_inter__netinfra__ibgp_fullmesh(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh_entry]
     mut def __init__(self, elements=[]):
@@ -783,13 +858,22 @@ class netinfra_inter__netinfra__ibgp_fullmesh(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__ibgp_fullmesh_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__ibgp_fullmesh_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__ibgp_fullmesh_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__asn, child_asn)
+    child_authentication_key = yang.gdata.from_xml_str(node, 'authentication-key')
+    yang.gdata.maybe_add(children, 'authentication-key', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__authentication_key, child_authentication_key)
+    child_router = yang.gdata.from_xml_opt_list(node, 'router')
+    yang.gdata.maybe_add(children, 'router', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router, child_router)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_asn)])
+
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__ibgp_fullmesh_element(e))
+    return yang.gdata.List(keys=['asn'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__ibgp_fullmesh_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -887,12 +971,16 @@ class netinfra_inter__netinfra(yang.adata.MNode):
             return netinfra_inter__netinfra(router=netinfra_inter__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra_inter__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')), ibgp_fullmesh=netinfra_inter__netinfra__ibgp_fullmesh.from_gdata(n.get_opt_list('ibgp-fullmesh')))
         return netinfra_inter__netinfra()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> netinfra_inter__netinfra:
-        if n != None:
-            return netinfra_inter__netinfra(router=netinfra_inter__netinfra__router.from_xml(yang.gdata.get_xml_children(n, 'router')), backbone_link=netinfra_inter__netinfra__backbone_link.from_xml(yang.gdata.get_xml_children(n, 'backbone-link')), ibgp_fullmesh=netinfra_inter__netinfra__ibgp_fullmesh.from_xml(yang.gdata.get_xml_children(n, 'ibgp-fullmesh')))
-        return netinfra_inter__netinfra()
 
+mut def from_xml_netinfra_inter__netinfra(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_router = yang.gdata.from_xml_opt_list(node, 'router')
+    yang.gdata.maybe_add(children, 'router', from_xml_netinfra_inter__netinfra__router, child_router)
+    child_backbone_link = yang.gdata.from_xml_opt_list(node, 'backbone-link')
+    yang.gdata.maybe_add(children, 'backbone-link', from_xml_netinfra_inter__netinfra__backbone_link, child_backbone_link)
+    child_ibgp_fullmesh = yang.gdata.from_xml_opt_list(node, 'ibgp-fullmesh')
+    yang.gdata.maybe_add(children, 'ibgp-fullmesh', from_xml_netinfra_inter__netinfra__ibgp_fullmesh, child_ibgp_fullmesh)
+    return yang.gdata.Container(children, ns='http://example.com/netinfra-inter', module='netinfra-inter')
 
 mut def from_json_path_netinfra_inter__netinfra(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -930,31 +1018,61 @@ mut def from_json_netinfra_inter__netinfra(jd: dict[str, ?value]) -> yang.gdata.
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__device(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__device(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__site(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__site(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__site_network_access(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__site_network_access(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__provider_ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__provider_ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__customer_ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__customer_ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp__as_number(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
@@ -977,12 +1095,12 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
             return l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(as_number=n.get_int('as-number'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?l3vpn_inter__l3vpns__l3vpn__endpoint__bgp:
-        if n != None:
-            return l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(as_number=yang.gdata.from_xml_int(n, 'as-number'))
-        return None
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_number = yang.gdata.from_xml_int(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp__as_number, child_as_number)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1004,7 +1122,7 @@ mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(jd: dict[str, ?value
     children = {}
     child_as_number = yang.gdata.take_json_int(jd, 'as-number')
     yang.gdata.maybe_add(children, 'as-number', from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp__as_number, child_as_number)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
     device: str
@@ -1064,10 +1182,6 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn_inter__l3vpns__l3vpn__endpoint_entry:
         return l3vpn_inter__l3vpns__l3vpn__endpoint_entry(device=n.get_str('device'), interface=n.get_str('interface'), site=n.get_str('site'), site_network_access=n.get_str('site-network-access'), provider_ipv4_address=n.get_str('provider-ipv4-address'), customer_ipv4_address=n.get_opt_str('customer-ipv4-address'), ipv4_prefix_length=n.get_int('ipv4-prefix-length'), bgp=l3vpn_inter__l3vpns__l3vpn__endpoint__bgp.from_gdata(n.get_opt_container('bgp')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> l3vpn_inter__l3vpns__l3vpn__endpoint_entry:
-        return l3vpn_inter__l3vpns__l3vpn__endpoint_entry(device=yang.gdata.from_xml_str(n, 'device'), interface=yang.gdata.from_xml_str(n, 'interface'), site=yang.gdata.from_xml_str(n, 'site'), site_network_access=yang.gdata.from_xml_str(n, 'site-network-access'), provider_ipv4_address=yang.gdata.from_xml_str(n, 'provider-ipv4-address'), customer_ipv4_address=yang.gdata.from_xml_opt_str(n, 'customer-ipv4-address'), ipv4_prefix_length=yang.gdata.from_xml_int(n, 'ipv4-prefix-length'), bgp=l3vpn_inter__l3vpns__l3vpn__endpoint__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')))
-
 class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -1107,13 +1221,32 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
                 res.append(l3vpn_inter__l3vpns__l3vpn__endpoint_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]:
-        res = []
-        for node in nodes:
-            res.append(l3vpn_inter__l3vpns__l3vpn__endpoint_entry.from_xml(node))
-        return res
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_device = yang.gdata.from_xml_str(node, 'device')
+    yang.gdata.maybe_add(children, 'device', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__device, child_device)
+    child_interface = yang.gdata.from_xml_str(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__interface, child_interface)
+    child_site = yang.gdata.from_xml_str(node, 'site')
+    yang.gdata.maybe_add(children, 'site', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__site, child_site)
+    child_site_network_access = yang.gdata.from_xml_str(node, 'site-network-access')
+    yang.gdata.maybe_add(children, 'site-network-access', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__site_network_access, child_site_network_access)
+    child_provider_ipv4_address = yang.gdata.from_xml_str(node, 'provider-ipv4-address')
+    yang.gdata.maybe_add(children, 'provider-ipv4-address', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__provider_ipv4_address, child_provider_ipv4_address)
+    child_customer_ipv4_address = yang.gdata.from_xml_opt_str(node, 'customer-ipv4-address')
+    yang.gdata.maybe_add(children, 'customer-ipv4-address', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__customer_ipv4_address, child_customer_ipv4_address)
+    child_ipv4_prefix_length = yang.gdata.from_xml_int(node, 'ipv4-prefix-length')
+    yang.gdata.maybe_add(children, 'ipv4-prefix-length', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__ipv4_prefix_length, child_ipv4_prefix_length)
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp, child_bgp)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_device), yang.gdata.yang_str(child_interface)])
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint_element(e))
+    return yang.gdata.List(keys=['device', 'interface'], elements=elements)
 
 mut def from_json_path_l3vpn_inter__l3vpns__l3vpn__endpoint_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1228,10 +1361,6 @@ class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn_inter__l3vpns__l3vpn_entry:
         return l3vpn_inter__l3vpns__l3vpn_entry(name=n.get_str('name'), description=n.get_opt_str('description'), endpoint=l3vpn_inter__l3vpns__l3vpn__endpoint.from_gdata(n.get_opt_list('endpoint')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> l3vpn_inter__l3vpns__l3vpn_entry:
-        return l3vpn_inter__l3vpns__l3vpn_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), endpoint=l3vpn_inter__l3vpns__l3vpn__endpoint.from_xml(yang.gdata.get_xml_children(n, 'endpoint')))
-
 class l3vpn_inter__l3vpns__l3vpn(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1268,13 +1397,22 @@ class l3vpn_inter__l3vpns__l3vpn(yang.adata.MNode):
                 res.append(l3vpn_inter__l3vpns__l3vpn_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[l3vpn_inter__l3vpns__l3vpn_entry]:
-        res = []
-        for node in nodes:
-            res.append(l3vpn_inter__l3vpns__l3vpn_entry.from_xml(node))
-        return res
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_l3vpn_inter__l3vpns__l3vpn__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_l3vpn_inter__l3vpns__l3vpn__description, child_description)
+    child_endpoint = yang.gdata.from_xml_opt_list(node, 'endpoint')
+    yang.gdata.maybe_add(children, 'endpoint', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint, child_endpoint)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_l3vpn_inter__l3vpns__l3vpn_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_l3vpn_inter__l3vpns__l3vpn_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1362,12 +1500,12 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
             return l3vpn_inter__l3vpns(l3vpn=l3vpn_inter__l3vpns__l3vpn.from_gdata(n.get_opt_list('l3vpn')))
         return l3vpn_inter__l3vpns()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> l3vpn_inter__l3vpns:
-        if n != None:
-            return l3vpn_inter__l3vpns(l3vpn=l3vpn_inter__l3vpns__l3vpn.from_xml(yang.gdata.get_xml_children(n, 'l3vpn')))
-        return l3vpn_inter__l3vpns()
 
+mut def from_xml_l3vpn_inter__l3vpns(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l3vpn = yang.gdata.from_xml_opt_list(node, 'l3vpn')
+    yang.gdata.maybe_add(children, 'l3vpn', from_xml_l3vpn_inter__l3vpns__l3vpn, child_l3vpn)
+    return yang.gdata.Container(children, ns='http://example.com/l3vpn-inter', module='l3vpn-inter')
 
 mut def from_json_path_l3vpn_inter__l3vpns(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1417,12 +1555,14 @@ class root(yang.adata.MNode):
             return root(netinfra=netinfra_inter__netinfra.from_gdata(n.get_opt_container('netinfra')), l3vpns=l3vpn_inter__l3vpns.from_gdata(n.get_opt_container('l3vpns')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(netinfra=netinfra_inter__netinfra.from_xml(yang.gdata.get_xml_opt_child(n, 'netinfra', 'http://example.com/netinfra-inter')), l3vpns=l3vpn_inter__l3vpns.from_xml(yang.gdata.get_xml_opt_child(n, 'l3vpns', 'http://example.com/l3vpn-inter')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_netinfra = yang.gdata.from_xml_opt_cnt(node, 'netinfra', 'http://example.com/netinfra-inter')
+    yang.gdata.maybe_add(children, 'netinfra', from_xml_netinfra_inter__netinfra, child_netinfra)
+    child_l3vpns = yang.gdata.from_xml_opt_cnt(node, 'l3vpns', 'http://example.com/l3vpn-inter')
+    yang.gdata.maybe_add(children, 'l3vpns', from_xml_l3vpn_inter__l3vpns, child_l3vpns)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/src/respnet/layers/y_1_loose.act
+++ b/src/respnet/layers/y_1_loose.act
@@ -10,22 +10,43 @@ import yang.gdata
 mut def from_json_netinfra_inter__netinfra__router__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 mut def from_json_netinfra_inter__netinfra__router__role(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__role(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__mock(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('enumeration', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__mock(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('enumeration', val)
 
 mut def from_json_netinfra_inter__netinfra__router__base_config__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__base_config__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_netinfra_inter__netinfra__router__base_config__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__base_config__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__base_config__ipv6_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__base_config__ipv6_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
@@ -58,12 +79,16 @@ class netinfra_inter__netinfra__router__base_config(yang.adata.MNode):
             return netinfra_inter__netinfra__router__base_config(asn=n.get_opt_int('asn'), ipv4_address=n.get_opt_str('ipv4-address'), ipv6_address=n.get_opt_str('ipv6-address'))
         raise ValueError('Missing required subtree netinfra_inter__netinfra__router__base_config')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> netinfra_inter__netinfra__router__base_config:
-        if n != None:
-            return netinfra_inter__netinfra__router__base_config(asn=yang.gdata.from_xml_opt_int(n, 'asn'), ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'), ipv6_address=yang.gdata.from_xml_opt_str(n, 'ipv6-address'))
-        raise ValueError('Missing required subtree netinfra_inter__netinfra__router__base_config')
 
+mut def from_xml_netinfra_inter__netinfra__router__base_config(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_netinfra_inter__netinfra__router__base_config__asn, child_asn)
+    child_ipv4_address = yang.gdata.from_xml_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_netinfra_inter__netinfra__router__base_config__ipv4_address, child_ipv4_address)
+    child_ipv6_address = yang.gdata.from_xml_str(node, 'ipv6-address')
+    yang.gdata.maybe_add(children, 'ipv6-address', from_xml_netinfra_inter__netinfra__router__base_config__ipv6_address, child_ipv6_address)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_netinfra_inter__netinfra__router__base_config(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -98,7 +123,13 @@ mut def from_json_netinfra_inter__netinfra__router__base_config(jd: dict[str, ?v
 mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf__vpn_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__router__l3vpn_vrf__vpn_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__router__l3vpn_vrf__ebgp_customer_address(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('union', val)
+
+mut def from_xml_netinfra_inter__netinfra__router__l3vpn_vrf__ebgp_customer_address(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('union', val)
 
 class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
@@ -121,10 +152,6 @@ class netinfra_inter__netinfra__router__l3vpn_vrf_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router__l3vpn_vrf_entry:
         return netinfra_inter__netinfra__router__l3vpn_vrf_entry(vpn_id=n.get_str('vpn-id'), ebgp_customer_address=n.get_opt_strs('ebgp-customer-address'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__router__l3vpn_vrf_entry:
-        return netinfra_inter__netinfra__router__l3vpn_vrf_entry(vpn_id=yang.gdata.from_xml_str(n, 'vpn-id'), ebgp_customer_address=yang.gdata.from_xml_opt_strs(n, 'ebgp-customer-address'))
 
 class netinfra_inter__netinfra__router__l3vpn_vrf(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]
@@ -162,13 +189,20 @@ class netinfra_inter__netinfra__router__l3vpn_vrf(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__router__l3vpn_vrf_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__router__l3vpn_vrf_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__router__l3vpn_vrf_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__router__l3vpn_vrf_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vpn_id = yang.gdata.from_xml_str(node, 'vpn-id')
+    yang.gdata.maybe_add(children, 'vpn-id', from_xml_netinfra_inter__netinfra__router__l3vpn_vrf__vpn_id, child_vpn_id)
+    child_ebgp_customer_address = yang.gdata.from_xml_opt_strs(node, 'ebgp-customer-address')
+    yang.gdata.maybe_add(children, 'ebgp-customer-address', from_xml_netinfra_inter__netinfra__router__l3vpn_vrf__ebgp_customer_address, child_ebgp_customer_address)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vpn_id)])
+
+mut def from_xml_netinfra_inter__netinfra__router__l3vpn_vrf(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__router__l3vpn_vrf_element(e))
+    return yang.gdata.List(keys=['vpn-id'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__router__l3vpn_vrf_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -275,10 +309,6 @@ class netinfra_inter__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__router_entry:
         return netinfra_inter__netinfra__router_entry(name=n.get_str('name'), id=n.get_opt_int('id'), role=n.get_opt_str('role'), mock=n.get_opt_str('mock'), base_config=netinfra_inter__netinfra__router__base_config.from_gdata(n.get_opt_container('base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_gdata(n.get_opt_list('l3vpn-vrf')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__router_entry:
-        return netinfra_inter__netinfra__router_entry(name=yang.gdata.from_xml_str(n, 'name'), id=yang.gdata.from_xml_opt_int(n, 'id'), role=yang.gdata.from_xml_opt_str(n, 'role'), mock=yang.gdata.from_xml_opt_str(n, 'mock'), base_config=netinfra_inter__netinfra__router__base_config.from_xml(yang.gdata.get_xml_opt_child(n, 'base-config')), l3vpn_vrf=netinfra_inter__netinfra__router__l3vpn_vrf.from_xml(yang.gdata.get_xml_children(n, 'l3vpn-vrf')))
-
 class netinfra_inter__netinfra__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -315,13 +345,28 @@ class netinfra_inter__netinfra__router(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__router_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__router_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__router_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__router_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_netinfra_inter__netinfra__router__name, child_name)
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_netinfra_inter__netinfra__router__id, child_id)
+    child_role = yang.gdata.from_xml_opt_str(node, 'role')
+    yang.gdata.maybe_add(children, 'role', from_xml_netinfra_inter__netinfra__router__role, child_role)
+    child_mock = yang.gdata.from_xml_opt_str(node, 'mock')
+    yang.gdata.maybe_add(children, 'mock', from_xml_netinfra_inter__netinfra__router__mock, child_mock)
+    child_base_config = yang.gdata.from_xml_opt_cnt(node, 'base-config')
+    yang.gdata.maybe_add(children, 'base-config', from_xml_netinfra_inter__netinfra__router__base_config, child_base_config)
+    child_l3vpn_vrf = yang.gdata.from_xml_opt_list(node, 'l3vpn-vrf')
+    yang.gdata.maybe_add(children, 'l3vpn-vrf', from_xml_netinfra_inter__netinfra__router__l3vpn_vrf, child_l3vpn_vrf)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_netinfra_inter__netinfra__router(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__router_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__router_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -404,13 +449,25 @@ mut def from_json_netinfra_inter__netinfra__router(jd: list[dict[str, ?value]]) 
 mut def from_json_netinfra_inter__netinfra__backbone_link__left_router(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__backbone_link__left_router(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__backbone_link__left_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__backbone_link__left_interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_netinfra_inter__netinfra__backbone_link__right_router(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__backbone_link__right_router(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__backbone_link__right_interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__backbone_link__right_interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
@@ -445,10 +502,6 @@ class netinfra_inter__netinfra__backbone_link_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__backbone_link_entry:
         return netinfra_inter__netinfra__backbone_link_entry(left_router=n.get_str('left-router'), left_interface=n.get_str('left-interface'), right_router=n.get_str('right-router'), right_interface=n.get_str('right-interface'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__backbone_link_entry:
-        return netinfra_inter__netinfra__backbone_link_entry(left_router=yang.gdata.from_xml_str(n, 'left-router'), left_interface=yang.gdata.from_xml_str(n, 'left-interface'), right_router=yang.gdata.from_xml_str(n, 'right-router'), right_interface=yang.gdata.from_xml_str(n, 'right-interface'))
 
 class netinfra_inter__netinfra__backbone_link(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__backbone_link_entry]
@@ -495,13 +548,24 @@ class netinfra_inter__netinfra__backbone_link(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__backbone_link_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__backbone_link_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__backbone_link_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__backbone_link_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_left_router = yang.gdata.from_xml_str(node, 'left-router')
+    yang.gdata.maybe_add(children, 'left-router', from_xml_netinfra_inter__netinfra__backbone_link__left_router, child_left_router)
+    child_left_interface = yang.gdata.from_xml_str(node, 'left-interface')
+    yang.gdata.maybe_add(children, 'left-interface', from_xml_netinfra_inter__netinfra__backbone_link__left_interface, child_left_interface)
+    child_right_router = yang.gdata.from_xml_str(node, 'right-router')
+    yang.gdata.maybe_add(children, 'right-router', from_xml_netinfra_inter__netinfra__backbone_link__right_router, child_right_router)
+    child_right_interface = yang.gdata.from_xml_str(node, 'right-interface')
+    yang.gdata.maybe_add(children, 'right-interface', from_xml_netinfra_inter__netinfra__backbone_link__right_interface, child_right_interface)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_left_router), yang.gdata.yang_str(child_left_interface), yang.gdata.yang_str(child_right_router), yang.gdata.yang_str(child_right_interface)])
+
+mut def from_xml_netinfra_inter__netinfra__backbone_link(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__backbone_link_element(e))
+    return yang.gdata.List(keys=['left-router', 'left-interface', 'right-router', 'right-interface'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__backbone_link_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -573,13 +637,25 @@ mut def from_json_netinfra_inter__netinfra__backbone_link(jd: list[dict[str, ?va
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__authentication_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__router__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_netinfra_inter__netinfra__ibgp_fullmesh__router__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
@@ -604,10 +680,6 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__ibgp_fullmesh__router_entry:
         return netinfra_inter__netinfra__ibgp_fullmesh__router_entry(name=n.get_str('name'), ipv4_address=n.get_opt_str('ipv4-address'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__ibgp_fullmesh__router_entry:
-        return netinfra_inter__netinfra__ibgp_fullmesh__router_entry(name=yang.gdata.from_xml_str(n, 'name'), ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'))
 
 class netinfra_inter__netinfra__ibgp_fullmesh__router(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]
@@ -645,13 +717,20 @@ class netinfra_inter__netinfra__ibgp_fullmesh__router(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__ibgp_fullmesh__router_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__ibgp_fullmesh__router_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__ibgp_fullmesh__router_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router__name, child_name)
+    child_ipv4_address = yang.gdata.from_xml_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router__ipv4_address, child_ipv4_address)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__ibgp_fullmesh__router_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -743,10 +822,6 @@ class netinfra_inter__netinfra__ibgp_fullmesh_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra_inter__netinfra__ibgp_fullmesh_entry:
         return netinfra_inter__netinfra__ibgp_fullmesh_entry(asn=n.get_int('asn'), authentication_key=n.get_opt_str('authentication-key'), router=netinfra_inter__netinfra__ibgp_fullmesh__router.from_gdata(n.get_opt_list('router')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> netinfra_inter__netinfra__ibgp_fullmesh_entry:
-        return netinfra_inter__netinfra__ibgp_fullmesh_entry(asn=yang.gdata.from_xml_int(n, 'asn'), authentication_key=yang.gdata.from_xml_opt_str(n, 'authentication-key'), router=netinfra_inter__netinfra__ibgp_fullmesh__router.from_xml(yang.gdata.get_xml_children(n, 'router')))
-
 class netinfra_inter__netinfra__ibgp_fullmesh(yang.adata.MNode):
     elements: list[netinfra_inter__netinfra__ibgp_fullmesh_entry]
     mut def __init__(self, elements=[]):
@@ -783,13 +858,22 @@ class netinfra_inter__netinfra__ibgp_fullmesh(yang.adata.MNode):
                 res.append(netinfra_inter__netinfra__ibgp_fullmesh_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[netinfra_inter__netinfra__ibgp_fullmesh_entry]:
-        res = []
-        for node in nodes:
-            res.append(netinfra_inter__netinfra__ibgp_fullmesh_entry.from_xml(node))
-        return res
 
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__asn, child_asn)
+    child_authentication_key = yang.gdata.from_xml_str(node, 'authentication-key')
+    yang.gdata.maybe_add(children, 'authentication-key', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__authentication_key, child_authentication_key)
+    child_router = yang.gdata.from_xml_opt_list(node, 'router')
+    yang.gdata.maybe_add(children, 'router', from_xml_netinfra_inter__netinfra__ibgp_fullmesh__router, child_router)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_asn)])
+
+mut def from_xml_netinfra_inter__netinfra__ibgp_fullmesh(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_netinfra_inter__netinfra__ibgp_fullmesh_element(e))
+    return yang.gdata.List(keys=['asn'], elements=elements)
 
 mut def from_json_path_netinfra_inter__netinfra__ibgp_fullmesh_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -887,12 +971,16 @@ class netinfra_inter__netinfra(yang.adata.MNode):
             return netinfra_inter__netinfra(router=netinfra_inter__netinfra__router.from_gdata(n.get_opt_list('router')), backbone_link=netinfra_inter__netinfra__backbone_link.from_gdata(n.get_opt_list('backbone-link')), ibgp_fullmesh=netinfra_inter__netinfra__ibgp_fullmesh.from_gdata(n.get_opt_list('ibgp-fullmesh')))
         return netinfra_inter__netinfra()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> netinfra_inter__netinfra:
-        if n != None:
-            return netinfra_inter__netinfra(router=netinfra_inter__netinfra__router.from_xml(yang.gdata.get_xml_children(n, 'router')), backbone_link=netinfra_inter__netinfra__backbone_link.from_xml(yang.gdata.get_xml_children(n, 'backbone-link')), ibgp_fullmesh=netinfra_inter__netinfra__ibgp_fullmesh.from_xml(yang.gdata.get_xml_children(n, 'ibgp-fullmesh')))
-        return netinfra_inter__netinfra()
 
+mut def from_xml_netinfra_inter__netinfra(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_router = yang.gdata.from_xml_opt_list(node, 'router')
+    yang.gdata.maybe_add(children, 'router', from_xml_netinfra_inter__netinfra__router, child_router)
+    child_backbone_link = yang.gdata.from_xml_opt_list(node, 'backbone-link')
+    yang.gdata.maybe_add(children, 'backbone-link', from_xml_netinfra_inter__netinfra__backbone_link, child_backbone_link)
+    child_ibgp_fullmesh = yang.gdata.from_xml_opt_list(node, 'ibgp-fullmesh')
+    yang.gdata.maybe_add(children, 'ibgp-fullmesh', from_xml_netinfra_inter__netinfra__ibgp_fullmesh, child_ibgp_fullmesh)
+    return yang.gdata.Container(children, ns='http://example.com/netinfra-inter', module='netinfra-inter')
 
 mut def from_json_path_netinfra_inter__netinfra(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -930,31 +1018,61 @@ mut def from_json_netinfra_inter__netinfra(jd: dict[str, ?value]) -> yang.gdata.
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__device(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__device(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__site(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__site(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__site_network_access(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__site_network_access(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__provider_ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__provider_ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__customer_ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__customer_ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp__as_number(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp__as_number(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
@@ -977,12 +1095,12 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(yang.adata.MNode):
             return l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(as_number=n.get_opt_int('as-number'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?l3vpn_inter__l3vpns__l3vpn__endpoint__bgp:
-        if n != None:
-            return l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(as_number=yang.gdata.from_xml_opt_int(n, 'as-number'))
-        return None
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_number = yang.gdata.from_xml_int(node, 'as-number')
+    yang.gdata.maybe_add(children, 'as-number', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp__as_number, child_as_number)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1004,7 +1122,7 @@ mut def from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp(jd: dict[str, ?value
     children = {}
     child_as_number = yang.gdata.take_json_int(jd, 'as-number')
     yang.gdata.maybe_add(children, 'as-number', from_json_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp__as_number, child_as_number)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
     device: str
@@ -1064,10 +1182,6 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn_inter__l3vpns__l3vpn__endpoint_entry:
         return l3vpn_inter__l3vpns__l3vpn__endpoint_entry(device=n.get_str('device'), interface=n.get_str('interface'), site=n.get_opt_str('site'), site_network_access=n.get_opt_str('site-network-access'), provider_ipv4_address=n.get_opt_str('provider-ipv4-address'), customer_ipv4_address=n.get_opt_str('customer-ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'), bgp=l3vpn_inter__l3vpns__l3vpn__endpoint__bgp.from_gdata(n.get_opt_container('bgp')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> l3vpn_inter__l3vpns__l3vpn__endpoint_entry:
-        return l3vpn_inter__l3vpns__l3vpn__endpoint_entry(device=yang.gdata.from_xml_str(n, 'device'), interface=yang.gdata.from_xml_str(n, 'interface'), site=yang.gdata.from_xml_opt_str(n, 'site'), site_network_access=yang.gdata.from_xml_opt_str(n, 'site-network-access'), provider_ipv4_address=yang.gdata.from_xml_opt_str(n, 'provider-ipv4-address'), customer_ipv4_address=yang.gdata.from_xml_opt_str(n, 'customer-ipv4-address'), ipv4_prefix_length=yang.gdata.from_xml_opt_int(n, 'ipv4-prefix-length'), bgp=l3vpn_inter__l3vpns__l3vpn__endpoint__bgp.from_xml(yang.gdata.get_xml_opt_child(n, 'bgp')))
-
 class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -1107,13 +1221,32 @@ class l3vpn_inter__l3vpns__l3vpn__endpoint(yang.adata.MNode):
                 res.append(l3vpn_inter__l3vpns__l3vpn__endpoint_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[l3vpn_inter__l3vpns__l3vpn__endpoint_entry]:
-        res = []
-        for node in nodes:
-            res.append(l3vpn_inter__l3vpns__l3vpn__endpoint_entry.from_xml(node))
-        return res
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_device = yang.gdata.from_xml_str(node, 'device')
+    yang.gdata.maybe_add(children, 'device', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__device, child_device)
+    child_interface = yang.gdata.from_xml_str(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__interface, child_interface)
+    child_site = yang.gdata.from_xml_str(node, 'site')
+    yang.gdata.maybe_add(children, 'site', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__site, child_site)
+    child_site_network_access = yang.gdata.from_xml_str(node, 'site-network-access')
+    yang.gdata.maybe_add(children, 'site-network-access', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__site_network_access, child_site_network_access)
+    child_provider_ipv4_address = yang.gdata.from_xml_str(node, 'provider-ipv4-address')
+    yang.gdata.maybe_add(children, 'provider-ipv4-address', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__provider_ipv4_address, child_provider_ipv4_address)
+    child_customer_ipv4_address = yang.gdata.from_xml_opt_str(node, 'customer-ipv4-address')
+    yang.gdata.maybe_add(children, 'customer-ipv4-address', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__customer_ipv4_address, child_customer_ipv4_address)
+    child_ipv4_prefix_length = yang.gdata.from_xml_int(node, 'ipv4-prefix-length')
+    yang.gdata.maybe_add(children, 'ipv4-prefix-length', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__ipv4_prefix_length, child_ipv4_prefix_length)
+    child_bgp = yang.gdata.from_xml_opt_cnt(node, 'bgp')
+    yang.gdata.maybe_add(children, 'bgp', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint__bgp, child_bgp)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_device), yang.gdata.yang_str(child_interface)])
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint_element(e))
+    return yang.gdata.List(keys=['device', 'interface'], elements=elements)
 
 mut def from_json_path_l3vpn_inter__l3vpns__l3vpn__endpoint_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1228,10 +1361,6 @@ class l3vpn_inter__l3vpns__l3vpn_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn_inter__l3vpns__l3vpn_entry:
         return l3vpn_inter__l3vpns__l3vpn_entry(name=n.get_str('name'), description=n.get_opt_str('description'), endpoint=l3vpn_inter__l3vpns__l3vpn__endpoint.from_gdata(n.get_opt_list('endpoint')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> l3vpn_inter__l3vpns__l3vpn_entry:
-        return l3vpn_inter__l3vpns__l3vpn_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), endpoint=l3vpn_inter__l3vpns__l3vpn__endpoint.from_xml(yang.gdata.get_xml_children(n, 'endpoint')))
-
 class l3vpn_inter__l3vpns__l3vpn(yang.adata.MNode):
     elements: list[l3vpn_inter__l3vpns__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1268,13 +1397,22 @@ class l3vpn_inter__l3vpns__l3vpn(yang.adata.MNode):
                 res.append(l3vpn_inter__l3vpns__l3vpn_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[l3vpn_inter__l3vpns__l3vpn_entry]:
-        res = []
-        for node in nodes:
-            res.append(l3vpn_inter__l3vpns__l3vpn_entry.from_xml(node))
-        return res
 
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_l3vpn_inter__l3vpns__l3vpn__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_l3vpn_inter__l3vpns__l3vpn__description, child_description)
+    child_endpoint = yang.gdata.from_xml_opt_list(node, 'endpoint')
+    yang.gdata.maybe_add(children, 'endpoint', from_xml_l3vpn_inter__l3vpns__l3vpn__endpoint, child_endpoint)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_l3vpn_inter__l3vpns__l3vpn(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_l3vpn_inter__l3vpns__l3vpn_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_l3vpn_inter__l3vpns__l3vpn_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1362,12 +1500,12 @@ class l3vpn_inter__l3vpns(yang.adata.MNode):
             return l3vpn_inter__l3vpns(l3vpn=l3vpn_inter__l3vpns__l3vpn.from_gdata(n.get_opt_list('l3vpn')))
         return l3vpn_inter__l3vpns()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> l3vpn_inter__l3vpns:
-        if n != None:
-            return l3vpn_inter__l3vpns(l3vpn=l3vpn_inter__l3vpns__l3vpn.from_xml(yang.gdata.get_xml_children(n, 'l3vpn')))
-        return l3vpn_inter__l3vpns()
 
+mut def from_xml_l3vpn_inter__l3vpns(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l3vpn = yang.gdata.from_xml_opt_list(node, 'l3vpn')
+    yang.gdata.maybe_add(children, 'l3vpn', from_xml_l3vpn_inter__l3vpns__l3vpn, child_l3vpn)
+    return yang.gdata.Container(children, ns='http://example.com/l3vpn-inter', module='l3vpn-inter')
 
 mut def from_json_path_l3vpn_inter__l3vpns(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1417,12 +1555,14 @@ class root(yang.adata.MNode):
             return root(netinfra=netinfra_inter__netinfra.from_gdata(n.get_opt_container('netinfra')), l3vpns=l3vpn_inter__l3vpns.from_gdata(n.get_opt_container('l3vpns')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(netinfra=netinfra_inter__netinfra.from_xml(yang.gdata.get_xml_opt_child(n, 'netinfra', 'http://example.com/netinfra-inter')), l3vpns=l3vpn_inter__l3vpns.from_xml(yang.gdata.get_xml_opt_child(n, 'l3vpns', 'http://example.com/l3vpn-inter')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_netinfra = yang.gdata.from_xml_opt_cnt(node, 'netinfra', 'http://example.com/netinfra-inter')
+    yang.gdata.maybe_add(children, 'netinfra', from_xml_netinfra_inter__netinfra, child_netinfra)
+    child_l3vpns = yang.gdata.from_xml_opt_cnt(node, 'l3vpns', 'http://example.com/l3vpn-inter')
+    yang.gdata.maybe_add(children, 'l3vpns', from_xml_l3vpn_inter__l3vpns, child_l3vpns)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/src/respnet/layers/y_2.act
+++ b/src/respnet/layers/y_2.act
@@ -10,28 +10,55 @@ import yang.gdata
 mut def from_json_orchestron_rfs__device__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__address__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__address__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__address__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_orchestron_rfs__device__address__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_orchestron_rfs__device__address__port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__address__port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__address__initial_credentials__username(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__address__initial_credentials__username(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__address__initial_credentials__password(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__address__initial_credentials__password(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__address__initial_credentials__key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__address__initial_credentials__key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__device__address__initial_credentials_entry(yang.adata.MNode):
@@ -61,10 +88,6 @@ class orchestron_rfs__device__address__initial_credentials_entry(yang.adata.MNod
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address__initial_credentials_entry:
         return orchestron_rfs__device__address__initial_credentials_entry(username=n.get_str('username'), password=n.get_str('password'), key=n.get_str('key'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__address__initial_credentials_entry:
-        return orchestron_rfs__device__address__initial_credentials_entry(username=yang.gdata.from_xml_str(n, 'username'), password=yang.gdata.from_xml_str(n, 'password'), key=yang.gdata.from_xml_str(n, 'key'))
 
 class orchestron_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[orchestron_rfs__device__address__initial_credentials_entry]
@@ -108,13 +131,22 @@ class orchestron_rfs__device__address__initial_credentials(yang.adata.MNode):
                 res.append(orchestron_rfs__device__address__initial_credentials_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__address__initial_credentials_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__address__initial_credentials_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__address__initial_credentials_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_username = yang.gdata.from_xml_str(node, 'username')
+    yang.gdata.maybe_add(children, 'username', from_xml_orchestron_rfs__device__address__initial_credentials__username, child_username)
+    child_password = yang.gdata.from_xml_str(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_orchestron_rfs__device__address__initial_credentials__password, child_password)
+    child_key = yang.gdata.from_xml_str(node, 'key')
+    yang.gdata.maybe_add(children, 'key', from_xml_orchestron_rfs__device__address__initial_credentials__key, child_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_username), yang.gdata.yang_str(child_password), yang.gdata.yang_str(child_key)])
+
+mut def from_xml_orchestron_rfs__device__address__initial_credentials(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__address__initial_credentials_element(e))
+    return yang.gdata.List(keys=['username', 'password', 'key'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__address__initial_credentials_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -213,10 +245,6 @@ class orchestron_rfs__device__address_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address_entry:
         return orchestron_rfs__device__address_entry(name=n.get_str('name'), address=n.get_str('address'), port=n.get_opt_str('port'), initial_credentials=orchestron_rfs__device__address__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__address_entry:
-        return orchestron_rfs__device__address_entry(name=yang.gdata.from_xml_str(n, 'name'), address=yang.gdata.from_xml_str(n, 'address'), port=yang.gdata.from_xml_opt_str(n, 'port'), initial_credentials=orchestron_rfs__device__address__initial_credentials.from_xml(yang.gdata.get_xml_children(n, 'initial-credentials')))
-
 class orchestron_rfs__device__address(yang.adata.MNode):
     elements: list[orchestron_rfs__device__address_entry]
     mut def __init__(self, elements=[]):
@@ -253,13 +281,24 @@ class orchestron_rfs__device__address(yang.adata.MNode):
                 res.append(orchestron_rfs__device__address_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__address_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__address_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__address_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__device__address__name, child_name)
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_orchestron_rfs__device__address__address, child_address)
+    child_port = yang.gdata.from_xml_opt_str(node, 'port')
+    yang.gdata.maybe_add(children, 'port', from_xml_orchestron_rfs__device__address__port, child_port)
+    child_initial_credentials = yang.gdata.from_xml_opt_list(node, 'initial-credentials')
+    yang.gdata.maybe_add(children, 'initial-credentials', from_xml_orchestron_rfs__device__address__initial_credentials, child_initial_credentials)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__device__address(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__address_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__address_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -334,13 +373,25 @@ mut def from_json_orchestron_rfs__device__address(jd: list[dict[str, ?value]]) -
 mut def from_json_orchestron_rfs__device__credentials__username(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__credentials__username(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__credentials__password(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__credentials__password(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__credentials__key__key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__credentials__key__key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__credentials__key__private_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__credentials__key__private_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__device__credentials__key_entry(yang.adata.MNode):
@@ -365,10 +416,6 @@ class orchestron_rfs__device__credentials__key_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__credentials__key_entry:
         return orchestron_rfs__device__credentials__key_entry(key=n.get_str('key'), private_key=n.get_opt_str('private-key'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__credentials__key_entry:
-        return orchestron_rfs__device__credentials__key_entry(key=yang.gdata.from_xml_str(n, 'key'), private_key=yang.gdata.from_xml_opt_str(n, 'private-key'))
 
 class orchestron_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[orchestron_rfs__device__credentials__key_entry]
@@ -406,13 +453,20 @@ class orchestron_rfs__device__credentials__key(yang.adata.MNode):
                 res.append(orchestron_rfs__device__credentials__key_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__credentials__key_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__credentials__key_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__credentials__key_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_key = yang.gdata.from_xml_str(node, 'key')
+    yang.gdata.maybe_add(children, 'key', from_xml_orchestron_rfs__device__credentials__key__key, child_key)
+    child_private_key = yang.gdata.from_xml_opt_str(node, 'private-key')
+    yang.gdata.maybe_add(children, 'private-key', from_xml_orchestron_rfs__device__credentials__key__private_key, child_private_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key)])
+
+mut def from_xml_orchestron_rfs__device__credentials__key(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__credentials__key_element(e))
+    return yang.gdata.List(keys=['key'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__credentials__key_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -506,12 +560,16 @@ class orchestron_rfs__device__credentials(yang.adata.MNode):
             return orchestron_rfs__device__credentials(username=n.get_str('username'), password=n.get_opt_str('password'), key=orchestron_rfs__device__credentials__key.from_gdata(n.get_opt_list('key')))
         raise ValueError('Missing required subtree orchestron_rfs__device__credentials')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> orchestron_rfs__device__credentials:
-        if n != None:
-            return orchestron_rfs__device__credentials(username=yang.gdata.from_xml_str(n, 'username'), password=yang.gdata.from_xml_opt_str(n, 'password'), key=orchestron_rfs__device__credentials__key.from_xml(yang.gdata.get_xml_children(n, 'key')))
-        raise ValueError('Missing required subtree orchestron_rfs__device__credentials')
 
+mut def from_xml_orchestron_rfs__device__credentials(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_username = yang.gdata.from_xml_str(node, 'username')
+    yang.gdata.maybe_add(children, 'username', from_xml_orchestron_rfs__device__credentials__username, child_username)
+    child_password = yang.gdata.from_xml_opt_str(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_orchestron_rfs__device__credentials__password, child_password)
+    child_key = yang.gdata.from_xml_opt_list(node, 'key')
+    yang.gdata.maybe_add(children, 'key', from_xml_orchestron_rfs__device__credentials__key, child_key)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_orchestron_rfs__device__credentials(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -547,10 +605,19 @@ mut def from_json_orchestron_rfs__device__credentials(jd: dict[str, ?value]) -> 
 mut def from_json_orchestron_rfs__device__initial_credentials__username(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__initial_credentials__username(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__initial_credentials__password(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__initial_credentials__password(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__initial_credentials__key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__initial_credentials__key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__device__initial_credentials_entry(yang.adata.MNode):
@@ -580,10 +647,6 @@ class orchestron_rfs__device__initial_credentials_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__initial_credentials_entry:
         return orchestron_rfs__device__initial_credentials_entry(username=n.get_str('username'), password=n.get_str('password'), key=n.get_str('key'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__initial_credentials_entry:
-        return orchestron_rfs__device__initial_credentials_entry(username=yang.gdata.from_xml_str(n, 'username'), password=yang.gdata.from_xml_str(n, 'password'), key=yang.gdata.from_xml_str(n, 'key'))
 
 class orchestron_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[orchestron_rfs__device__initial_credentials_entry]
@@ -627,13 +690,22 @@ class orchestron_rfs__device__initial_credentials(yang.adata.MNode):
                 res.append(orchestron_rfs__device__initial_credentials_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__initial_credentials_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__initial_credentials_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__initial_credentials_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_username = yang.gdata.from_xml_str(node, 'username')
+    yang.gdata.maybe_add(children, 'username', from_xml_orchestron_rfs__device__initial_credentials__username, child_username)
+    child_password = yang.gdata.from_xml_str(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_orchestron_rfs__device__initial_credentials__password, child_password)
+    child_key = yang.gdata.from_xml_str(node, 'key')
+    yang.gdata.maybe_add(children, 'key', from_xml_orchestron_rfs__device__initial_credentials__key, child_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_username), yang.gdata.yang_str(child_password), yang.gdata.yang_str(child_key)])
+
+mut def from_xml_orchestron_rfs__device__initial_credentials(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__initial_credentials_element(e))
+    return yang.gdata.List(keys=['username', 'password', 'key'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__initial_credentials_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -702,16 +774,31 @@ mut def from_json_orchestron_rfs__device__initial_credentials(jd: list[dict[str,
 mut def from_json_orchestron_rfs__device__mock__preset(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
+mut def from_xml_orchestron_rfs__device__mock__preset(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
 mut def from_json_orchestron_rfs__device__mock__module__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__mock__module__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__mock__module__namespace(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__mock__module__namespace(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__mock__module__revision(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__mock__module__revision(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__mock__module__feature(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_orchestron_rfs__device__mock__module__feature(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
@@ -744,10 +831,6 @@ class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__mock__module_entry:
         return orchestron_rfs__device__mock__module_entry(name=n.get_str('name'), namespace=n.get_str('namespace'), revision=n.get_opt_str('revision'), feature=n.get_opt_strs('feature'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__mock__module_entry:
-        return orchestron_rfs__device__mock__module_entry(name=yang.gdata.from_xml_str(n, 'name'), namespace=yang.gdata.from_xml_str(n, 'namespace'), revision=yang.gdata.from_xml_opt_str(n, 'revision'), feature=yang.gdata.from_xml_opt_strs(n, 'feature'))
 
 class orchestron_rfs__device__mock__module(yang.adata.MNode):
     elements: list[orchestron_rfs__device__mock__module_entry]
@@ -785,13 +868,24 @@ class orchestron_rfs__device__mock__module(yang.adata.MNode):
                 res.append(orchestron_rfs__device__mock__module_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__mock__module_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__mock__module_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__mock__module_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__device__mock__module__name, child_name)
+    child_namespace = yang.gdata.from_xml_str(node, 'namespace')
+    yang.gdata.maybe_add(children, 'namespace', from_xml_orchestron_rfs__device__mock__module__namespace, child_namespace)
+    child_revision = yang.gdata.from_xml_opt_str(node, 'revision')
+    yang.gdata.maybe_add(children, 'revision', from_xml_orchestron_rfs__device__mock__module__revision, child_revision)
+    child_feature = yang.gdata.from_xml_opt_strs(node, 'feature')
+    yang.gdata.maybe_add(children, 'feature', from_xml_orchestron_rfs__device__mock__module__feature, child_feature)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__device__mock__module(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__mock__module_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__mock__module_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -886,12 +980,14 @@ class orchestron_rfs__device__mock(yang.adata.MNode):
             return orchestron_rfs__device__mock(preset=n.get_opt_strs('preset'), module=orchestron_rfs__device__mock__module.from_gdata(n.get_opt_list('module')))
         return orchestron_rfs__device__mock()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> orchestron_rfs__device__mock:
-        if n != None:
-            return orchestron_rfs__device__mock(preset=yang.gdata.from_xml_opt_strs(n, 'preset'), module=orchestron_rfs__device__mock__module.from_xml(yang.gdata.get_xml_children(n, 'module')))
-        return orchestron_rfs__device__mock()
 
+mut def from_xml_orchestron_rfs__device__mock(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_preset = yang.gdata.from_xml_opt_strs(node, 'preset')
+    yang.gdata.maybe_add(children, 'preset', from_xml_orchestron_rfs__device__mock__preset, child_preset)
+    child_module = yang.gdata.from_xml_opt_list(node, 'module')
+    yang.gdata.maybe_add(children, 'module', from_xml_orchestron_rfs__device__mock__module, child_module)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_orchestron_rfs__device__mock(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -968,10 +1064,6 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:
         return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_container('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_container('mock')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device_entry:
-        return orchestron_rfs__device_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), type=yang.gdata.from_xml_opt_str(n, 'type'), address=orchestron_rfs__device__address.from_xml(yang.gdata.get_xml_children(n, 'address')), credentials=orchestron_rfs__device__credentials.from_xml(yang.gdata.get_xml_child(n, 'credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_xml(yang.gdata.get_xml_children(n, 'initial-credentials')), mock=orchestron_rfs__device__mock.from_xml(yang.gdata.get_xml_opt_child(n, 'mock')))
-
 class orchestron_rfs__device(yang.adata.MNode):
     elements: list[orchestron_rfs__device_entry]
     mut def __init__(self, elements=[]):
@@ -1008,13 +1100,30 @@ class orchestron_rfs__device(yang.adata.MNode):
                 res.append(orchestron_rfs__device_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__device__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__device__description, child_description)
+    child_type = yang.gdata.from_xml_opt_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_orchestron_rfs__device__type, child_type)
+    child_address = yang.gdata.from_xml_opt_list(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_orchestron_rfs__device__address, child_address)
+    child_credentials = yang.gdata.from_xml_cnt(node, 'credentials')
+    yang.gdata.maybe_add(children, 'credentials', from_xml_orchestron_rfs__device__credentials, child_credentials)
+    child_initial_credentials = yang.gdata.from_xml_opt_list(node, 'initial-credentials')
+    yang.gdata.maybe_add(children, 'initial-credentials', from_xml_orchestron_rfs__device__initial_credentials, child_initial_credentials)
+    child_mock = yang.gdata.from_xml_opt_cnt(node, 'mock')
+    yang.gdata.maybe_add(children, 'mock', from_xml_orchestron_rfs__device__mock, child_mock)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__device(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')
 
 mut def from_json_path_orchestron_rfs__device_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1101,19 +1210,37 @@ mut def from_json_orchestron_rfs__device(jd: list[dict[str, ?value]]) -> yang.gd
 mut def from_json_orchestron_rfs__rfs__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__base_config__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__base_config__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__base_config__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__base_config__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__base_config__ipv6_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__base_config__ipv6_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__base_config__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__base_config__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__base_config__ibgp_authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__base_config__ibgp_authentication_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__rfs__base_config_entry(yang.adata.MNode):
@@ -1154,10 +1281,6 @@ class orchestron_rfs__rfs__base_config_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__base_config_entry:
         return orchestron_rfs__rfs__base_config_entry(name=n.get_str('name'), ipv4_address=n.get_str('ipv4-address'), ipv6_address=n.get_str('ipv6-address'), asn=n.get_int('asn'), ibgp_authentication_key=n.get_str('ibgp-authentication-key'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__base_config_entry:
-        return orchestron_rfs__rfs__base_config_entry(name=yang.gdata.from_xml_str(n, 'name'), ipv4_address=yang.gdata.from_xml_str(n, 'ipv4-address'), ipv6_address=yang.gdata.from_xml_str(n, 'ipv6-address'), asn=yang.gdata.from_xml_int(n, 'asn'), ibgp_authentication_key=yang.gdata.from_xml_str(n, 'ibgp-authentication-key'))
-
 class orchestron_rfs__rfs__base_config(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__base_config_entry]
     mut def __init__(self, elements=[]):
@@ -1194,13 +1317,26 @@ class orchestron_rfs__rfs__base_config(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__base_config_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__base_config_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__base_config_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__base_config_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__base_config__name, child_name)
+    child_ipv4_address = yang.gdata.from_xml_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_orchestron_rfs__rfs__base_config__ipv4_address, child_ipv4_address)
+    child_ipv6_address = yang.gdata.from_xml_str(node, 'ipv6-address')
+    yang.gdata.maybe_add(children, 'ipv6-address', from_xml_orchestron_rfs__rfs__base_config__ipv6_address, child_ipv6_address)
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_orchestron_rfs__rfs__base_config__asn, child_asn)
+    child_ibgp_authentication_key = yang.gdata.from_xml_str(node, 'ibgp-authentication-key')
+    yang.gdata.maybe_add(children, 'ibgp-authentication-key', from_xml_orchestron_rfs__rfs__base_config__ibgp_authentication_key, child_ibgp_authentication_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs__base_config(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__base_config_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__base_config_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1279,22 +1415,43 @@ mut def from_json_orchestron_rfs__rfs__base_config(jd: list[dict[str, ?value]]) 
 mut def from_json_orchestron_rfs__rfs__backbone_interface__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__backbone_interface__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__backbone_interface__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_orchestron_rfs__rfs__backbone_interface__ipv6_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__ipv6_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__backbone_interface__ipv6_prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__ipv6_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_orchestron_rfs__rfs__backbone_interface__remote__device(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__remote__device(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__backbone_interface__remote__interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__remote__interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
@@ -1322,12 +1479,14 @@ class orchestron_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
             return orchestron_rfs__rfs__backbone_interface__remote(device=n.get_str('device'), interface=n.get_str('interface'))
         raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__remote')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> orchestron_rfs__rfs__backbone_interface__remote:
-        if n != None:
-            return orchestron_rfs__rfs__backbone_interface__remote(device=yang.gdata.from_xml_str(n, 'device'), interface=yang.gdata.from_xml_str(n, 'interface'))
-        raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__remote')
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__remote(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_device = yang.gdata.from_xml_str(node, 'device')
+    yang.gdata.maybe_add(children, 'device', from_xml_orchestron_rfs__rfs__backbone_interface__remote__device, child_device)
+    child_interface = yang.gdata.from_xml_str(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_orchestron_rfs__rfs__backbone_interface__remote__interface, child_interface)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_orchestron_rfs__rfs__backbone_interface__remote(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1398,10 +1557,6 @@ class orchestron_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__backbone_interface_entry:
         return orchestron_rfs__rfs__backbone_interface_entry(name=n.get_str('name'), ipv4_address=n.get_opt_str('ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'), ipv6_address=n.get_opt_str('ipv6-address'), ipv6_prefix_length=n.get_opt_int('ipv6-prefix-length'), remote=orchestron_rfs__rfs__backbone_interface__remote.from_gdata(n.get_container('remote')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__backbone_interface_entry:
-        return orchestron_rfs__rfs__backbone_interface_entry(name=yang.gdata.from_xml_str(n, 'name'), ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'), ipv4_prefix_length=yang.gdata.from_xml_opt_int(n, 'ipv4-prefix-length'), ipv6_address=yang.gdata.from_xml_opt_str(n, 'ipv6-address'), ipv6_prefix_length=yang.gdata.from_xml_opt_int(n, 'ipv6-prefix-length'), remote=orchestron_rfs__rfs__backbone_interface__remote.from_xml(yang.gdata.get_xml_child(n, 'remote')))
-
 class orchestron_rfs__rfs__backbone_interface(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__backbone_interface_entry]
     mut def __init__(self, elements=[]):
@@ -1438,13 +1593,28 @@ class orchestron_rfs__rfs__backbone_interface(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__backbone_interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__backbone_interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__backbone_interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__backbone_interface__name, child_name)
+    child_ipv4_address = yang.gdata.from_xml_opt_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_orchestron_rfs__rfs__backbone_interface__ipv4_address, child_ipv4_address)
+    child_ipv4_prefix_length = yang.gdata.from_xml_opt_int(node, 'ipv4-prefix-length')
+    yang.gdata.maybe_add(children, 'ipv4-prefix-length', from_xml_orchestron_rfs__rfs__backbone_interface__ipv4_prefix_length, child_ipv4_prefix_length)
+    child_ipv6_address = yang.gdata.from_xml_opt_str(node, 'ipv6-address')
+    yang.gdata.maybe_add(children, 'ipv6-address', from_xml_orchestron_rfs__rfs__backbone_interface__ipv6_address, child_ipv6_address)
+    child_ipv6_prefix_length = yang.gdata.from_xml_opt_int(node, 'ipv6-prefix-length')
+    yang.gdata.maybe_add(children, 'ipv6-prefix-length', from_xml_orchestron_rfs__rfs__backbone_interface__ipv6_prefix_length, child_ipv6_prefix_length)
+    child_remote = yang.gdata.from_xml_cnt(node, 'remote')
+    yang.gdata.maybe_add(children, 'remote', from_xml_orchestron_rfs__rfs__backbone_interface__remote, child_remote)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs__backbone_interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__backbone_interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__backbone_interface_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1527,10 +1697,19 @@ mut def from_json_orchestron_rfs__rfs__backbone_interface(jd: list[dict[str, ?va
 mut def from_json_orchestron_rfs__rfs__ibgp_neighbor__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_orchestron_rfs__rfs__ibgp_neighbor__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__ibgp_neighbor__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
@@ -1560,10 +1739,6 @@ class orchestron_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__ibgp_neighbor_entry:
         return orchestron_rfs__rfs__ibgp_neighbor_entry(address=n.get_str('address'), asn=n.get_int('asn'), description=n.get_str('description'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__ibgp_neighbor_entry:
-        return orchestron_rfs__rfs__ibgp_neighbor_entry(address=yang.gdata.from_xml_str(n, 'address'), asn=yang.gdata.from_xml_int(n, 'asn'), description=yang.gdata.from_xml_str(n, 'description'))
 
 class orchestron_rfs__rfs__ibgp_neighbor(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__ibgp_neighbor_entry]
@@ -1601,13 +1776,22 @@ class orchestron_rfs__rfs__ibgp_neighbor(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__ibgp_neighbor_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__ibgp_neighbor_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__ibgp_neighbor_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_orchestron_rfs__rfs__ibgp_neighbor__address, child_address)
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_orchestron_rfs__rfs__ibgp_neighbor__asn, child_asn)
+    child_description = yang.gdata.from_xml_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__rfs__ibgp_neighbor__description, child_description)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_address)])
+
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__ibgp_neighbor_element(e))
+    return yang.gdata.List(keys=['address'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__ibgp_neighbor_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1678,16 +1862,31 @@ mut def from_json_orchestron_rfs__rfs__ibgp_neighbor(jd: list[dict[str, ?value]]
 mut def from_json_orchestron_rfs__rfs__vrf__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__vrf__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__vrf__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf__router_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf__router_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_orchestron_rfs__rfs__vrf__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class orchestron_rfs__rfs__vrf_entry(yang.adata.MNode):
@@ -1728,10 +1927,6 @@ class orchestron_rfs__rfs__vrf_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__vrf_entry:
         return orchestron_rfs__rfs__vrf_entry(name=n.get_str('name'), description=n.get_opt_str('description'), id=n.get_int('id'), router_id=n.get_int('router-id'), asn=n.get_int('asn'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__vrf_entry:
-        return orchestron_rfs__rfs__vrf_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), id=yang.gdata.from_xml_int(n, 'id'), router_id=yang.gdata.from_xml_int(n, 'router-id'), asn=yang.gdata.from_xml_int(n, 'asn'))
-
 class orchestron_rfs__rfs__vrf(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__vrf_entry]
     mut def __init__(self, elements=[]):
@@ -1768,13 +1963,26 @@ class orchestron_rfs__rfs__vrf(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__vrf_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__vrf_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__vrf_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__vrf_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__vrf__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__rfs__vrf__description, child_description)
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_orchestron_rfs__rfs__vrf__id, child_id)
+    child_router_id = yang.gdata.from_xml_int(node, 'router-id')
+    yang.gdata.maybe_add(children, 'router-id', from_xml_orchestron_rfs__rfs__vrf__router_id, child_router_id)
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_orchestron_rfs__rfs__vrf__asn, child_asn)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs__vrf(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__vrf_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__vrf_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1853,16 +2061,31 @@ mut def from_json_orchestron_rfs__rfs__vrf(jd: list[dict[str, ?value]]) -> yang.
 mut def from_json_orchestron_rfs__rfs__vrf_interface__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf_interface__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__vrf_interface__vrf(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__vrf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf_interface__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf_interface__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 class orchestron_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
@@ -1903,10 +2126,6 @@ class orchestron_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__vrf_interface_entry:
         return orchestron_rfs__rfs__vrf_interface_entry(name=n.get_str('name'), description=n.get_opt_str('description'), vrf=n.get_str('vrf'), ipv4_address=n.get_opt_str('ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__vrf_interface_entry:
-        return orchestron_rfs__rfs__vrf_interface_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), vrf=yang.gdata.from_xml_str(n, 'vrf'), ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'), ipv4_prefix_length=yang.gdata.from_xml_opt_int(n, 'ipv4-prefix-length'))
-
 class orchestron_rfs__rfs__vrf_interface(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__vrf_interface_entry]
     mut def __init__(self, elements=[]):
@@ -1943,13 +2162,26 @@ class orchestron_rfs__rfs__vrf_interface(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__vrf_interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__vrf_interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__vrf_interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__vrf_interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__vrf_interface__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__rfs__vrf_interface__description, child_description)
+    child_vrf = yang.gdata.from_xml_str(node, 'vrf')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_orchestron_rfs__rfs__vrf_interface__vrf, child_vrf)
+    child_ipv4_address = yang.gdata.from_xml_opt_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_orchestron_rfs__rfs__vrf_interface__ipv4_address, child_ipv4_address)
+    child_ipv4_prefix_length = yang.gdata.from_xml_opt_int(node, 'ipv4-prefix-length')
+    yang.gdata.maybe_add(children, 'ipv4-prefix-length', from_xml_orchestron_rfs__rfs__vrf_interface__ipv4_prefix_length, child_ipv4_prefix_length)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs__vrf_interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__vrf_interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__vrf_interface_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2028,19 +2260,37 @@ mut def from_json_orchestron_rfs__rfs__vrf_interface(jd: list[dict[str, ?value]]
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__vrf(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__vrf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__local_asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__local_asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__peer_asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__peer_asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__authentication_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
@@ -2086,10 +2336,6 @@ class orchestron_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__ebgp_customer_entry:
         return orchestron_rfs__rfs__ebgp_customer_entry(vrf=n.get_str('vrf'), address=n.get_str('address'), local_asn=n.get_int('local-asn'), peer_asn=n.get_int('peer-asn'), description=n.get_opt_str('description'), authentication_key=n.get_str('authentication-key'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__ebgp_customer_entry:
-        return orchestron_rfs__rfs__ebgp_customer_entry(vrf=yang.gdata.from_xml_str(n, 'vrf'), address=yang.gdata.from_xml_str(n, 'address'), local_asn=yang.gdata.from_xml_int(n, 'local-asn'), peer_asn=yang.gdata.from_xml_int(n, 'peer-asn'), description=yang.gdata.from_xml_opt_str(n, 'description'), authentication_key=yang.gdata.from_xml_str(n, 'authentication-key'))
-
 class orchestron_rfs__rfs__ebgp_customer(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__ebgp_customer_entry]
     mut def __init__(self, elements=[]):
@@ -2129,13 +2375,28 @@ class orchestron_rfs__rfs__ebgp_customer(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__ebgp_customer_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__ebgp_customer_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__ebgp_customer_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vrf = yang.gdata.from_xml_str(node, 'vrf')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_orchestron_rfs__rfs__ebgp_customer__vrf, child_vrf)
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_orchestron_rfs__rfs__ebgp_customer__address, child_address)
+    child_local_asn = yang.gdata.from_xml_int(node, 'local-asn')
+    yang.gdata.maybe_add(children, 'local-asn', from_xml_orchestron_rfs__rfs__ebgp_customer__local_asn, child_local_asn)
+    child_peer_asn = yang.gdata.from_xml_int(node, 'peer-asn')
+    yang.gdata.maybe_add(children, 'peer-asn', from_xml_orchestron_rfs__rfs__ebgp_customer__peer_asn, child_peer_asn)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__rfs__ebgp_customer__description, child_description)
+    child_authentication_key = yang.gdata.from_xml_str(node, 'authentication-key')
+    yang.gdata.maybe_add(children, 'authentication-key', from_xml_orchestron_rfs__rfs__ebgp_customer__authentication_key, child_authentication_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vrf), yang.gdata.yang_str(child_address)])
+
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__ebgp_customer_element(e))
+    return yang.gdata.List(keys=['vrf', 'address'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__ebgp_customer_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2262,10 +2523,6 @@ class orchestron_rfs__rfs_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs_entry:
         return orchestron_rfs__rfs_entry(name=n.get_str('name'), base_config=orchestron_rfs__rfs__base_config.from_gdata(n.get_opt_list('base-config')), backbone_interface=orchestron_rfs__rfs__backbone_interface.from_gdata(n.get_opt_list('backbone-interface')), ibgp_neighbor=orchestron_rfs__rfs__ibgp_neighbor.from_gdata(n.get_opt_list('ibgp-neighbor')), vrf=orchestron_rfs__rfs__vrf.from_gdata(n.get_opt_list('vrf')), vrf_interface=orchestron_rfs__rfs__vrf_interface.from_gdata(n.get_opt_list('vrf-interface')), ebgp_customer=orchestron_rfs__rfs__ebgp_customer.from_gdata(n.get_opt_list('ebgp-customer')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs_entry:
-        return orchestron_rfs__rfs_entry(name=yang.gdata.from_xml_str(n, 'name'), base_config=orchestron_rfs__rfs__base_config.from_xml(yang.gdata.get_xml_children(n, 'base-config', 'http://example.com/respnet-rfs')), backbone_interface=orchestron_rfs__rfs__backbone_interface.from_xml(yang.gdata.get_xml_children(n, 'backbone-interface', 'http://example.com/respnet-rfs')), ibgp_neighbor=orchestron_rfs__rfs__ibgp_neighbor.from_xml(yang.gdata.get_xml_children(n, 'ibgp-neighbor', 'http://example.com/respnet-rfs')), vrf=orchestron_rfs__rfs__vrf.from_xml(yang.gdata.get_xml_children(n, 'vrf', 'http://example.com/respnet-rfs')), vrf_interface=orchestron_rfs__rfs__vrf_interface.from_xml(yang.gdata.get_xml_children(n, 'vrf-interface', 'http://example.com/respnet-rfs')), ebgp_customer=orchestron_rfs__rfs__ebgp_customer.from_xml(yang.gdata.get_xml_children(n, 'ebgp-customer', 'http://example.com/respnet-rfs')))
-
 class orchestron_rfs__rfs(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs_entry]
     mut def __init__(self, elements=[]):
@@ -2302,13 +2559,30 @@ class orchestron_rfs__rfs(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__name, child_name)
+    child_base_config = yang.gdata.from_xml_opt_list(node, 'base-config', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'base-config', from_xml_orchestron_rfs__rfs__base_config, child_base_config)
+    child_backbone_interface = yang.gdata.from_xml_opt_list(node, 'backbone-interface', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'backbone-interface', from_xml_orchestron_rfs__rfs__backbone_interface, child_backbone_interface)
+    child_ibgp_neighbor = yang.gdata.from_xml_opt_list(node, 'ibgp-neighbor', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'ibgp-neighbor', from_xml_orchestron_rfs__rfs__ibgp_neighbor, child_ibgp_neighbor)
+    child_vrf = yang.gdata.from_xml_opt_list(node, 'vrf', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_orchestron_rfs__rfs__vrf, child_vrf)
+    child_vrf_interface = yang.gdata.from_xml_opt_list(node, 'vrf-interface', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'vrf-interface', from_xml_orchestron_rfs__rfs__vrf_interface, child_vrf_interface)
+    child_ebgp_customer = yang.gdata.from_xml_opt_list(node, 'ebgp-customer', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'ebgp-customer', from_xml_orchestron_rfs__rfs__ebgp_customer, child_ebgp_customer)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2417,12 +2691,14 @@ class root(yang.adata.MNode):
             return root(device=orchestron_rfs__device.from_gdata(n.get_opt_list('device')), rfs=orchestron_rfs__rfs.from_gdata(n.get_opt_list('rfs')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(device=orchestron_rfs__device.from_xml(yang.gdata.get_xml_children(n, 'device', 'http://orchestron.org/yang/orchestron-rfs.yang')), rfs=orchestron_rfs__rfs.from_xml(yang.gdata.get_xml_children(n, 'rfs', 'http://orchestron.org/yang/orchestron-rfs.yang')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_device = yang.gdata.from_xml_opt_list(node, 'device', 'http://orchestron.org/yang/orchestron-rfs.yang')
+    yang.gdata.maybe_add(children, 'device', from_xml_orchestron_rfs__device, child_device)
+    child_rfs = yang.gdata.from_xml_opt_list(node, 'rfs', 'http://orchestron.org/yang/orchestron-rfs.yang')
+    yang.gdata.maybe_add(children, 'rfs', from_xml_orchestron_rfs__rfs, child_rfs)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/src/respnet/layers/y_2_loose.act
+++ b/src/respnet/layers/y_2_loose.act
@@ -10,28 +10,55 @@ import yang.gdata
 mut def from_json_orchestron_rfs__device__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__type(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__type(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__address__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__address__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__address__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_orchestron_rfs__device__address__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_orchestron_rfs__device__address__port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__address__port(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__address__initial_credentials__username(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__address__initial_credentials__username(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__address__initial_credentials__password(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__address__initial_credentials__password(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__address__initial_credentials__key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__address__initial_credentials__key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__device__address__initial_credentials_entry(yang.adata.MNode):
@@ -61,10 +88,6 @@ class orchestron_rfs__device__address__initial_credentials_entry(yang.adata.MNod
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address__initial_credentials_entry:
         return orchestron_rfs__device__address__initial_credentials_entry(username=n.get_str('username'), password=n.get_str('password'), key=n.get_str('key'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__address__initial_credentials_entry:
-        return orchestron_rfs__device__address__initial_credentials_entry(username=yang.gdata.from_xml_str(n, 'username'), password=yang.gdata.from_xml_str(n, 'password'), key=yang.gdata.from_xml_str(n, 'key'))
 
 class orchestron_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[orchestron_rfs__device__address__initial_credentials_entry]
@@ -108,13 +131,22 @@ class orchestron_rfs__device__address__initial_credentials(yang.adata.MNode):
                 res.append(orchestron_rfs__device__address__initial_credentials_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__address__initial_credentials_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__address__initial_credentials_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__address__initial_credentials_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_username = yang.gdata.from_xml_str(node, 'username')
+    yang.gdata.maybe_add(children, 'username', from_xml_orchestron_rfs__device__address__initial_credentials__username, child_username)
+    child_password = yang.gdata.from_xml_str(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_orchestron_rfs__device__address__initial_credentials__password, child_password)
+    child_key = yang.gdata.from_xml_str(node, 'key')
+    yang.gdata.maybe_add(children, 'key', from_xml_orchestron_rfs__device__address__initial_credentials__key, child_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_username), yang.gdata.yang_str(child_password), yang.gdata.yang_str(child_key)])
+
+mut def from_xml_orchestron_rfs__device__address__initial_credentials(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__address__initial_credentials_element(e))
+    return yang.gdata.List(keys=['username', 'password', 'key'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__address__initial_credentials_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -213,10 +245,6 @@ class orchestron_rfs__device__address_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address_entry:
         return orchestron_rfs__device__address_entry(name=n.get_str('name'), address=n.get_opt_str('address'), port=n.get_opt_str('port'), initial_credentials=orchestron_rfs__device__address__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__address_entry:
-        return orchestron_rfs__device__address_entry(name=yang.gdata.from_xml_str(n, 'name'), address=yang.gdata.from_xml_opt_str(n, 'address'), port=yang.gdata.from_xml_opt_str(n, 'port'), initial_credentials=orchestron_rfs__device__address__initial_credentials.from_xml(yang.gdata.get_xml_children(n, 'initial-credentials')))
-
 class orchestron_rfs__device__address(yang.adata.MNode):
     elements: list[orchestron_rfs__device__address_entry]
     mut def __init__(self, elements=[]):
@@ -253,13 +281,24 @@ class orchestron_rfs__device__address(yang.adata.MNode):
                 res.append(orchestron_rfs__device__address_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__address_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__address_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__address_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__device__address__name, child_name)
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_orchestron_rfs__device__address__address, child_address)
+    child_port = yang.gdata.from_xml_opt_str(node, 'port')
+    yang.gdata.maybe_add(children, 'port', from_xml_orchestron_rfs__device__address__port, child_port)
+    child_initial_credentials = yang.gdata.from_xml_opt_list(node, 'initial-credentials')
+    yang.gdata.maybe_add(children, 'initial-credentials', from_xml_orchestron_rfs__device__address__initial_credentials, child_initial_credentials)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__device__address(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__address_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__address_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -334,13 +373,25 @@ mut def from_json_orchestron_rfs__device__address(jd: list[dict[str, ?value]]) -
 mut def from_json_orchestron_rfs__device__credentials__username(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__credentials__username(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__credentials__password(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__credentials__password(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__credentials__key__key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__credentials__key__key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__credentials__key__private_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__credentials__key__private_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__device__credentials__key_entry(yang.adata.MNode):
@@ -365,10 +416,6 @@ class orchestron_rfs__device__credentials__key_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__credentials__key_entry:
         return orchestron_rfs__device__credentials__key_entry(key=n.get_str('key'), private_key=n.get_opt_str('private-key'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__credentials__key_entry:
-        return orchestron_rfs__device__credentials__key_entry(key=yang.gdata.from_xml_str(n, 'key'), private_key=yang.gdata.from_xml_opt_str(n, 'private-key'))
 
 class orchestron_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[orchestron_rfs__device__credentials__key_entry]
@@ -406,13 +453,20 @@ class orchestron_rfs__device__credentials__key(yang.adata.MNode):
                 res.append(orchestron_rfs__device__credentials__key_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__credentials__key_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__credentials__key_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__credentials__key_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_key = yang.gdata.from_xml_str(node, 'key')
+    yang.gdata.maybe_add(children, 'key', from_xml_orchestron_rfs__device__credentials__key__key, child_key)
+    child_private_key = yang.gdata.from_xml_opt_str(node, 'private-key')
+    yang.gdata.maybe_add(children, 'private-key', from_xml_orchestron_rfs__device__credentials__key__private_key, child_private_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key)])
+
+mut def from_xml_orchestron_rfs__device__credentials__key(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__credentials__key_element(e))
+    return yang.gdata.List(keys=['key'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__credentials__key_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -506,12 +560,16 @@ class orchestron_rfs__device__credentials(yang.adata.MNode):
             return orchestron_rfs__device__credentials(username=n.get_opt_str('username'), password=n.get_opt_str('password'), key=orchestron_rfs__device__credentials__key.from_gdata(n.get_opt_list('key')))
         raise ValueError('Missing required subtree orchestron_rfs__device__credentials')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> orchestron_rfs__device__credentials:
-        if n != None:
-            return orchestron_rfs__device__credentials(username=yang.gdata.from_xml_opt_str(n, 'username'), password=yang.gdata.from_xml_opt_str(n, 'password'), key=orchestron_rfs__device__credentials__key.from_xml(yang.gdata.get_xml_children(n, 'key')))
-        raise ValueError('Missing required subtree orchestron_rfs__device__credentials')
 
+mut def from_xml_orchestron_rfs__device__credentials(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_username = yang.gdata.from_xml_str(node, 'username')
+    yang.gdata.maybe_add(children, 'username', from_xml_orchestron_rfs__device__credentials__username, child_username)
+    child_password = yang.gdata.from_xml_opt_str(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_orchestron_rfs__device__credentials__password, child_password)
+    child_key = yang.gdata.from_xml_opt_list(node, 'key')
+    yang.gdata.maybe_add(children, 'key', from_xml_orchestron_rfs__device__credentials__key, child_key)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_orchestron_rfs__device__credentials(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -547,10 +605,19 @@ mut def from_json_orchestron_rfs__device__credentials(jd: dict[str, ?value]) -> 
 mut def from_json_orchestron_rfs__device__initial_credentials__username(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__initial_credentials__username(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__initial_credentials__password(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__initial_credentials__password(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__initial_credentials__key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__initial_credentials__key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__device__initial_credentials_entry(yang.adata.MNode):
@@ -580,10 +647,6 @@ class orchestron_rfs__device__initial_credentials_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__initial_credentials_entry:
         return orchestron_rfs__device__initial_credentials_entry(username=n.get_str('username'), password=n.get_str('password'), key=n.get_str('key'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__initial_credentials_entry:
-        return orchestron_rfs__device__initial_credentials_entry(username=yang.gdata.from_xml_str(n, 'username'), password=yang.gdata.from_xml_str(n, 'password'), key=yang.gdata.from_xml_str(n, 'key'))
 
 class orchestron_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[orchestron_rfs__device__initial_credentials_entry]
@@ -627,13 +690,22 @@ class orchestron_rfs__device__initial_credentials(yang.adata.MNode):
                 res.append(orchestron_rfs__device__initial_credentials_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__initial_credentials_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__initial_credentials_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__initial_credentials_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_username = yang.gdata.from_xml_str(node, 'username')
+    yang.gdata.maybe_add(children, 'username', from_xml_orchestron_rfs__device__initial_credentials__username, child_username)
+    child_password = yang.gdata.from_xml_str(node, 'password')
+    yang.gdata.maybe_add(children, 'password', from_xml_orchestron_rfs__device__initial_credentials__password, child_password)
+    child_key = yang.gdata.from_xml_str(node, 'key')
+    yang.gdata.maybe_add(children, 'key', from_xml_orchestron_rfs__device__initial_credentials__key, child_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_username), yang.gdata.yang_str(child_password), yang.gdata.yang_str(child_key)])
+
+mut def from_xml_orchestron_rfs__device__initial_credentials(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__initial_credentials_element(e))
+    return yang.gdata.List(keys=['username', 'password', 'key'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__initial_credentials_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -702,16 +774,31 @@ mut def from_json_orchestron_rfs__device__initial_credentials(jd: list[dict[str,
 mut def from_json_orchestron_rfs__device__mock__preset(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('enumeration', val)
 
+mut def from_xml_orchestron_rfs__device__mock__preset(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('enumeration', val)
+
 mut def from_json_orchestron_rfs__device__mock__module__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__device__mock__module__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__device__mock__module__namespace(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__mock__module__namespace(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__mock__module__revision(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__device__mock__module__revision(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__device__mock__module__feature(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_orchestron_rfs__device__mock__module__feature(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
@@ -744,10 +831,6 @@ class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__mock__module_entry:
         return orchestron_rfs__device__mock__module_entry(name=n.get_str('name'), namespace=n.get_opt_str('namespace'), revision=n.get_opt_str('revision'), feature=n.get_opt_strs('feature'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__mock__module_entry:
-        return orchestron_rfs__device__mock__module_entry(name=yang.gdata.from_xml_str(n, 'name'), namespace=yang.gdata.from_xml_opt_str(n, 'namespace'), revision=yang.gdata.from_xml_opt_str(n, 'revision'), feature=yang.gdata.from_xml_opt_strs(n, 'feature'))
 
 class orchestron_rfs__device__mock__module(yang.adata.MNode):
     elements: list[orchestron_rfs__device__mock__module_entry]
@@ -785,13 +868,24 @@ class orchestron_rfs__device__mock__module(yang.adata.MNode):
                 res.append(orchestron_rfs__device__mock__module_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__mock__module_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device__mock__module_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device__mock__module_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__device__mock__module__name, child_name)
+    child_namespace = yang.gdata.from_xml_str(node, 'namespace')
+    yang.gdata.maybe_add(children, 'namespace', from_xml_orchestron_rfs__device__mock__module__namespace, child_namespace)
+    child_revision = yang.gdata.from_xml_opt_str(node, 'revision')
+    yang.gdata.maybe_add(children, 'revision', from_xml_orchestron_rfs__device__mock__module__revision, child_revision)
+    child_feature = yang.gdata.from_xml_opt_strs(node, 'feature')
+    yang.gdata.maybe_add(children, 'feature', from_xml_orchestron_rfs__device__mock__module__feature, child_feature)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__device__mock__module(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device__mock__module_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_orchestron_rfs__device__mock__module_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -886,12 +980,14 @@ class orchestron_rfs__device__mock(yang.adata.MNode):
             return orchestron_rfs__device__mock(preset=n.get_opt_strs('preset'), module=orchestron_rfs__device__mock__module.from_gdata(n.get_opt_list('module')))
         return orchestron_rfs__device__mock()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> orchestron_rfs__device__mock:
-        if n != None:
-            return orchestron_rfs__device__mock(preset=yang.gdata.from_xml_opt_strs(n, 'preset'), module=orchestron_rfs__device__mock__module.from_xml(yang.gdata.get_xml_children(n, 'module')))
-        return orchestron_rfs__device__mock()
 
+mut def from_xml_orchestron_rfs__device__mock(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_preset = yang.gdata.from_xml_opt_strs(node, 'preset')
+    yang.gdata.maybe_add(children, 'preset', from_xml_orchestron_rfs__device__mock__preset, child_preset)
+    child_module = yang.gdata.from_xml_opt_list(node, 'module')
+    yang.gdata.maybe_add(children, 'module', from_xml_orchestron_rfs__device__mock__module, child_module)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_orchestron_rfs__device__mock(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -968,10 +1064,6 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:
         return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_opt_container('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_container('mock')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device_entry:
-        return orchestron_rfs__device_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), type=yang.gdata.from_xml_opt_str(n, 'type'), address=orchestron_rfs__device__address.from_xml(yang.gdata.get_xml_children(n, 'address')), credentials=orchestron_rfs__device__credentials.from_xml(yang.gdata.get_xml_opt_child(n, 'credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_xml(yang.gdata.get_xml_children(n, 'initial-credentials')), mock=orchestron_rfs__device__mock.from_xml(yang.gdata.get_xml_opt_child(n, 'mock')))
-
 class orchestron_rfs__device(yang.adata.MNode):
     elements: list[orchestron_rfs__device_entry]
     mut def __init__(self, elements=[]):
@@ -1008,13 +1100,30 @@ class orchestron_rfs__device(yang.adata.MNode):
                 res.append(orchestron_rfs__device_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__device_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__device_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__device__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__device__description, child_description)
+    child_type = yang.gdata.from_xml_opt_str(node, 'type')
+    yang.gdata.maybe_add(children, 'type', from_xml_orchestron_rfs__device__type, child_type)
+    child_address = yang.gdata.from_xml_opt_list(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_orchestron_rfs__device__address, child_address)
+    child_credentials = yang.gdata.from_xml_opt_cnt(node, 'credentials')
+    yang.gdata.maybe_add(children, 'credentials', from_xml_orchestron_rfs__device__credentials, child_credentials)
+    child_initial_credentials = yang.gdata.from_xml_opt_list(node, 'initial-credentials')
+    yang.gdata.maybe_add(children, 'initial-credentials', from_xml_orchestron_rfs__device__initial_credentials, child_initial_credentials)
+    child_mock = yang.gdata.from_xml_opt_cnt(node, 'mock')
+    yang.gdata.maybe_add(children, 'mock', from_xml_orchestron_rfs__device__mock, child_mock)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__device(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__device_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')
 
 mut def from_json_path_orchestron_rfs__device_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1101,19 +1210,37 @@ mut def from_json_orchestron_rfs__device(jd: list[dict[str, ?value]]) -> yang.gd
 mut def from_json_orchestron_rfs__rfs__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__base_config__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__base_config__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__base_config__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__base_config__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__base_config__ipv6_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__base_config__ipv6_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__base_config__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__base_config__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__base_config__ibgp_authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__base_config__ibgp_authentication_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__rfs__base_config_entry(yang.adata.MNode):
@@ -1154,10 +1281,6 @@ class orchestron_rfs__rfs__base_config_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__base_config_entry:
         return orchestron_rfs__rfs__base_config_entry(name=n.get_str('name'), ipv4_address=n.get_opt_str('ipv4-address'), ipv6_address=n.get_opt_str('ipv6-address'), asn=n.get_opt_int('asn'), ibgp_authentication_key=n.get_opt_str('ibgp-authentication-key'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__base_config_entry:
-        return orchestron_rfs__rfs__base_config_entry(name=yang.gdata.from_xml_str(n, 'name'), ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'), ipv6_address=yang.gdata.from_xml_opt_str(n, 'ipv6-address'), asn=yang.gdata.from_xml_opt_int(n, 'asn'), ibgp_authentication_key=yang.gdata.from_xml_opt_str(n, 'ibgp-authentication-key'))
-
 class orchestron_rfs__rfs__base_config(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__base_config_entry]
     mut def __init__(self, elements=[]):
@@ -1194,13 +1317,26 @@ class orchestron_rfs__rfs__base_config(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__base_config_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__base_config_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__base_config_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__base_config_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__base_config__name, child_name)
+    child_ipv4_address = yang.gdata.from_xml_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_orchestron_rfs__rfs__base_config__ipv4_address, child_ipv4_address)
+    child_ipv6_address = yang.gdata.from_xml_str(node, 'ipv6-address')
+    yang.gdata.maybe_add(children, 'ipv6-address', from_xml_orchestron_rfs__rfs__base_config__ipv6_address, child_ipv6_address)
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_orchestron_rfs__rfs__base_config__asn, child_asn)
+    child_ibgp_authentication_key = yang.gdata.from_xml_str(node, 'ibgp-authentication-key')
+    yang.gdata.maybe_add(children, 'ibgp-authentication-key', from_xml_orchestron_rfs__rfs__base_config__ibgp_authentication_key, child_ibgp_authentication_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs__base_config(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__base_config_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__base_config_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1279,22 +1415,43 @@ mut def from_json_orchestron_rfs__rfs__base_config(jd: list[dict[str, ?value]]) 
 mut def from_json_orchestron_rfs__rfs__backbone_interface__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__backbone_interface__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__backbone_interface__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_orchestron_rfs__rfs__backbone_interface__ipv6_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__ipv6_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__backbone_interface__ipv6_prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__ipv6_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
 mut def from_json_orchestron_rfs__rfs__backbone_interface__remote__device(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__remote__device(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__backbone_interface__remote__interface(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__remote__interface(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
@@ -1322,12 +1479,14 @@ class orchestron_rfs__rfs__backbone_interface__remote(yang.adata.MNode):
             return orchestron_rfs__rfs__backbone_interface__remote(device=n.get_opt_str('device'), interface=n.get_opt_str('interface'))
         raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__remote')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> orchestron_rfs__rfs__backbone_interface__remote:
-        if n != None:
-            return orchestron_rfs__rfs__backbone_interface__remote(device=yang.gdata.from_xml_opt_str(n, 'device'), interface=yang.gdata.from_xml_opt_str(n, 'interface'))
-        raise ValueError('Missing required subtree orchestron_rfs__rfs__backbone_interface__remote')
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface__remote(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_device = yang.gdata.from_xml_str(node, 'device')
+    yang.gdata.maybe_add(children, 'device', from_xml_orchestron_rfs__rfs__backbone_interface__remote__device, child_device)
+    child_interface = yang.gdata.from_xml_str(node, 'interface')
+    yang.gdata.maybe_add(children, 'interface', from_xml_orchestron_rfs__rfs__backbone_interface__remote__interface, child_interface)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_orchestron_rfs__rfs__backbone_interface__remote(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1398,10 +1557,6 @@ class orchestron_rfs__rfs__backbone_interface_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__backbone_interface_entry:
         return orchestron_rfs__rfs__backbone_interface_entry(name=n.get_str('name'), ipv4_address=n.get_opt_str('ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'), ipv6_address=n.get_opt_str('ipv6-address'), ipv6_prefix_length=n.get_opt_int('ipv6-prefix-length'), remote=orchestron_rfs__rfs__backbone_interface__remote.from_gdata(n.get_opt_container('remote')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__backbone_interface_entry:
-        return orchestron_rfs__rfs__backbone_interface_entry(name=yang.gdata.from_xml_str(n, 'name'), ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'), ipv4_prefix_length=yang.gdata.from_xml_opt_int(n, 'ipv4-prefix-length'), ipv6_address=yang.gdata.from_xml_opt_str(n, 'ipv6-address'), ipv6_prefix_length=yang.gdata.from_xml_opt_int(n, 'ipv6-prefix-length'), remote=orchestron_rfs__rfs__backbone_interface__remote.from_xml(yang.gdata.get_xml_opt_child(n, 'remote')))
-
 class orchestron_rfs__rfs__backbone_interface(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__backbone_interface_entry]
     mut def __init__(self, elements=[]):
@@ -1438,13 +1593,28 @@ class orchestron_rfs__rfs__backbone_interface(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__backbone_interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__backbone_interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__backbone_interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__backbone_interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__backbone_interface__name, child_name)
+    child_ipv4_address = yang.gdata.from_xml_opt_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_orchestron_rfs__rfs__backbone_interface__ipv4_address, child_ipv4_address)
+    child_ipv4_prefix_length = yang.gdata.from_xml_opt_int(node, 'ipv4-prefix-length')
+    yang.gdata.maybe_add(children, 'ipv4-prefix-length', from_xml_orchestron_rfs__rfs__backbone_interface__ipv4_prefix_length, child_ipv4_prefix_length)
+    child_ipv6_address = yang.gdata.from_xml_opt_str(node, 'ipv6-address')
+    yang.gdata.maybe_add(children, 'ipv6-address', from_xml_orchestron_rfs__rfs__backbone_interface__ipv6_address, child_ipv6_address)
+    child_ipv6_prefix_length = yang.gdata.from_xml_opt_int(node, 'ipv6-prefix-length')
+    yang.gdata.maybe_add(children, 'ipv6-prefix-length', from_xml_orchestron_rfs__rfs__backbone_interface__ipv6_prefix_length, child_ipv6_prefix_length)
+    child_remote = yang.gdata.from_xml_opt_cnt(node, 'remote')
+    yang.gdata.maybe_add(children, 'remote', from_xml_orchestron_rfs__rfs__backbone_interface__remote, child_remote)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs__backbone_interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__backbone_interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__backbone_interface_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1527,10 +1697,19 @@ mut def from_json_orchestron_rfs__rfs__backbone_interface(jd: list[dict[str, ?va
 mut def from_json_orchestron_rfs__rfs__ibgp_neighbor__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_orchestron_rfs__rfs__ibgp_neighbor__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__ibgp_neighbor__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
@@ -1560,10 +1739,6 @@ class orchestron_rfs__rfs__ibgp_neighbor_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__ibgp_neighbor_entry:
         return orchestron_rfs__rfs__ibgp_neighbor_entry(address=n.get_str('address'), asn=n.get_opt_int('asn'), description=n.get_opt_str('description'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__ibgp_neighbor_entry:
-        return orchestron_rfs__rfs__ibgp_neighbor_entry(address=yang.gdata.from_xml_str(n, 'address'), asn=yang.gdata.from_xml_opt_int(n, 'asn'), description=yang.gdata.from_xml_opt_str(n, 'description'))
 
 class orchestron_rfs__rfs__ibgp_neighbor(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__ibgp_neighbor_entry]
@@ -1601,13 +1776,22 @@ class orchestron_rfs__rfs__ibgp_neighbor(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__ibgp_neighbor_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__ibgp_neighbor_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__ibgp_neighbor_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_orchestron_rfs__rfs__ibgp_neighbor__address, child_address)
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_orchestron_rfs__rfs__ibgp_neighbor__asn, child_asn)
+    child_description = yang.gdata.from_xml_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__rfs__ibgp_neighbor__description, child_description)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_address)])
+
+mut def from_xml_orchestron_rfs__rfs__ibgp_neighbor(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__ibgp_neighbor_element(e))
+    return yang.gdata.List(keys=['address'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__ibgp_neighbor_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1678,16 +1862,31 @@ mut def from_json_orchestron_rfs__rfs__ibgp_neighbor(jd: list[dict[str, ?value]]
 mut def from_json_orchestron_rfs__rfs__vrf__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__vrf__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__vrf__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf__router_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf__router_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf__asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_orchestron_rfs__rfs__vrf__asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 class orchestron_rfs__rfs__vrf_entry(yang.adata.MNode):
@@ -1728,10 +1927,6 @@ class orchestron_rfs__rfs__vrf_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__vrf_entry:
         return orchestron_rfs__rfs__vrf_entry(name=n.get_str('name'), description=n.get_opt_str('description'), id=n.get_opt_int('id'), router_id=n.get_opt_int('router-id'), asn=n.get_opt_int('asn'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__vrf_entry:
-        return orchestron_rfs__rfs__vrf_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), id=yang.gdata.from_xml_opt_int(n, 'id'), router_id=yang.gdata.from_xml_opt_int(n, 'router-id'), asn=yang.gdata.from_xml_opt_int(n, 'asn'))
-
 class orchestron_rfs__rfs__vrf(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__vrf_entry]
     mut def __init__(self, elements=[]):
@@ -1768,13 +1963,26 @@ class orchestron_rfs__rfs__vrf(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__vrf_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__vrf_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__vrf_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__vrf_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__vrf__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__rfs__vrf__description, child_description)
+    child_id = yang.gdata.from_xml_int(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_orchestron_rfs__rfs__vrf__id, child_id)
+    child_router_id = yang.gdata.from_xml_int(node, 'router-id')
+    yang.gdata.maybe_add(children, 'router-id', from_xml_orchestron_rfs__rfs__vrf__router_id, child_router_id)
+    child_asn = yang.gdata.from_xml_int(node, 'asn')
+    yang.gdata.maybe_add(children, 'asn', from_xml_orchestron_rfs__rfs__vrf__asn, child_asn)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs__vrf(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__vrf_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__vrf_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1853,16 +2061,31 @@ mut def from_json_orchestron_rfs__rfs__vrf(jd: list[dict[str, ?value]]) -> yang.
 mut def from_json_orchestron_rfs__rfs__vrf_interface__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf_interface__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_orchestron_rfs__rfs__vrf_interface__vrf(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__vrf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf_interface__ipv4_address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__ipv4_address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__vrf_interface__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint8', val)
+
+mut def from_xml_orchestron_rfs__rfs__vrf_interface__ipv4_prefix_length(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint8', val)
 
 class orchestron_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
@@ -1903,10 +2126,6 @@ class orchestron_rfs__rfs__vrf_interface_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__vrf_interface_entry:
         return orchestron_rfs__rfs__vrf_interface_entry(name=n.get_str('name'), description=n.get_opt_str('description'), vrf=n.get_opt_str('vrf'), ipv4_address=n.get_opt_str('ipv4-address'), ipv4_prefix_length=n.get_opt_int('ipv4-prefix-length'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__vrf_interface_entry:
-        return orchestron_rfs__rfs__vrf_interface_entry(name=yang.gdata.from_xml_str(n, 'name'), description=yang.gdata.from_xml_opt_str(n, 'description'), vrf=yang.gdata.from_xml_opt_str(n, 'vrf'), ipv4_address=yang.gdata.from_xml_opt_str(n, 'ipv4-address'), ipv4_prefix_length=yang.gdata.from_xml_opt_int(n, 'ipv4-prefix-length'))
-
 class orchestron_rfs__rfs__vrf_interface(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__vrf_interface_entry]
     mut def __init__(self, elements=[]):
@@ -1943,13 +2162,26 @@ class orchestron_rfs__rfs__vrf_interface(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__vrf_interface_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__vrf_interface_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__vrf_interface_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__vrf_interface_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__vrf_interface__name, child_name)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__rfs__vrf_interface__description, child_description)
+    child_vrf = yang.gdata.from_xml_str(node, 'vrf')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_orchestron_rfs__rfs__vrf_interface__vrf, child_vrf)
+    child_ipv4_address = yang.gdata.from_xml_opt_str(node, 'ipv4-address')
+    yang.gdata.maybe_add(children, 'ipv4-address', from_xml_orchestron_rfs__rfs__vrf_interface__ipv4_address, child_ipv4_address)
+    child_ipv4_prefix_length = yang.gdata.from_xml_opt_int(node, 'ipv4-prefix-length')
+    yang.gdata.maybe_add(children, 'ipv4-prefix-length', from_xml_orchestron_rfs__rfs__vrf_interface__ipv4_prefix_length, child_ipv4_prefix_length)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs__vrf_interface(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__vrf_interface_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__vrf_interface_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2028,19 +2260,37 @@ mut def from_json_orchestron_rfs__rfs__vrf_interface(jd: list[dict[str, ?value]]
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__vrf(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__vrf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__address(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__address(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__local_asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__local_asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__peer_asn(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__peer_asn(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('uint32', val)
 
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__description(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__description(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_rfs__rfs__ebgp_customer__authentication_key(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer__authentication_key(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
@@ -2086,10 +2336,6 @@ class orchestron_rfs__rfs__ebgp_customer_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs__ebgp_customer_entry:
         return orchestron_rfs__rfs__ebgp_customer_entry(vrf=n.get_str('vrf'), address=n.get_str('address'), local_asn=n.get_opt_int('local-asn'), peer_asn=n.get_opt_int('peer-asn'), description=n.get_opt_str('description'), authentication_key=n.get_opt_str('authentication-key'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs__ebgp_customer_entry:
-        return orchestron_rfs__rfs__ebgp_customer_entry(vrf=yang.gdata.from_xml_str(n, 'vrf'), address=yang.gdata.from_xml_str(n, 'address'), local_asn=yang.gdata.from_xml_opt_int(n, 'local-asn'), peer_asn=yang.gdata.from_xml_opt_int(n, 'peer-asn'), description=yang.gdata.from_xml_opt_str(n, 'description'), authentication_key=yang.gdata.from_xml_opt_str(n, 'authentication-key'))
-
 class orchestron_rfs__rfs__ebgp_customer(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs__ebgp_customer_entry]
     mut def __init__(self, elements=[]):
@@ -2129,13 +2375,28 @@ class orchestron_rfs__rfs__ebgp_customer(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs__ebgp_customer_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs__ebgp_customer_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs__ebgp_customer_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_vrf = yang.gdata.from_xml_str(node, 'vrf')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_orchestron_rfs__rfs__ebgp_customer__vrf, child_vrf)
+    child_address = yang.gdata.from_xml_str(node, 'address')
+    yang.gdata.maybe_add(children, 'address', from_xml_orchestron_rfs__rfs__ebgp_customer__address, child_address)
+    child_local_asn = yang.gdata.from_xml_int(node, 'local-asn')
+    yang.gdata.maybe_add(children, 'local-asn', from_xml_orchestron_rfs__rfs__ebgp_customer__local_asn, child_local_asn)
+    child_peer_asn = yang.gdata.from_xml_int(node, 'peer-asn')
+    yang.gdata.maybe_add(children, 'peer-asn', from_xml_orchestron_rfs__rfs__ebgp_customer__peer_asn, child_peer_asn)
+    child_description = yang.gdata.from_xml_opt_str(node, 'description')
+    yang.gdata.maybe_add(children, 'description', from_xml_orchestron_rfs__rfs__ebgp_customer__description, child_description)
+    child_authentication_key = yang.gdata.from_xml_str(node, 'authentication-key')
+    yang.gdata.maybe_add(children, 'authentication-key', from_xml_orchestron_rfs__rfs__ebgp_customer__authentication_key, child_authentication_key)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_vrf), yang.gdata.yang_str(child_address)])
+
+mut def from_xml_orchestron_rfs__rfs__ebgp_customer(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs__ebgp_customer_element(e))
+    return yang.gdata.List(keys=['vrf', 'address'], elements=elements, ns='http://example.com/respnet-rfs', module='respnet-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs__ebgp_customer_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2262,10 +2523,6 @@ class orchestron_rfs__rfs_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__rfs_entry:
         return orchestron_rfs__rfs_entry(name=n.get_str('name'), base_config=orchestron_rfs__rfs__base_config.from_gdata(n.get_opt_list('base-config')), backbone_interface=orchestron_rfs__rfs__backbone_interface.from_gdata(n.get_opt_list('backbone-interface')), ibgp_neighbor=orchestron_rfs__rfs__ibgp_neighbor.from_gdata(n.get_opt_list('ibgp-neighbor')), vrf=orchestron_rfs__rfs__vrf.from_gdata(n.get_opt_list('vrf')), vrf_interface=orchestron_rfs__rfs__vrf_interface.from_gdata(n.get_opt_list('vrf-interface')), ebgp_customer=orchestron_rfs__rfs__ebgp_customer.from_gdata(n.get_opt_list('ebgp-customer')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__rfs_entry:
-        return orchestron_rfs__rfs_entry(name=yang.gdata.from_xml_str(n, 'name'), base_config=orchestron_rfs__rfs__base_config.from_xml(yang.gdata.get_xml_children(n, 'base-config', 'http://example.com/respnet-rfs')), backbone_interface=orchestron_rfs__rfs__backbone_interface.from_xml(yang.gdata.get_xml_children(n, 'backbone-interface', 'http://example.com/respnet-rfs')), ibgp_neighbor=orchestron_rfs__rfs__ibgp_neighbor.from_xml(yang.gdata.get_xml_children(n, 'ibgp-neighbor', 'http://example.com/respnet-rfs')), vrf=orchestron_rfs__rfs__vrf.from_xml(yang.gdata.get_xml_children(n, 'vrf', 'http://example.com/respnet-rfs')), vrf_interface=orchestron_rfs__rfs__vrf_interface.from_xml(yang.gdata.get_xml_children(n, 'vrf-interface', 'http://example.com/respnet-rfs')), ebgp_customer=orchestron_rfs__rfs__ebgp_customer.from_xml(yang.gdata.get_xml_children(n, 'ebgp-customer', 'http://example.com/respnet-rfs')))
-
 class orchestron_rfs__rfs(yang.adata.MNode):
     elements: list[orchestron_rfs__rfs_entry]
     mut def __init__(self, elements=[]):
@@ -2302,13 +2559,30 @@ class orchestron_rfs__rfs(yang.adata.MNode):
                 res.append(orchestron_rfs__rfs_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__rfs_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_rfs__rfs_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_rfs__rfs_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_rfs__rfs__name, child_name)
+    child_base_config = yang.gdata.from_xml_opt_list(node, 'base-config', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'base-config', from_xml_orchestron_rfs__rfs__base_config, child_base_config)
+    child_backbone_interface = yang.gdata.from_xml_opt_list(node, 'backbone-interface', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'backbone-interface', from_xml_orchestron_rfs__rfs__backbone_interface, child_backbone_interface)
+    child_ibgp_neighbor = yang.gdata.from_xml_opt_list(node, 'ibgp-neighbor', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'ibgp-neighbor', from_xml_orchestron_rfs__rfs__ibgp_neighbor, child_ibgp_neighbor)
+    child_vrf = yang.gdata.from_xml_opt_list(node, 'vrf', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'vrf', from_xml_orchestron_rfs__rfs__vrf, child_vrf)
+    child_vrf_interface = yang.gdata.from_xml_opt_list(node, 'vrf-interface', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'vrf-interface', from_xml_orchestron_rfs__rfs__vrf_interface, child_vrf_interface)
+    child_ebgp_customer = yang.gdata.from_xml_opt_list(node, 'ebgp-customer', 'http://example.com/respnet-rfs')
+    yang.gdata.maybe_add(children, 'ebgp-customer', from_xml_orchestron_rfs__rfs__ebgp_customer, child_ebgp_customer)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_rfs__rfs(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_rfs__rfs_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')
 
 mut def from_json_path_orchestron_rfs__rfs_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -2417,12 +2691,14 @@ class root(yang.adata.MNode):
             return root(device=orchestron_rfs__device.from_gdata(n.get_opt_list('device')), rfs=orchestron_rfs__rfs.from_gdata(n.get_opt_list('rfs')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(device=orchestron_rfs__device.from_xml(yang.gdata.get_xml_children(n, 'device', 'http://orchestron.org/yang/orchestron-rfs.yang')), rfs=orchestron_rfs__rfs.from_xml(yang.gdata.get_xml_children(n, 'rfs', 'http://orchestron.org/yang/orchestron-rfs.yang')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_device = yang.gdata.from_xml_opt_list(node, 'device', 'http://orchestron.org/yang/orchestron-rfs.yang')
+    yang.gdata.maybe_add(children, 'device', from_xml_orchestron_rfs__device, child_device)
+    child_rfs = yang.gdata.from_xml_opt_list(node, 'rfs', 'http://orchestron.org/yang/orchestron-rfs.yang')
+    yang.gdata.maybe_add(children, 'rfs', from_xml_orchestron_rfs__rfs, child_rfs)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/src/respnet/layers/y_3.act
+++ b/src/respnet/layers/y_3.act
@@ -10,7 +10,13 @@ import yang.gdata
 mut def from_json_orchestron_device__devices__device__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_device__devices__device__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_device__devices__device__modset_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_device__devices__device__modset_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_device__devices__device_entry(yang.adata.MNode):
@@ -35,10 +41,6 @@ class orchestron_device__devices__device_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_device__devices__device_entry:
         return orchestron_device__devices__device_entry(name=n.get_str('name'), modset_id=n.get_opt_str('modset_id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_device__devices__device_entry:
-        return orchestron_device__devices__device_entry(name=yang.gdata.from_xml_str(n, 'name'), modset_id=yang.gdata.from_xml_opt_str(n, 'modset_id'))
 
 class orchestron_device__devices__device(yang.adata.MNode):
     elements: list[orchestron_device__devices__device_entry]
@@ -76,13 +78,20 @@ class orchestron_device__devices__device(yang.adata.MNode):
                 res.append(orchestron_device__devices__device_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_device__devices__device_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_device__devices__device_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_device__devices__device_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_device__devices__device__name, child_name)
+    child_modset_id = yang.gdata.from_xml_opt_str(node, 'modset_id')
+    yang.gdata.maybe_add(children, 'modset_id', from_xml_orchestron_device__devices__device__modset_id, child_modset_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_device__devices__device(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_device__devices__device_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_orchestron_device__devices__device_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -166,12 +175,12 @@ class orchestron_device__devices(yang.adata.MNode):
             return orchestron_device__devices(device=orchestron_device__devices__device.from_gdata(n.get_opt_list('device')))
         return orchestron_device__devices()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> orchestron_device__devices:
-        if n != None:
-            return orchestron_device__devices(device=orchestron_device__devices__device.from_xml(yang.gdata.get_xml_children(n, 'device')))
-        return orchestron_device__devices()
 
+mut def from_xml_orchestron_device__devices(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_device = yang.gdata.from_xml_opt_list(node, 'device')
+    yang.gdata.maybe_add(children, 'device', from_xml_orchestron_device__devices__device, child_device)
+    return yang.gdata.Container(children, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')
 
 mut def from_json_path_orchestron_device__devices(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -216,12 +225,12 @@ class root(yang.adata.MNode):
             return root(devices=orchestron_device__devices.from_gdata(n.get_opt_container('devices')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(devices=orchestron_device__devices.from_xml(yang.gdata.get_xml_opt_child(n, 'devices', 'http://orchestron.org/yang/orchestron-device.yang')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_devices = yang.gdata.from_xml_opt_cnt(node, 'devices', 'http://orchestron.org/yang/orchestron-device.yang')
+    yang.gdata.maybe_add(children, 'devices', from_xml_orchestron_device__devices, child_devices)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/src/respnet/layers/y_3_loose.act
+++ b/src/respnet/layers/y_3_loose.act
@@ -10,7 +10,13 @@ import yang.gdata
 mut def from_json_orchestron_device__devices__device__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_orchestron_device__devices__device__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_orchestron_device__devices__device__modset_id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_orchestron_device__devices__device__modset_id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class orchestron_device__devices__device_entry(yang.adata.MNode):
@@ -35,10 +41,6 @@ class orchestron_device__devices__device_entry(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_device__devices__device_entry:
         return orchestron_device__devices__device_entry(name=n.get_str('name'), modset_id=n.get_opt_str('modset_id'))
-
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_device__devices__device_entry:
-        return orchestron_device__devices__device_entry(name=yang.gdata.from_xml_str(n, 'name'), modset_id=yang.gdata.from_xml_opt_str(n, 'modset_id'))
 
 class orchestron_device__devices__device(yang.adata.MNode):
     elements: list[orchestron_device__devices__device_entry]
@@ -76,13 +78,20 @@ class orchestron_device__devices__device(yang.adata.MNode):
                 res.append(orchestron_device__devices__device_entry.from_gdata(e))
         return res
 
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_device__devices__device_entry]:
-        res = []
-        for node in nodes:
-            res.append(orchestron_device__devices__device_entry.from_xml(node))
-        return res
 
+mut def from_xml_orchestron_device__devices__device_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_orchestron_device__devices__device__name, child_name)
+    child_modset_id = yang.gdata.from_xml_opt_str(node, 'modset_id')
+    yang.gdata.maybe_add(children, 'modset_id', from_xml_orchestron_device__devices__device__modset_id, child_modset_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_orchestron_device__devices__device(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_orchestron_device__devices__device_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_orchestron_device__devices__device_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -166,12 +175,12 @@ class orchestron_device__devices(yang.adata.MNode):
             return orchestron_device__devices(device=orchestron_device__devices__device.from_gdata(n.get_opt_list('device')))
         return orchestron_device__devices()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> orchestron_device__devices:
-        if n != None:
-            return orchestron_device__devices(device=orchestron_device__devices__device.from_xml(yang.gdata.get_xml_children(n, 'device')))
-        return orchestron_device__devices()
 
+mut def from_xml_orchestron_device__devices(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_device = yang.gdata.from_xml_opt_list(node, 'device')
+    yang.gdata.maybe_add(children, 'device', from_xml_orchestron_device__devices__device, child_device)
+    return yang.gdata.Container(children, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')
 
 mut def from_json_path_orchestron_device__devices(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -216,12 +225,12 @@ class root(yang.adata.MNode):
             return root(devices=orchestron_device__devices.from_gdata(n.get_opt_container('devices')))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(devices=orchestron_device__devices.from_xml(yang.gdata.get_xml_opt_child(n, 'devices', 'http://orchestron.org/yang/orchestron-device.yang')))
-        return root()
 
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_devices = yang.gdata.from_xml_opt_cnt(node, 'devices', 'http://orchestron.org/yang/orchestron-device.yang')
+    yang.gdata.maybe_add(children, 'devices', from_xml_orchestron_device__devices, child_devices)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/src/test_respnet.act
+++ b/src/test_respnet.act
@@ -9,7 +9,7 @@ import orchestron.ttt
 import orchestron.device as odev
 
 import respnet.layers
-from respnet.layers.y_0 import root as cfs_root
+import respnet.layers.y_0 as cfs_layer
 
 def rfs_for_device(dev):
     return gdata.Container({
@@ -52,7 +52,7 @@ netinfra1_in = """<data>
 
 actor netinfra_tester(t: testing.AsyncT):
     xml_conf = xml.decode(netinfra1_in)
-    input_config = cfs_root.from_xml(xml_conf)
+    input_config = cfs_layer.from_xml(xml_conf)
 
     dev_mgr = odev.DeviceManager(log_handler=t.log_handler)
     cfs = respnet.layers.get_layers(dev_mgr)
@@ -67,7 +67,7 @@ actor netinfra_tester(t: testing.AsyncT):
         print(dev_conf, err=True)
         t.success(dev_conf)
 
-    session.edit_config(input_config.to_gdata(), None, cont)
+    session.edit_config(input_config, None, cont)
 
     def fail():
         print("Test Config failed", err=True)
@@ -345,7 +345,7 @@ l3vpn_in = """<data>
 
 actor l3vpn_tester(t: testing.AsyncT, output_formatter: mut(gdata.Node) -> str):
     xml_conf = xml.decode(l3vpn_in)
-    input_config = cfs_root.from_xml(xml_conf)
+    input_config = cfs_layer.from_xml(xml_conf)
 
     dev_mgr = odev.DeviceManager(log_handler=t.log_handler)
     cfs = respnet.layers.get_layers(dev_mgr)
@@ -359,7 +359,7 @@ actor l3vpn_tester(t: testing.AsyncT, output_formatter: mut(gdata.Node) -> str):
         print(output)
         t.success(output)
 
-    session.edit_config(input_config.to_gdata(), None, cont)
+    session.edit_config(input_config, None, cont)
 
 def _test_l3vpn_svc(t: testing.AsyncT):
     l3vpn_tester(t, lambda n: n.to_xmlstr())


### PR DESCRIPTION
Uses the new generated `from_xml*()` free functions to get gdata directly from XML, instead of going through adata.